### PR TITLE
[Design] Callout 공통 컴포넌트 생성

### DIFF
--- a/src/common/components/Callout/index.tsx
+++ b/src/common/components/Callout/index.tsx
@@ -1,0 +1,31 @@
+import { colors } from '@sopt-makers/colors';
+import { IconAlertCircle } from '@sopt-makers/icons';
+
+import { container } from './style.css';
+
+import type { HTMLAttributes, ReactNode } from 'react';
+
+interface CalloutProps extends HTMLAttributes<HTMLElement> {
+  children?: ReactNode;
+  size?: 'sm' | 'lg';
+}
+
+const Callout = ({ children, size = 'sm', ...calloutElementProps }: CalloutProps) => {
+  return (
+    <article className={container[size]} {...calloutElementProps}>
+      <IconAlertCircle
+        style={{
+          width: '32px',
+          minWidth: '32px',
+          height: '32px',
+          borderRadius: '50%',
+          color: `${colors.yellow700}`,
+          fill: `${colors.yellow200}`,
+        }}
+      />
+      {children}
+    </article>
+  );
+};
+
+export default Callout;

--- a/src/common/components/Callout/style.css.ts
+++ b/src/common/components/Callout/style.css.ts
@@ -11,6 +11,7 @@ const containerBase = style({
   borderRadius: '15px',
   backgroundColor: theme.color.subBackground,
   whiteSpace: 'pre-line',
+  ...theme.font.HEADING_6_18_B,
 });
 
 export const container = styleVariants({

--- a/src/common/components/Callout/style.css.ts
+++ b/src/common/components/Callout/style.css.ts
@@ -1,0 +1,18 @@
+import { style, styleVariants } from '@vanilla-extract/css';
+
+import { theme } from 'styles/theme.css';
+
+const containerBase = style({
+  display: 'flex',
+  gap: '22px',
+  alignItems: 'center',
+  width: 'fit-content',
+  padding: '28px 28px',
+  borderRadius: '15px',
+  backgroundColor: theme.color.subBackground,
+});
+
+export const container = styleVariants({
+  sm: [containerBase, { width: '466px' }],
+  lg: [containerBase, { width: '720px' }],
+});

--- a/src/common/components/Callout/style.css.ts
+++ b/src/common/components/Callout/style.css.ts
@@ -10,6 +10,7 @@ const containerBase = style({
   padding: '28px 28px',
   borderRadius: '15px',
   backgroundColor: theme.color.subBackground,
+  whiteSpace: 'pre-line',
 });
 
 export const container = styleVariants({


### PR DESCRIPTION
**Related Issue :** Closes  #11 

---

## 🧑‍🎤 Summary
- [x] Callout 공통 컴포넌트 생성

## 🧑‍🎤 Screenshot
<img width="478" alt="스크린샷 2024-06-05 오전 11 18 47" src="https://github.com/sopt-makers/sopt-recruiting-frontend/assets/121864459/7fdc7bef-8976-4080-b15e-b9b34f3f8934">


## 🧑‍🎤 Comment
### 사용법
#### props
- `children` (필수)
- `size`: sm(default) | lg

```tsx
<Callout size="sm">
  {`마감 시간 이후에는 지원 제출을 받지 않습니다.\n제출하신 서류와 포트폴리오는 반환하지 않습니다.\n서버 오류를 대비해 지원서를 백업해 두시길 바랍니다.`}
</Callout>

<Callout size="sm">
  <SomeComponent />
</Callout>
```

아직 icon에 대한 논의가 완료되지 않아 일단 올리고 추후에 디자인 변경되면 수정하도록 하겠습니다.

icon에 색은 따로 theme으로 빼주지 않았는데요. mds icon을 이용할 생각이었어서 뺄 필요가 없을 것이라 판단해서 그랬습니다. 하지만 mds icon을 사용해도 색을 변경해줘야 하더라고요. theme으로 빼줄까 생각도 했지만 여기서 밖에 사용되지 않아서 빼주진 않았습니다.
```ts
<IconAlertCircle
  style={{
  width: '32px',
  minWidth: '32px',
  height: '32px',
  borderRadius: '50%',
  color: `${colors.yellow700}`,
  fill: `${colors.yellow200}`,
  }}
/>
```
위와 같이 구현했는데 큰 문제는 없는 거 같습니다.
