### PR TITLE
[Design] Button 공통 컴포넌트 생성

### DIFF
--- a/src/common/components/Button/index.tsx
+++ b/src/common/components/Button/index.tsx
@@ -1,0 +1,18 @@
+import { container } from './style.css';
+
+import type { ButtonHTMLAttributes, ReactNode } from 'react';
+
+interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  children?: ReactNode;
+  buttonStyle?: 'solid' | 'line';
+}
+
+const Button = ({ children, buttonStyle = 'solid', ...buttonElementProps }: ButtonProps) => {
+  return (
+    <button type="button" className={container[buttonStyle]} {...buttonElementProps}>
+      {children}
+    </button>
+  );
+};
+
+export default Button;

--- a/src/common/components/Button/index.tsx
+++ b/src/common/components/Button/index.tsx
@@ -1,4 +1,4 @@
-import { container } from './style.css';
+import { container, disableStyle, outsideBox } from './style.css';
 
 import type { ButtonHTMLAttributes, ReactNode } from 'react';
 
@@ -9,10 +9,14 @@ interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
 }
 
 const Button = ({ children, className, buttonStyle = 'solid', ...buttonElementProps }: ButtonProps) => {
+  const { disabled } = buttonElementProps;
+
   return (
-    <button type="button" className={`${container[buttonStyle]} ${className}`} {...buttonElementProps}>
-      {children}
-    </button>
+    <div className={`${disabled && disableStyle} ${className} ${outsideBox[buttonStyle]}`}>
+      <button type="button" className={`${container[buttonStyle]} ${className}`} {...buttonElementProps}>
+        {children}
+      </button>
+    </div>
   );
 };
 

--- a/src/common/components/Button/index.tsx
+++ b/src/common/components/Button/index.tsx
@@ -1,19 +1,29 @@
-import { container, disableStyle, outsideBox } from './style.css';
+import { container, disableStyle, outsideBox, paddings } from './style.css';
 
 import type { ButtonHTMLAttributes, ReactNode } from 'react';
 
 interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   children?: ReactNode;
   className?: string;
+  padding?: '15x32' | '13x20' | '10x24' | '15x25';
   buttonStyle?: 'solid' | 'line';
 }
 
-const Button = ({ children, className, buttonStyle = 'solid', ...buttonElementProps }: ButtonProps) => {
+const Button = ({
+  children,
+  className,
+  buttonStyle = 'solid',
+  padding = '15x32',
+  ...buttonElementProps
+}: ButtonProps) => {
   const { disabled } = buttonElementProps;
 
   return (
     <div className={`${disabled && disableStyle} ${className} ${outsideBox[buttonStyle]}`}>
-      <button type="button" className={`${container[buttonStyle]} ${className}`} {...buttonElementProps}>
+      <button
+        type="button"
+        className={`${container[buttonStyle]} ${paddings[padding]} ${className}`}
+        {...buttonElementProps}>
         {children}
       </button>
     </div>

--- a/src/common/components/Button/index.tsx
+++ b/src/common/components/Button/index.tsx
@@ -1,4 +1,4 @@
-import { container, disableStyle, outsideBox, paddings } from './style.css';
+import { container, outsideBox, paddings } from './style.css';
 
 import type { ButtonHTMLAttributes, ReactNode } from 'react';
 
@@ -19,7 +19,7 @@ const Button = ({
   const { disabled } = buttonElementProps;
 
   return (
-    <div className={`${disabled && disableStyle} ${className} ${outsideBox[buttonStyle]}`}>
+    <div className={`${className} ${outsideBox[disabled ? 'disabled' : buttonStyle]}`}>
       <button
         type="button"
         className={`${container[buttonStyle]} ${paddings[padding]} ${className}`}

--- a/src/common/components/Button/index.tsx
+++ b/src/common/components/Button/index.tsx
@@ -4,12 +4,13 @@ import type { ButtonHTMLAttributes, ReactNode } from 'react';
 
 interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   children?: ReactNode;
+  className?: string;
   buttonStyle?: 'solid' | 'line';
 }
 
-const Button = ({ children, buttonStyle = 'solid', ...buttonElementProps }: ButtonProps) => {
+const Button = ({ children, className, buttonStyle = 'solid', ...buttonElementProps }: ButtonProps) => {
   return (
-    <button type="button" className={container[buttonStyle]} {...buttonElementProps}>
+    <button type="button" className={`${container[buttonStyle]} ${className}`} {...buttonElementProps}>
       {children}
     </button>
   );

--- a/src/common/components/Button/index.tsx
+++ b/src/common/components/Button/index.tsx
@@ -16,12 +16,12 @@ const Button = ({
   padding = '15x32',
   ...buttonElementProps
 }: ButtonProps) => {
-  const { disabled } = buttonElementProps;
+  const { disabled, type = 'button' } = buttonElementProps;
 
   return (
     <div className={`${className} ${outsideBox[disabled ? 'disabled' : buttonStyle]}`}>
       <button
-        type="button"
+        type={type}
         className={`${container[buttonStyle]} ${paddings[padding]} ${className}`}
         {...buttonElementProps}>
         {children}

--- a/src/common/components/Button/style.css.ts
+++ b/src/common/components/Button/style.css.ts
@@ -35,7 +35,6 @@ const containerBase = style({
   width: 'fit-content',
   borderRadius: '12px',
   transition: 'background-color 0.3s ease-out',
-  ...theme.font.LABEL_3_14_SB,
 
   selectors: {
     '&:disabled, &:disabled:hover': {

--- a/src/common/components/Button/style.css.ts
+++ b/src/common/components/Button/style.css.ts
@@ -35,7 +35,7 @@ const containerBase = style({
   width: 'fit-content',
   borderRadius: '12px',
   transition: 'background-color 0.3s ease-out',
-  ...theme.font.TITLE_5_18_SB,
+  ...theme.font.LABEL_3_14_SB,
 
   selectors: {
     '&:disabled, &:disabled:hover': {

--- a/src/common/components/Button/style.css.ts
+++ b/src/common/components/Button/style.css.ts
@@ -33,7 +33,6 @@ const containerBase = style({
   alignItems: 'center',
   justifyContent: 'center',
   width: 'fit-content',
-  padding: '15px 32px',
   borderRadius: '12px',
   transition: 'background-color 0.3s ease-out',
   ...theme.font.TITLE_5_18_SB,
@@ -46,6 +45,13 @@ const containerBase = style({
       color: theme.color.white,
     },
   },
+});
+
+export const paddings = styleVariants({
+  '15x32': { padding: '15px 32px' },
+  '13x20': { padding: '13px 20px' },
+  '10x24': { padding: '10px 24px' },
+  '15x25': { padding: '15px 25px' },
 });
 
 export const container = styleVariants({

--- a/src/common/components/Button/style.css.ts
+++ b/src/common/components/Button/style.css.ts
@@ -2,6 +2,32 @@ import { style, styleVariants } from '@vanilla-extract/css';
 
 import { theme } from 'styles/theme.css';
 
+const outsideBoxBase = style({
+  width: 'fit-content',
+  borderRadius: '12px',
+});
+
+export const outsideBox = styleVariants({
+  solid: [
+    outsideBoxBase,
+    {
+      color: theme.color.white,
+      backgroundColor: theme.color.primary,
+    },
+  ],
+  line: [
+    outsideBoxBase,
+    {
+      color: theme.color.primary,
+      boxShadow: `0 0 0 1px ${theme.color.primary}`,
+    },
+  ],
+});
+
+export const disableStyle = style({
+  boxShadow: 'none',
+});
+
 const containerBase = style({
   display: 'flex',
   alignItems: 'center',
@@ -9,7 +35,7 @@ const containerBase = style({
   width: 'fit-content',
   padding: '15px 32px',
   borderRadius: '12px',
-  transition: 'all 0.3s ease',
+  transition: 'background-color 0.3s ease-out',
   ...theme.font.TITLE_5_18_SB,
 
   selectors: {
@@ -32,8 +58,24 @@ export const container = styleVariants({
     {
       color: theme.color.white,
       backgroundColor: theme.color.primary,
+
       ':hover': {
         backgroundColor: theme.color.primaryDark,
+      },
+      ':active': {
+        margin: '0 auto',
+        borderRadius: '100%',
+        width: '50%',
+        whiteSpace: 'nowrap',
+      },
+
+      selectors: {
+        '&:disabled:active': {
+          width: '100%',
+          margin: 'none',
+          borderRadius: '12px',
+          whiteSpace: 'pre-line',
+        },
       },
     },
   ],
@@ -41,9 +83,25 @@ export const container = styleVariants({
     containerBase,
     {
       color: theme.color.primary,
-      boxShadow: `0 0 0 1px ${theme.color.primary}`,
+
       ':hover': {
         backgroundColor: theme.color.subBackground,
+      },
+
+      ':active': {
+        margin: '0 auto',
+        borderRadius: '100%',
+        width: '50%',
+        whiteSpace: 'nowrap',
+      },
+
+      selectors: {
+        '&:disabled:active': {
+          width: '100%',
+          margin: 'none',
+          borderRadius: '12px',
+          whiteSpace: 'nowrap',
+        },
       },
     },
   ],

--- a/src/common/components/Button/style.css.ts
+++ b/src/common/components/Button/style.css.ts
@@ -6,7 +6,7 @@ const containerBase = style({
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',
-  width: '96px',
+  width: 'fit-content',
   padding: '15px 32px',
   borderRadius: '12px',
   transition: 'all 0.3s ease',

--- a/src/common/components/Button/style.css.ts
+++ b/src/common/components/Button/style.css.ts
@@ -1,0 +1,50 @@
+import { style, styleVariants } from '@vanilla-extract/css';
+
+import { theme } from 'styles/theme.css';
+
+const containerBase = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  width: '96px',
+  padding: '15px 32px',
+  borderRadius: '12px',
+  transition: 'all 0.3s ease',
+  ...theme.font.TITLE_5_18_SB,
+
+  selectors: {
+    '&:disabled': {
+      backgroundColor: theme.color.buttonDisable,
+      cursor: 'default',
+      boxShadow: 'none',
+      color: theme.color.white,
+    },
+
+    '&:disabled:hover': {
+      backgroundColor: theme.color.buttonDisable,
+    },
+  },
+});
+
+export const container = styleVariants({
+  solid: [
+    containerBase,
+    {
+      color: theme.color.white,
+      backgroundColor: theme.color.primary,
+      ':hover': {
+        backgroundColor: theme.color.primaryDark,
+      },
+    },
+  ],
+  line: [
+    containerBase,
+    {
+      color: theme.color.primary,
+      boxShadow: `0 0 0 1px ${theme.color.primary}`,
+      ':hover': {
+        backgroundColor: theme.color.subBackground,
+      },
+    },
+  ],
+});

--- a/src/common/components/Button/style.css.ts
+++ b/src/common/components/Button/style.css.ts
@@ -22,10 +22,12 @@ export const outsideBox = styleVariants({
       boxShadow: `0 0 0 1px ${theme.color.primary}`,
     },
   ],
-});
-
-export const disableStyle = style({
-  boxShadow: 'none',
+  disabled: [
+    outsideBoxBase,
+    {
+      boxShadow: 'none',
+    },
+  ],
 });
 
 const containerBase = style({

--- a/src/common/components/Button/style.css.ts
+++ b/src/common/components/Button/style.css.ts
@@ -39,15 +39,11 @@ const containerBase = style({
   ...theme.font.TITLE_5_18_SB,
 
   selectors: {
-    '&:disabled': {
+    '&:disabled, &:disabled:hover': {
       backgroundColor: theme.color.buttonDisable,
       cursor: 'default',
       boxShadow: 'none',
       color: theme.color.white,
-    },
-
-    '&:disabled:hover': {
-      backgroundColor: theme.color.buttonDisable,
     },
   },
 });

--- a/src/common/components/Button/style.css.ts
+++ b/src/common/components/Button/style.css.ts
@@ -37,6 +37,7 @@ const containerBase = style({
   width: 'fit-content',
   borderRadius: '12px',
   transition: 'background-color 0.3s ease-out',
+  ...theme.font.TITLE_5_18_SB,
 
   selectors: {
     '&:disabled, &:disabled:hover': {


### PR DESCRIPTION
**Related Issue :** Closes  #12 

---

## 🧑‍🎤 Summary
- [x] Button 공통 컴포넌트 생성

## 🧑‍🎤 Screenshot
<img width="160" alt="스크린샷 2024-06-05 오전 11 38 44" src="https://github.com/sopt-makers/sopt-recruiting-frontend/assets/121864459/553f6c07-2f18-42fa-b8fa-7f917741c42f">



## 🧑‍🎤 Comment
### 사용법
#### props
- `children` (필수)
- `className`
- `buttonStyle`: 'solid' (default) | 'line';

```tsx
<Button buttonStyle="solid">제출하기</Button>
<Button buttonStyle="line">임시저장</Button>
<Button buttonStyle="line" disabled>
  이메일 인증
</Button>
<Button className={buttonStyle} buttonStyle="line" disabled>
  확인
</Button>
```

```ts
import { style } from '@vanilla-extract/css';

export const buttonStyle = style({
  selectors: {
    'html &': {
      width: '146px',
    },
  },
});
```

버튼의 크기가 다양해서 이를 sm, md, lg 등의 variants를 주기 보다 className으로 설정할 수 있도록 해주었습니다.
이때, CSS 우선순위에 밀려 className이 적용 안 될 수 있는데 그럴 경우 
```ts
selectors: {
  'html &': {
    width: '146px',
  },
}
```
이런 식의 꼼수를 이용하여 우선순위를 높여주면 됩니다.

---

active 상태에 대한 디자인을 구현하기 위해
외부 박스(div)와 내부 박스(button)으로 구현을 하게 되었습니다.
actvie 될 때도 transition을 주고 싶었으나 그렇게 할 경우 바뀌는 과정에서 모양이 깨지는 오류가 발생해서 쩔 수 없이 background-color에만 transition을 주었습니다.

```tsx
<div>
  <button>{children}</button>
</div>
```