### PR TITLE
[Init] path alias 설정

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,22 @@
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true
+    "noFallthroughCasesInSwitch": true,
+
+    /* path and alias */
+    "baseUrl": "./src",
+    "paths": {
+      // "@apis/*": ["common/apis/*"],
+      "@assets/*": ["common/assets/*"],
+      "@components/*": ["common/components/*"],
+      "@constants/*": ["common/constants/*"],
+      "@hooks/*": ["common/hooks/*"],
+      // "@type/*": ["common/type/*"],
+      "@utils/*": ["common/utils/*"],
+      "pages/*": ["pages/*"],
+      "styles/*": ["styles/*"],
+      "views/*": ["views/*"]
+    }
   },
   "include": ["src"],
   "references": [{ "path": "./tsconfig.node.json" }]

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,8 +1,38 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
-import { vanillaExtractPlugin } from '@vanilla-extract/vite-plugin'
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import path from 'path';
+import { vanillaExtractPlugin } from '@vanilla-extract/vite-plugin';
 
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react(), vanillaExtractPlugin()],
-})
+  resolve: {
+    alias: [
+      // { find: '@apis', replacement: path.resolve(__dirname, 'src/common/apis') },
+      {
+        find: '@assets',
+        replacement: path.resolve(__dirname, 'src/common/assets'),
+      },
+      {
+        find: '@components',
+        replacement: path.resolve(__dirname, 'src/common/components'),
+      },
+      {
+        find: '@constants',
+        replacement: path.resolve(__dirname, 'src/common/constants'),
+      },
+      {
+        find: '@hooks',
+        replacement: path.resolve(__dirname, 'src/common/hooks'),
+      },
+      // { find: '@type', replacement: path.resolve(__dirname, 'src/common/type') },
+      {
+        find: '@utils',
+        replacement: path.resolve(__dirname, 'src/common/utils'),
+      },
+      { find: 'pages', replacement: path.resolve(__dirname, 'src/pages') },
+      { find: 'styles', replacement: path.resolve(__dirname, 'src/styles') },
+      { find: 'views', replacement: path.resolve(__dirname, 'src/views') },
+    ],
+  },
+});


### PR DESCRIPTION
close #3 

## 작업 내용

- [x] common 폴더에 대한 alias 설정

## pr point
`common` 폴더 속 폴더들은 alias를 `@`로 시작되게 하였습니다. 
`@common/components/~~` 이런 식으로 하면 너무 길어지는 거 같아 `@components` 이런 식으로 `common`을 생략했습니다.

다만 이렇게 되면 `common` 안에 있지 않은 `pages`, `styles`, `views`와 구분이 다소 어려울 것으로 판단이 되어,
`pages`, `styles`, `views`의 alias는 `@`를 제외한 그냥 `pages/~~`, `styles/~~`, `views/~~` 이런 식으로 진행되게 하였습니다.

처음에는 `common`에만 alias 설정하려 했었는데, `pages`에서 `views` 컴포넌트를 사용하는 등 나중에 중첩 길어질 수도 있을 거 같아 하는 김에 다 해줬습니다.

추후에 common 폴더에 apis나 type과 관련된 폴더가 생길 수도 있을 거 같아 일단은 주석 처리 해뒀습니다.
```typescript
    "paths": {
      // "@apis/*": ["common/apis/*"],
      "@assets/*": ["common/assets/*"],
      "@components/*": ["common/components/*"],
      "@constants/*": ["common/constants/*"],
      "@hooks/*": ["common/hooks/*"],
      // "@type/*": ["common/type/*"],
      "@utils/*": ["common/utils/*"],
      "pages/*": ["pages/*"],
      "styles/*": ["styles/*"],
      "views/*": ["views/*"]
    }
```

## 실행 화면
![스크린샷 2024-05-19 오후 4 32 13](https://github.com/sopt-makers/sopt-recruiting-frontend/assets/121864459/0acbddce-f935-4591-870b-b75d9dd49f67)

테스트도 완료했습니다.

이에 대해 다른 의견 있으시면 편하게 말씀해 주세요.