### PR TITLE
[Design] Dialog 공통 컴포넌트 생성

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ko">
   <head>
     <meta charset="UTF-8" />
@@ -11,10 +11,7 @@
 
     <meta property="og:type" content="website" />
     <meta property="og:title" content="SOPT 35기 모집 지원하기" />
-    <meta
-      property="og:description"
-      content="SOPT의 신입 기수 모집페이지입니다."
-    />
+    <meta property="og:description" content="SOPT의 신입 기수 모집페이지입니다." />
     <meta property="og:site_name" content="SOPT 리크루팅" />
     <meta property="og:locale" content="ko_KR" />
     <!-- <meta property="og:url" content="https://www.someurl.com" /> -->
@@ -25,10 +22,7 @@
 
     <meta property="twitter:card" content="website" />
     <meta name="twitter:title" content="SOPT 35기 모집 지원하기" />
-    <meta
-      name="twitter:description"
-      content="SOPT의 신입 기수 모집페이지입니다."
-    />
+    <meta name="twitter:description" content="SOPT의 신입 기수 모집페이지입니다." />
     <!-- <meta property="twitter:site" content="https://www.someurl.com" /> -->
     <meta name="twitter:image" content="/imgOg.png" />
     <meta property="twitter:image:alt" content="SOPT 공식 홈페이지 이미지" />
@@ -38,6 +32,7 @@
     <meta name="description" content="SOPT의 신입 기수 모집페이지입니다." />
   </head>
   <body>
+    <div id="modal"></div>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/src/common/components/Dialog/index.tsx
+++ b/src/common/components/Dialog/index.tsx
@@ -1,0 +1,19 @@
+import { forwardRef, type DialogHTMLAttributes, type ReactNode } from 'react';
+
+import { container } from './style.css';
+
+interface DialogProps extends DialogHTMLAttributes<HTMLDialogElement> {
+  children?: ReactNode;
+}
+
+const Dialog = forwardRef<HTMLDialogElement, DialogProps>(({ children, ...dialogElementProps }: DialogProps, ref) => {
+  return (
+    <dialog ref={ref} className={container} {...dialogElementProps}>
+      {children}
+    </dialog>
+  );
+});
+
+Dialog.displayName = 'Dialog';
+
+export default Dialog;

--- a/src/common/components/Dialog/index.tsx
+++ b/src/common/components/Dialog/index.tsx
@@ -1,4 +1,5 @@
 import { forwardRef, type DialogHTMLAttributes, type ReactNode } from 'react';
+import { createPortal } from 'react-dom';
 
 import { container } from './style.css';
 
@@ -7,10 +8,11 @@ interface DialogProps extends DialogHTMLAttributes<HTMLDialogElement> {
 }
 
 const Dialog = forwardRef<HTMLDialogElement, DialogProps>(({ children, ...dialogElementProps }: DialogProps, ref) => {
-  return (
+  return createPortal(
     <dialog ref={ref} className={container} {...dialogElementProps}>
       {children}
-    </dialog>
+    </dialog>,
+    document.getElementById('modal')!,
   );
 });
 

--- a/src/common/components/Dialog/style.css.ts
+++ b/src/common/components/Dialog/style.css.ts
@@ -1,15 +1,14 @@
+import { colors } from '@sopt-makers/colors';
 import { style } from '@vanilla-extract/css';
-
-import { theme } from 'styles/theme.css';
 
 export const container = style({
   width: '400px',
   padding: '24px',
-  backgroundColor: theme.color.subBackground,
+  backgroundColor: colors.gray30, // subBackground
   borderRadius: '14px',
   border: 'none',
 
   '::backdrop': {
-    backgroundColor: theme.color.backgroundDimmed,
+    backgroundColor: colors.grayAlpha500, // backgroundDimmed
   },
 });

--- a/src/common/components/Dialog/style.css.ts
+++ b/src/common/components/Dialog/style.css.ts
@@ -1,0 +1,15 @@
+import { style } from '@vanilla-extract/css';
+
+import { theme } from 'styles/theme.css';
+
+export const container = style({
+  width: '400px',
+  padding: '24px',
+  backgroundColor: theme.color.subBackground,
+  borderRadius: '14px',
+  border: 'none',
+
+  '::backdrop': {
+    backgroundColor: theme.color.backgroundDimmed,
+  },
+});


### PR DESCRIPTION
**Related Issue :** Closes  #13 

---

## 🧑‍🎤 Summary
- [x] Dialog 공통 컴포넌트 생성

## 🧑‍🎤 Screenshot
<img width="990" alt="스크린샷 2024-06-05 오전 11 55 11" src="https://github.com/sopt-makers/sopt-recruiting-frontend/assets/121864459/fe96e815-511d-495e-b2ec-4896d5acc71a">


## 🧑‍🎤 Comment
### 사용법
#### props
- `children` (필수)

```tsx
const dialog = useRef<HTMLDialogElement>(null);

const handleOpenDialog = () => {
  dialog.current?.showModal();
};

return (  
  <button onClick={handleOpenDialog}>Open Modal</button>
  <Dialog ref={dialog}>
    <h1>내용</h1>
    <form method="dialog">
      <button>Close</button>
    </form>
  </Dialog>
);
```

1. ref 생성
```tsx
const dialog = useRef<HTMLDialogElement>(null);
```


2. dialog 여는 handler 생성
```tsx
const handleOpenDialog = () => {
  dialog.current?.showModal();
};
```

3. trigger 설정
```tsx
<button onClick={handleOpenDialog}>Open Modal</button>
```

4. Dialog와 ref 연결
```tsx
<Dialog ref={dialog}></Dialog>
```

5. 내용 추가
이때, form method="dialog" 태그 속 button이 dialog를 닫는 역할을 함.
```tsx
<Dialog ref={dialog}>
  <h1>내용</h1>
  <form method="dialog">
    <button>Close</button>
  </form>
</Dialog>
```

---

portal을 구현하면서 theme의 적용 범위를 벗어나게 되어 theme을 사용할 수 없게 되었습니다. 
그래서 theme이 아닌 그냥 color 변수를 박아주었습니다.
```ts
export const container = style({
  width: '400px',
  padding: '24px',
  backgroundColor: colors.gray30, // subBackground
  borderRadius: '14px',
  border: 'none',

  '::backdrop': {
    backgroundColor: colors.grayAlpha500, // backgroundDimmed
  },
});
```