### PR TITLE
[Feat] Input 공통 컴포넌트 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "axios": "^1.6.8",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-hook-form": "^7.51.5",
     "react-router-dom": "^6.23.1"
   },
   "devDependencies": {

--- a/src/common/components/Input/constants.ts
+++ b/src/common/components/Input/constants.ts
@@ -1,0 +1,7 @@
+import { SizeType } from './types';
+
+export const containerSize: Record<SizeType, number> = {
+  sm: 356,
+  md: 466,
+  lg: 720,
+};

--- a/src/common/components/Input/index.tsx
+++ b/src/common/components/Input/index.tsx
@@ -1,53 +1,66 @@
-import { container, circle, input, label, description } from './style.css';
+import { InputHTMLAttributes, ReactNode } from 'react';
 
-export interface InputProps {
-  title: string;
-  placeholderText: string;
+import { container, circle, input, description, error, title } from './style.css';
 
-  size?: 'sm' | 'md' | 'lg';
-  isRequired?: boolean;
-  isFixed?: boolean;
-  descriptionText?: string;
-  errorText?: string;
-  inputType?: 'text' | 'email' | 'number' | 'password' | 'tel' | 'url';
-  maxLength?: number;
-  pattern?: string;
-  descriptionButtonText?: string;
-  descriptionButtonOnClick?: () => void;
-}
-const Input = (props: InputProps) => {
-  const {
-    title,
-    placeholderText,
-    size = 'sm',
-    isRequired,
-    isFixed,
-    descriptionText,
-    errorText,
-    inputType,
-    maxLength,
-    pattern,
-    descriptionButtonText,
-    descriptionButtonOnClick,
-  } = props;
+const Container = ({ children }: { children: ReactNode }) => {
+  return <div className={container}>{children}</div>;
+};
 
+const Title = ({ children, isRequired }: { children: string; isRequired?: boolean }) => {
   return (
-    <div className={container}>
-      <label className={label}>
-        <span>{title}</span>
-        {isRequired && <i className={circle} />}
-      </label>
-      <input className={input} placeholder={placeholderText} type={inputType} maxLength={maxLength} pattern={pattern} />
-      <div className={description}>
-        {descriptionText && <p>{descriptionText}</p>}
-        {descriptionButtonText && (
-          <button type="button" style={{ cursor: 'pointer' }} onClick={descriptionButtonOnClick}>
-            {descriptionButtonText}
-          </button>
-        )}
-      </div>
+    <label className={title}>
+      <span>{children}</span>
+      {isRequired && <i className={circle} />}
+    </label>
+  );
+};
+
+const Description = ({
+  children,
+  buttonText,
+  buttonHandler,
+  isError,
+}: {
+  children: string;
+  buttonText?: string;
+  buttonHandler?: () => void;
+  isError?: boolean;
+}) => {
+  return (
+    <div className={`${description} ${isError && error}`}>
+      <p>{children}</p>
+      {buttonText && (
+        <button type="button" style={{ cursor: 'pointer' }} onClick={buttonHandler}>
+          {buttonText}
+        </button>
+      )}
     </div>
   );
 };
 
-export default Input;
+export interface InputProps extends Pick<InputHTMLAttributes<HTMLInputElement>, 'maxLength' | 'type' | 'pattern'> {
+  placeholderText: string;
+  //size?: 'xs' | 'sm' | 'md' | 'lg'; 나중에하겠습니다...
+  isRequired?: boolean;
+  isFixed?: boolean;
+  errorText?: string;
+}
+
+const Input = ({ placeholderText, isRequired, isFixed, errorText, ...inputElementProps }: InputProps) => {
+  return (
+    <>
+      <input className={input} placeholder={placeholderText} {...inputElementProps} />
+      {errorText && <Description isError>{errorText}</Description>}
+      {/* 에러 조건 추가 */}
+    </>
+  );
+};
+
+const TextBox = {
+  Container,
+  Title,
+  Description,
+  Input,
+};
+
+export default TextBox;

--- a/src/common/components/Input/index.tsx
+++ b/src/common/components/Input/index.tsx
@@ -10,19 +10,28 @@ const TextBox = ({
   isFixed,
   errorText,
   button,
+  secondary,
+  register,
   ...inputElementProps
 }: TextBoxProps) => {
   // 조건부 렌더링 / 유효성 검증은 추후 구현
   return (
     <div className={container}>
-      {label && (
+      {!secondary && (
         <label className={title} htmlFor={label}>
           <span>{label}</span>
           {isRequired && <i className={circle} />}
         </label>
       )}
       <div className={inputLine}>
-        <input id={label} className={input} placeholder={placeholderText} disabled={isFixed} {...inputElementProps} />
+        <input
+          id={label}
+          className={input}
+          placeholder={placeholderText}
+          disabled={isFixed}
+          {...inputElementProps}
+          {...() => register && { ...register(label) }}
+        />
         {button}
       </div>
       {descriptionText && (

--- a/src/common/components/Input/index.tsx
+++ b/src/common/components/Input/index.tsx
@@ -28,7 +28,6 @@ const InputLine = ({
         <input
           id={label}
           className={inputVar[errors?.[label] ? 'error' : 'default']}
-          onFocus={() => clearErrors && clearErrors(label)}
           {...inputElementProps}
           {...register(label, {
             required: required && '필수 입력 항목이에요',
@@ -41,6 +40,7 @@ const InputLine = ({
                 : undefined,
             validate: validate,
           })}
+          onChange={() => clearErrors && clearErrors(label)}
         />
         {button}
       </div>

--- a/src/common/components/Input/index.tsx
+++ b/src/common/components/Input/index.tsx
@@ -12,12 +12,15 @@ const TextBox = ({
   button,
   secondary,
   pattern,
-
-  register,
-  errors,
-  clearErrors,
+  formObject,
   ...inputElementProps
 }: TextBoxProps) => {
+  const {
+    register,
+    formState: { errors },
+    clearErrors,
+  } = formObject;
+
   return (
     <div className={container}>
       {!secondary && (

--- a/src/common/components/Input/index.tsx
+++ b/src/common/components/Input/index.tsx
@@ -15,10 +15,12 @@ const TextBox = ({
   // 조건부 렌더링 / 유효성 검증은 추후 구현
   return (
     <div className={container}>
-      <label className={title} htmlFor={label}>
-        <span>{label}</span>
-        {isRequired && <i className={circle} />}
-      </label>
+      {label && (
+        <label className={title} htmlFor={label}>
+          <span>{label}</span>
+          {isRequired && <i className={circle} />}
+        </label>
+      )}
       <input id={label} className={input} placeholder={placeholderText} {...inputElementProps} />
       {descriptionText && (
         <div className={description}>

--- a/src/common/components/Input/index.tsx
+++ b/src/common/components/Input/index.tsx
@@ -1,24 +1,50 @@
 import { container, circle, input, label, description } from './style.css';
 
-const DescriptionButton = ({ children }: { children: string }) => {
-  return (
-    <button type="button" style={{ cursor: 'pointer' }}>
-      {children}
-    </button>
-  );
-};
+export interface InputProps {
+  title: string;
+  placeholderText: string;
 
-const Input = () => {
+  size?: 'sm' | 'md' | 'lg';
+  isRequired?: boolean;
+  isFixed?: boolean;
+  descriptionText?: string;
+  errorText?: string;
+  inputType?: 'text' | 'email' | 'number' | 'password' | 'tel' | 'url';
+  maxLength?: number;
+  pattern?: string;
+  descriptionButtonText?: string;
+  descriptionButtonOnClick?: () => void;
+}
+const Input = (props: InputProps) => {
+  const {
+    title,
+    placeholderText,
+    size = 'sm',
+    isRequired,
+    isFixed,
+    descriptionText,
+    errorText,
+    inputType,
+    maxLength,
+    pattern,
+    descriptionButtonText,
+    descriptionButtonOnClick,
+  } = props;
+
   return (
     <div className={container}>
       <label className={label}>
-        <span>타이틀</span>
-        <i className={circle} />
+        <span>{title}</span>
+        {isRequired && <i className={circle} />}
       </label>
-      <input className={input} placeholder="디폴트" />
+      <input className={input} placeholder={placeholderText} type={inputType} maxLength={maxLength} pattern={pattern} />
       <div className={description}>
-        <p>비밀번호를 잃어버리셨나요?</p>
-        <DescriptionButton>비밀번호 재설정하기</DescriptionButton>
+        {descriptionText && <p>{descriptionText}</p>}
+        {descriptionButtonText && (
+          <button type="button" style={{ cursor: 'pointer' }} onClick={descriptionButtonOnClick}>
+            {descriptionButtonText}
+          </button>
+        )}
       </div>
     </div>
   );

--- a/src/common/components/Input/index.tsx
+++ b/src/common/components/Input/index.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable indent */
 import { createContext, useContext } from 'react';
 
 import { circle, title, inputLine, containerVar, inputVar, descriptionVar } from './style.css';
@@ -8,6 +9,7 @@ const ThemeContext = createContext({} as Pick<TextBoxProps, 'required' | 'formOb
 const InputLine = ({
   label,
   pattern,
+  validate,
   button,
   errorText,
   ...inputElementProps
@@ -20,7 +22,6 @@ const InputLine = ({
       clearErrors,
     },
   } = useContext(ThemeContext);
-
   return (
     <>
       <div className={inputLine}>
@@ -31,14 +32,21 @@ const InputLine = ({
           {...inputElementProps}
           {...register(label, {
             required: required && '필수 입력 항목이에요',
-            pattern: pattern,
+            pattern:
+              pattern && errorText
+                ? {
+                    value: pattern,
+                    message: errorText,
+                  }
+                : undefined,
+            validate: validate,
           })}
         />
         {button}
       </div>
-      {errors?.[label] && (
+      {errors[label] && (
         <Description styleType="error">
-          <p>{errors[label]?.message || errorText}</p>
+          <p>{errors[label].message}</p>
         </Description>
       )}
     </>

--- a/src/common/components/Input/index.tsx
+++ b/src/common/components/Input/index.tsx
@@ -1,12 +1,11 @@
-import { InputHTMLAttributes, ReactNode } from 'react';
-
 import { container, circle, input, description, error, title } from './style.css';
+import { ContainerProps, DescriptionProps, InputProps, TitleProps } from './types';
 
-const Container = ({ children }: { children: ReactNode }) => {
+const Container = ({ children }: ContainerProps) => {
   return <div className={container}>{children}</div>;
 };
 
-const Title = ({ children, isRequired }: { children: string; isRequired?: boolean }) => {
+const Title = ({ children, isRequired }: TitleProps) => {
   return (
     <label className={title}>
       <span>{children}</span>
@@ -15,17 +14,7 @@ const Title = ({ children, isRequired }: { children: string; isRequired?: boolea
   );
 };
 
-const Description = ({
-  children,
-  buttonText,
-  buttonHandler,
-  isError,
-}: {
-  children: string;
-  buttonText?: string;
-  buttonHandler?: () => void;
-  isError?: boolean;
-}) => {
+const Description = ({ children, buttonText, buttonHandler, isError }: DescriptionProps) => {
   return (
     <div className={`${description} ${isError && error}`}>
       <p>{children}</p>
@@ -38,15 +27,8 @@ const Description = ({
   );
 };
 
-export interface InputProps extends Pick<InputHTMLAttributes<HTMLInputElement>, 'maxLength' | 'type' | 'pattern'> {
-  placeholderText: string;
-  //size?: 'xs' | 'sm' | 'md' | 'lg'; 나중에하겠습니다...
-  isRequired?: boolean;
-  isFixed?: boolean;
-  errorText?: string;
-}
-
 const Input = ({ placeholderText, isRequired, isFixed, errorText, ...inputElementProps }: InputProps) => {
+  // isRequired, isFixed에 따라 동적스타일링
   return (
     <>
       <input className={input} placeholder={placeholderText} {...inputElementProps} />

--- a/src/common/components/Input/index.tsx
+++ b/src/common/components/Input/index.tsx
@@ -1,4 +1,4 @@
-import { circle, input, description, title, inputLine, error, errorInput, containerVar } from './style.css';
+import { circle, input, description, title, inputLine, errorInput, containerVar, errorDescription } from './style.css';
 import { TextBoxProps } from './types';
 
 const TextBox = ({
@@ -34,7 +34,7 @@ const TextBox = ({
       <div className={inputLine}>
         <input
           id={label}
-          className={`${input} ${errors?.[label] && errorInput}`}
+          className={errors?.[label] ? errorInput : input}
           placeholder={placeholderText}
           type={type}
           disabled={isFixed}
@@ -54,7 +54,7 @@ const TextBox = ({
         </div>
       )}
       {errors?.[label] && (
-        <div className={`${description} ${error}`}>
+        <div className={errorDescription}>
           <p>{errors[label]?.message || errorText}</p>
         </div>
       )}

--- a/src/common/components/Input/index.tsx
+++ b/src/common/components/Input/index.tsx
@@ -1,4 +1,4 @@
-import { container, circle, input, description, title, inputLine } from './style.css';
+import { container, circle, input, description, title, inputLine, error, errorInput } from './style.css';
 import { TextBoxProps } from './types';
 
 const TextBox = ({
@@ -11,10 +11,12 @@ const TextBox = ({
   errorText,
   button,
   secondary,
+  pattern,
+
   register,
+  errors,
   ...inputElementProps
 }: TextBoxProps) => {
-  // 조건부 렌더링 / 유효성 검증은 추후 구현
   return (
     <div className={container}>
       {!secondary && (
@@ -26,11 +28,15 @@ const TextBox = ({
       <div className={inputLine}>
         <input
           id={label}
-          className={input}
+          className={`${input} ${errors?.[label] && errorInput}`}
           placeholder={placeholderText}
           disabled={isFixed}
           {...inputElementProps}
-          {...() => register && { ...register(label) }}
+          {...register(label, {
+            required: isRequired && '필수 입력 항목이에요',
+            maxLength: inputElementProps.maxLength,
+            pattern: pattern,
+          })}
         />
         {button}
       </div>
@@ -38,6 +44,11 @@ const TextBox = ({
         <div className={description}>
           <p>{descriptionText}</p>
           {descriptionButton}
+        </div>
+      )}
+      {errors?.[label] && (
+        <div className={`${description} ${error}`}>
+          <p>{errors[label]?.message || errorText}</p>
         </div>
       )}
     </div>

--- a/src/common/components/Input/index.tsx
+++ b/src/common/components/Input/index.tsx
@@ -1,0 +1,5 @@
+const Input = () => {
+  return <div>index</div>;
+};
+
+export default Input;

--- a/src/common/components/Input/index.tsx
+++ b/src/common/components/Input/index.tsx
@@ -21,7 +21,7 @@ const TextBox = ({
           {isRequired && <i className={circle} />}
         </label>
       )}
-      <input id={label} className={input} placeholder={placeholderText} {...inputElementProps} />
+      <input id={label} className={input} placeholder={placeholderText} disabled={isFixed} {...inputElementProps} />
       {descriptionText && (
         <div className={description}>
           <p>{descriptionText}</p>

--- a/src/common/components/Input/index.tsx
+++ b/src/common/components/Input/index.tsx
@@ -1,5 +1,27 @@
+import { container, circle, input, label, description } from './style.css';
+
+const DescriptionButton = ({ children }: { children: string }) => {
+  return (
+    <button type="button" style={{ cursor: 'pointer' }}>
+      {children}
+    </button>
+  );
+};
+
 const Input = () => {
-  return <div>index</div>;
+  return (
+    <div className={container}>
+      <label className={label}>
+        <span>타이틀</span>
+        <i className={circle} />
+      </label>
+      <input className={input} placeholder="디폴트" />
+      <div className={description}>
+        <p>비밀번호를 잃어버리셨나요?</p>
+        <DescriptionButton>비밀번호 재설정하기</DescriptionButton>
+      </div>
+    </div>
+  );
 };
 
 export default Input;

--- a/src/common/components/Input/index.tsx
+++ b/src/common/components/Input/index.tsx
@@ -15,6 +15,7 @@ const TextBox = ({
 
   register,
   errors,
+  clearErrors,
   ...inputElementProps
 }: TextBoxProps) => {
   return (
@@ -32,6 +33,7 @@ const TextBox = ({
           placeholder={placeholderText}
           disabled={isFixed}
           {...inputElementProps}
+          onFocus={() => clearErrors && clearErrors(label)}
           {...register(label, {
             required: isRequired && '필수 입력 항목이에요',
             maxLength: inputElementProps.maxLength,

--- a/src/common/components/Input/index.tsx
+++ b/src/common/components/Input/index.tsx
@@ -3,19 +3,16 @@ import { TextBoxProps } from './types';
 
 const TextBox = ({
   label,
-  placeholder,
   size = 'sm',
   descriptionText,
   descriptionButton,
   required,
-  disabled,
   errorText,
   button,
   secondary,
   pattern,
   formObject,
-  maxLength,
-  type,
+  ...inputElementProps
 }: TextBoxProps) => {
   const {
     register,
@@ -35,11 +32,8 @@ const TextBox = ({
         <input
           id={label}
           className={inputVar[errors?.[label] ? 'error' : 'default']}
-          placeholder={placeholder}
-          type={type}
-          disabled={disabled}
-          maxLength={maxLength}
           onFocus={() => clearErrors && clearErrors(label)}
+          {...inputElementProps}
           {...register(label, {
             required: required && '필수 입력 항목이에요',
             pattern: pattern,

--- a/src/common/components/Input/index.tsx
+++ b/src/common/components/Input/index.tsx
@@ -1,33 +1,28 @@
+import { createContext, useContext } from 'react';
+
 import { circle, title, inputLine, containerVar, inputVar, descriptionVar } from './style.css';
 import { TextBoxProps } from './types';
 
-const TextBox = ({
+const ThemeContext = createContext({} as Pick<TextBoxProps, 'required' | 'formObject'>);
+
+const InputLine = ({
   label,
-  size = 'sm',
-  descriptionText,
-  descriptionButton,
-  required,
-  errorText,
-  button,
-  secondary,
   pattern,
-  formObject,
+  button,
+  errorText,
   ...inputElementProps
-}: TextBoxProps) => {
+}: Omit<TextBoxProps, 'size' | 'children' | 'formObject'>) => {
   const {
-    register,
-    formState: { errors },
-    clearErrors,
-  } = formObject;
+    required,
+    formObject: {
+      register,
+      formState: { errors },
+      clearErrors,
+    },
+  } = useContext(ThemeContext);
 
   return (
-    <div className={containerVar[size]}>
-      {!secondary && (
-        <label className={title} htmlFor={label}>
-          <span>{label}</span>
-          {required && <i className={circle} />}
-        </label>
-      )}
+    <>
       <div className={inputLine}>
         <input
           id={label}
@@ -41,19 +36,43 @@ const TextBox = ({
         />
         {button}
       </div>
-      {descriptionText && (
-        <div className={descriptionVar['default']}>
-          <p>{descriptionText}</p>
-          {descriptionButton}
-        </div>
-      )}
       {errors?.[label] && (
-        <div className={descriptionVar['error']}>
+        <Description styleType="error">
           <p>{errors[label]?.message || errorText}</p>
-        </div>
+        </Description>
       )}
-    </div>
+    </>
   );
+};
+
+const Description = ({ children, styleType = 'default' }: Pick<TextBoxProps, 'children' | 'styleType'>) => (
+  <div className={descriptionVar[styleType]}>{children}</div>
+);
+
+const Container = ({
+  children,
+  label,
+  size = 'md',
+  required,
+  formObject,
+}: Pick<TextBoxProps, 'children' | 'label' | 'size' | 'required' | 'formObject'>) => {
+  return (
+    <ThemeContext.Provider value={{ required, formObject }}>
+      <div className={containerVar[size]}>
+        <label className={title} htmlFor={label}>
+          <span>{label}</span>
+          {required && <i className={circle} />}
+        </label>
+        {children}
+      </div>
+    </ThemeContext.Provider>
+  );
+};
+
+const TextBox = {
+  Container,
+  InputLine,
+  Description,
 };
 
 export default TextBox;

--- a/src/common/components/Input/index.tsx
+++ b/src/common/components/Input/index.tsx
@@ -4,7 +4,7 @@ import { createContext, useContext } from 'react';
 import { circle, title, inputLine, containerVar, inputVar, descriptionVar } from './style.css';
 import { TextBoxProps } from './types';
 
-const ThemeContext = createContext({} as Pick<TextBoxProps, 'required' | 'formObject'>);
+const FormContext = createContext({} as Pick<TextBoxProps, 'required' | 'formObject'>);
 
 const InputLine = ({
   label,
@@ -17,7 +17,7 @@ const InputLine = ({
   const {
     required,
     formObject: { register, formState, clearErrors, trigger },
-  } = useContext(ThemeContext);
+  } = useContext(FormContext);
   const { errors } = formState;
 
   return (
@@ -48,7 +48,7 @@ const InputLine = ({
       </div>
       {errors[label] && (
         <Description styleType="error">
-          <p>{errors[label].message}</p>
+          <p>{errors[label]?.message as string}</p>
         </Description>
       )}
     </>
@@ -67,7 +67,7 @@ const Container = ({
   formObject,
 }: Pick<TextBoxProps, 'children' | 'label' | 'size' | 'required' | 'formObject'>) => {
   return (
-    <ThemeContext.Provider value={{ required, formObject }}>
+    <FormContext.Provider value={{ required, formObject }}>
       <div className={containerVar[size]}>
         <label className={title} htmlFor={label}>
           <span>{label}</span>
@@ -75,7 +75,7 @@ const Container = ({
         </label>
         {children}
       </div>
-    </ThemeContext.Provider>
+    </FormContext.Provider>
   );
 };
 

--- a/src/common/components/Input/index.tsx
+++ b/src/common/components/Input/index.tsx
@@ -16,12 +16,10 @@ const InputLine = ({
 }: Omit<TextBoxProps, 'size' | 'children' | 'formObject'>) => {
   const {
     required,
-    formObject: {
-      register,
-      formState: { errors },
-      clearErrors,
-    },
+    formObject: { register, formState, clearErrors, trigger },
   } = useContext(ThemeContext);
+  const { errors } = formState;
+
   return (
     <>
       <div className={inputLine}>
@@ -39,8 +37,12 @@ const InputLine = ({
                   }
                 : undefined,
             validate: validate,
+            onBlur: (e) => {
+              if (!pattern || e.currentTarget.value === '') return;
+              trigger(label);
+            },
+            onChange: () => clearErrors && clearErrors(label),
           })}
-          onChange={() => clearErrors && clearErrors(label)}
         />
         {button}
       </div>

--- a/src/common/components/Input/index.tsx
+++ b/src/common/components/Input/index.tsx
@@ -1,48 +1,37 @@
-import { container, circle, input, description, error, title } from './style.css';
-import { ContainerProps, DescriptionProps, InputProps, TitleProps } from './types';
+import { container, circle, input, description, title } from './style.css';
+import { TextBoxProps } from './types';
 
-const Container = ({ children }: ContainerProps) => {
-  return <div className={container}>{children}</div>;
-};
-
-const Title = ({ children, isRequired }: TitleProps) => {
+const TextBox = ({
+  label,
+  placeholderText,
+  descriptionText,
+  isRequired,
+  isFixed,
+  errorText,
+  buttonText,
+  buttonHandler,
+  ...inputElementProps
+}: TextBoxProps) => {
+  // 조건부 렌더링 / 유효성 검증은 추후 구현
   return (
-    <label className={title}>
-      <span>{children}</span>
-      {isRequired && <i className={circle} />}
-    </label>
-  );
-};
-
-const Description = ({ children, buttonText, buttonHandler, isError }: DescriptionProps) => {
-  return (
-    <div className={`${description} ${isError && error}`}>
-      <p>{children}</p>
-      {buttonText && (
-        <button type="button" style={{ cursor: 'pointer' }} onClick={buttonHandler}>
-          {buttonText}
-        </button>
+    <div className={container}>
+      <label className={title} htmlFor={label}>
+        <span>{label}</span>
+        {isRequired && <i className={circle} />}
+      </label>
+      <input id={label} className={input} placeholder={placeholderText} {...inputElementProps} />
+      {descriptionText && (
+        <div className={description}>
+          <p>{descriptionText}</p>
+          {buttonText && (
+            <button type="button" style={{ cursor: 'pointer' }} onClick={buttonHandler}>
+              {buttonText}
+            </button>
+          )}
+        </div>
       )}
     </div>
   );
-};
-
-const Input = ({ placeholderText, isRequired, isFixed, errorText, ...inputElementProps }: InputProps) => {
-  // isRequired, isFixed에 따라 동적스타일링
-  return (
-    <>
-      <input className={input} placeholder={placeholderText} {...inputElementProps} />
-      {errorText && <Description isError>{errorText}</Description>}
-      {/* 에러 조건 추가 */}
-    </>
-  );
-};
-
-const TextBox = {
-  Container,
-  Title,
-  Description,
-  Input,
 };
 
 export default TextBox;

--- a/src/common/components/Input/index.tsx
+++ b/src/common/components/Input/index.tsx
@@ -1,9 +1,10 @@
-import { container, circle, input, description, title, inputLine, error, errorInput } from './style.css';
+import { circle, input, description, title, inputLine, error, errorInput, containerVar } from './style.css';
 import { TextBoxProps } from './types';
 
 const TextBox = ({
   label,
   placeholderText,
+  size = 'sm',
   descriptionText,
   descriptionButton,
   isRequired,
@@ -22,7 +23,7 @@ const TextBox = ({
   } = formObject;
 
   return (
-    <div className={container}>
+    <div className={containerVar[size]}>
       {!secondary && (
         <label className={title} htmlFor={label}>
           <span>{label}</span>

--- a/src/common/components/Input/index.tsx
+++ b/src/common/components/Input/index.tsx
@@ -1,14 +1,14 @@
-import { circle, input, description, title, inputLine, errorInput, containerVar, errorDescription } from './style.css';
+import { circle, title, inputLine, containerVar, inputVar, descriptionVar } from './style.css';
 import { TextBoxProps } from './types';
 
 const TextBox = ({
   label,
-  placeholderText,
+  placeholder,
   size = 'sm',
   descriptionText,
   descriptionButton,
-  isRequired,
-  isFixed,
+  required,
+  disabled,
   errorText,
   button,
   secondary,
@@ -28,33 +28,33 @@ const TextBox = ({
       {!secondary && (
         <label className={title} htmlFor={label}>
           <span>{label}</span>
-          {isRequired && <i className={circle} />}
+          {required && <i className={circle} />}
         </label>
       )}
       <div className={inputLine}>
         <input
           id={label}
-          className={errors?.[label] ? errorInput : input}
-          placeholder={placeholderText}
+          className={inputVar[errors?.[label] ? 'error' : 'default']}
+          placeholder={placeholder}
           type={type}
-          disabled={isFixed}
+          disabled={disabled}
           maxLength={maxLength}
           onFocus={() => clearErrors && clearErrors(label)}
           {...register(label, {
-            required: isRequired && '필수 입력 항목이에요',
+            required: required && '필수 입력 항목이에요',
             pattern: pattern,
           })}
         />
         {button}
       </div>
       {descriptionText && (
-        <div className={description}>
+        <div className={descriptionVar['default']}>
           <p>{descriptionText}</p>
           {descriptionButton}
         </div>
       )}
       {errors?.[label] && (
-        <div className={errorDescription}>
+        <div className={descriptionVar['error']}>
           <p>{errors[label]?.message || errorText}</p>
         </div>
       )}

--- a/src/common/components/Input/index.tsx
+++ b/src/common/components/Input/index.tsx
@@ -14,7 +14,7 @@ const TextBox = ({
   secondary,
   pattern,
   formObject,
-  ...inputElementProps
+  maxLength,
 }: TextBoxProps) => {
   const {
     register,
@@ -36,11 +36,10 @@ const TextBox = ({
           className={`${input} ${errors?.[label] && errorInput}`}
           placeholder={placeholderText}
           disabled={isFixed}
-          {...inputElementProps}
+          maxLength={maxLength}
           onFocus={() => clearErrors && clearErrors(label)}
           {...register(label, {
             required: isRequired && '필수 입력 항목이에요',
-            maxLength: inputElementProps.maxLength,
             pattern: pattern,
           })}
         />

--- a/src/common/components/Input/index.tsx
+++ b/src/common/components/Input/index.tsx
@@ -15,6 +15,7 @@ const TextBox = ({
   pattern,
   formObject,
   maxLength,
+  type,
 }: TextBoxProps) => {
   const {
     register,
@@ -35,6 +36,7 @@ const TextBox = ({
           id={label}
           className={`${input} ${errors?.[label] && errorInput}`}
           placeholder={placeholderText}
+          type={type}
           disabled={isFixed}
           maxLength={maxLength}
           onFocus={() => clearErrors && clearErrors(label)}

--- a/src/common/components/Input/index.tsx
+++ b/src/common/components/Input/index.tsx
@@ -1,15 +1,15 @@
-import { container, circle, input, description, title } from './style.css';
+import { container, circle, input, description, title, inputLine } from './style.css';
 import { TextBoxProps } from './types';
 
 const TextBox = ({
   label,
   placeholderText,
   descriptionText,
+  descriptionButton,
   isRequired,
   isFixed,
   errorText,
-  buttonText,
-  buttonHandler,
+  button,
   ...inputElementProps
 }: TextBoxProps) => {
   // 조건부 렌더링 / 유효성 검증은 추후 구현
@@ -21,15 +21,14 @@ const TextBox = ({
           {isRequired && <i className={circle} />}
         </label>
       )}
-      <input id={label} className={input} placeholder={placeholderText} disabled={isFixed} {...inputElementProps} />
+      <div className={inputLine}>
+        <input id={label} className={input} placeholder={placeholderText} disabled={isFixed} {...inputElementProps} />
+        {button}
+      </div>
       {descriptionText && (
         <div className={description}>
           <p>{descriptionText}</p>
-          {buttonText && (
-            <button type="button" style={{ cursor: 'pointer' }} onClick={buttonHandler}>
-              {buttonText}
-            </button>
-          )}
+          {descriptionButton}
         </div>
       )}
     </div>

--- a/src/common/components/Input/style.css.ts
+++ b/src/common/components/Input/style.css.ts
@@ -11,7 +11,7 @@ export const container = style({
   ...theme.font.BODY_1_18_M,
 });
 
-export const label = style({
+export const title = style({
   display: 'flex',
   alignItems: 'center',
   gap: 6,
@@ -48,4 +48,8 @@ export const description = style({
 
   color: theme.color.lightestText,
   ...theme.font.LABEL_2_16_SB,
+});
+
+export const error = style({
+  color: theme.color.error,
 });

--- a/src/common/components/Input/style.css.ts
+++ b/src/common/components/Input/style.css.ts
@@ -1,4 +1,4 @@
-import { ComplexStyleRule, style } from '@vanilla-extract/css';
+import { style } from '@vanilla-extract/css';
 
 import { theme } from 'styles/theme.css';
 

--- a/src/common/components/Input/style.css.ts
+++ b/src/common/components/Input/style.css.ts
@@ -1,3 +1,51 @@
 import { style } from '@vanilla-extract/css';
 
-import { vars } from 'styles/theme.css';
+import { theme } from 'styles/theme.css';
+
+export const container = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 8,
+
+  color: theme.color.black,
+  ...theme.font.BODY_1_18_M,
+});
+
+export const label = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: 6,
+
+  color: theme.color.baseText,
+  ...theme.font.TITLE_5_18_SB,
+});
+
+export const circle = style({
+  width: 8,
+  height: 8,
+  borderRadius: 4,
+  backgroundColor: theme.color.primary,
+});
+
+export const input = style({
+  padding: 16,
+  backgroundColor: theme.color.white,
+  borderRadius: 12,
+  border: `1px solid ${theme.color.border}`,
+
+  color: theme.color.baseText,
+  ...theme.font.BODY_2_16_R,
+
+  '::placeholder': {
+    color: theme.color.placeholder,
+    ...theme.font.BODY_2_16_R,
+  },
+});
+
+export const description = style({
+  display: 'flex',
+  gap: 10,
+
+  color: theme.color.lightestText,
+  ...theme.font.LABEL_2_16_SB,
+});

--- a/src/common/components/Input/style.css.ts
+++ b/src/common/components/Input/style.css.ts
@@ -9,7 +9,6 @@ export const container = style({
   flexDirection: 'column',
   gap: 8,
 
-  color: theme.color.black,
   ...theme.font.BODY_1_18_M,
 });
 
@@ -36,13 +35,12 @@ export const inputLine = style({
   gap: 10,
 });
 
-export const input = style({
+const input = style({
   flex: 1,
 
   padding: 16,
   backgroundColor: theme.color.white,
   borderRadius: 12,
-  border: `1px solid ${theme.color.border}`,
 
   color: theme.color.baseText,
   ...theme.font.BODY_2_16_R,
@@ -53,7 +51,7 @@ export const input = style({
   },
 
   ':focus': {
-    borderColor: theme.color.primary,
+    boxShadow: `0 0 0 1px ${theme.color.primary} inset`,
   },
 
   ':disabled': {
@@ -62,14 +60,20 @@ export const input = style({
   },
 });
 
-export const errorInput = style([
-  input,
+export const inputVar = styleVariants(
   {
-    borderColor: theme.color.error,
+    default: theme.color.border,
+    error: theme.color.error,
   },
-]);
+  (borderColor) => [
+    input,
+    {
+      boxShadow: `0 0 0 1px ${borderColor} inset`,
+    },
+  ],
+);
 
-export const description = style({
+const description = style({
   display: 'flex',
   gap: 10,
 
@@ -77,9 +81,15 @@ export const description = style({
   ...theme.font.LABEL_2_16_SB,
 });
 
-export const errorDescription = style([
-  description,
+export const descriptionVar = styleVariants(
   {
-    color: theme.color.error,
+    default: theme.color.lightestText,
+    error: theme.color.error,
   },
-]);
+  (color) => [
+    description,
+    {
+      color,
+    },
+  ],
+);

--- a/src/common/components/Input/style.css.ts
+++ b/src/common/components/Input/style.css.ts
@@ -62,9 +62,12 @@ export const input = style({
   },
 });
 
-export const errorInput = style({
-  borderColor: theme.color.error,
-});
+export const errorInput = style([
+  input,
+  {
+    borderColor: theme.color.error,
+  },
+]);
 
 export const description = style({
   display: 'flex',
@@ -74,6 +77,9 @@ export const description = style({
   ...theme.font.LABEL_2_16_SB,
 });
 
-export const error = style({
-  color: theme.color.error,
-});
+export const errorDescription = style([
+  description,
+  {
+    color: theme.color.error,
+  },
+]);

--- a/src/common/components/Input/style.css.ts
+++ b/src/common/components/Input/style.css.ts
@@ -58,6 +58,10 @@ export const input = style({
   },
 });
 
+export const errorInput = style({
+  borderColor: theme.color.error,
+});
+
 export const description = style({
   display: 'flex',
   gap: 10,

--- a/src/common/components/Input/style.css.ts
+++ b/src/common/components/Input/style.css.ts
@@ -1,6 +1,8 @@
-import { style } from '@vanilla-extract/css';
+import { style, styleVariants } from '@vanilla-extract/css';
 
 import { theme } from 'styles/theme.css';
+
+import { containerSize } from './constants';
 
 export const container = style({
   display: 'flex',
@@ -10,6 +12,8 @@ export const container = style({
   color: theme.color.black,
   ...theme.font.BODY_1_18_M,
 });
+
+export const containerVar = styleVariants(containerSize, (size) => [container, { width: size }]);
 
 export const title = style({
   display: 'flex',

--- a/src/common/components/Input/style.css.ts
+++ b/src/common/components/Input/style.css.ts
@@ -27,7 +27,14 @@ export const circle = style({
   backgroundColor: theme.color.primary,
 });
 
+export const inputLine = style({
+  display: 'flex',
+  gap: 10,
+});
+
 export const input = style({
+  flex: 1,
+
   padding: 16,
   backgroundColor: theme.color.white,
   borderRadius: 12,

--- a/src/common/components/Input/style.css.ts
+++ b/src/common/components/Input/style.css.ts
@@ -19,8 +19,12 @@ export const title = style({
   alignItems: 'center',
   gap: 6,
 
+  width: 'fit-content',
+
   color: theme.color.baseText,
   ...theme.font.TITLE_5_18_SB,
+
+  cursor: 'pointer',
 });
 
 export const circle = style({

--- a/src/common/components/Input/style.css.ts
+++ b/src/common/components/Input/style.css.ts
@@ -1,4 +1,4 @@
-import { style } from '@vanilla-extract/css';
+import { ComplexStyleRule, style } from '@vanilla-extract/css';
 
 import { theme } from 'styles/theme.css';
 
@@ -39,6 +39,10 @@ export const input = style({
   '::placeholder': {
     color: theme.color.placeholder,
     ...theme.font.BODY_2_16_R,
+  },
+
+  ':focus': {
+    borderColor: theme.color.primary,
   },
 });
 

--- a/src/common/components/Input/style.css.ts
+++ b/src/common/components/Input/style.css.ts
@@ -1,0 +1,3 @@
+import { style } from '@vanilla-extract/css';
+
+import { vars } from 'styles/theme.css';

--- a/src/common/components/Input/style.css.ts
+++ b/src/common/components/Input/style.css.ts
@@ -44,6 +44,11 @@ export const input = style({
   ':focus': {
     borderColor: theme.color.primary,
   },
+
+  ':disabled': {
+    backgroundColor: theme.color.subBackground, // gray30 -> 20으로 수정해야함
+    color: theme.color.lighterText,
+  },
 });
 
 export const description = style({

--- a/src/common/components/Input/types.ts
+++ b/src/common/components/Input/types.ts
@@ -5,10 +5,9 @@ export interface TextBoxProps extends InputHTMLAttributes<HTMLInputElement> {
   placeholderText: string;
   //size?: 'xs' | 'sm' | 'md' | 'lg'; 나중에하겠습니다...
   descriptionText?: string;
+  descriptionButton?: ReactNode;
   isRequired?: boolean;
   isFixed?: boolean;
   errorText?: string;
-  buttonText?: string;
-  buttonHandler?: () => void;
   button?: ReactNode;
 }

--- a/src/common/components/Input/types.ts
+++ b/src/common/components/Input/types.ts
@@ -1,0 +1,25 @@
+import { InputHTMLAttributes, ReactNode } from 'react';
+
+export interface ContainerProps {
+  children: ReactNode;
+}
+
+export interface TitleProps {
+  children: string;
+  isRequired?: boolean;
+}
+
+export interface DescriptionProps {
+  children: string;
+  buttonText?: string;
+  buttonHandler?: () => void;
+  isError?: boolean;
+}
+
+export interface InputProps extends Pick<InputHTMLAttributes<HTMLInputElement>, 'maxLength' | 'type' | 'pattern'> {
+  placeholderText: string;
+  //size?: 'xs' | 'sm' | 'md' | 'lg'; 나중에하겠습니다...
+  isRequired?: boolean;
+  isFixed?: boolean;
+  errorText?: string;
+}

--- a/src/common/components/Input/types.ts
+++ b/src/common/components/Input/types.ts
@@ -1,7 +1,6 @@
 import { InputHTMLAttributes, ReactNode } from 'react';
 
-export interface TextBoxProps
-  extends Pick<InputHTMLAttributes<HTMLInputElement>, 'maxLength' | 'type' | 'pattern' | 'required'> {
+export interface TextBoxProps extends InputHTMLAttributes<HTMLInputElement> {
   label?: string;
   placeholderText: string;
   //size?: 'xs' | 'sm' | 'md' | 'lg'; 나중에하겠습니다...

--- a/src/common/components/Input/types.ts
+++ b/src/common/components/Input/types.ts
@@ -1,5 +1,5 @@
 import { InputHTMLAttributes, ReactNode } from 'react';
-import { FieldErrors, UseFormClearErrors, UseFormRegister } from 'react-hook-form';
+import { FieldErrors, UseFormClearErrors, UseFormRegister, Validate } from 'react-hook-form';
 
 export type SizeType = 'sm' | 'md' | 'lg';
 
@@ -17,6 +17,7 @@ export interface TextBoxProps
   errorText?: string;
   button?: ReactNode;
   pattern?: RegExp;
+  validate?: Validate | Record<string, Validate>; // <TFieldValue, TFormValues>
   formObject: FormObjectProps;
   children: ReactNode;
   styleType?: 'default' | 'error';

--- a/src/common/components/Input/types.ts
+++ b/src/common/components/Input/types.ts
@@ -1,26 +1,14 @@
-import { InputHTMLAttributes, ReactNode } from 'react';
+import { InputHTMLAttributes } from 'react';
 
-export interface ContainerProps {
-  children: ReactNode;
-}
-
-export interface TitleProps {
-  children: string;
-  isRequired?: boolean;
-}
-
-export interface DescriptionProps {
-  children: string;
-  buttonText?: string;
-  buttonHandler?: () => void;
-  isError?: boolean;
-}
-
-export interface InputProps
+export interface TextBoxProps
   extends Pick<InputHTMLAttributes<HTMLInputElement>, 'maxLength' | 'type' | 'pattern' | 'required'> {
+  label: string;
   placeholderText: string;
   //size?: 'xs' | 'sm' | 'md' | 'lg'; 나중에하겠습니다...
+  descriptionText: string;
   isRequired?: boolean;
   isFixed?: boolean;
-  errorText?: string;
+  errorText: string;
+  buttonText?: string;
+  buttonHandler?: () => void;
 }

--- a/src/common/components/Input/types.ts
+++ b/src/common/components/Input/types.ts
@@ -14,11 +14,10 @@ export interface TextBoxProps
   extends Pick<InputHTMLAttributes<HTMLInputElement>, 'type' | 'maxLength' | 'placeholder' | 'required' | 'disabled'> {
   label: string;
   size?: 'sm' | 'md' | 'lg';
-  descriptionText?: string;
-  descriptionButton?: ReactNode;
   errorText?: string;
   button?: ReactNode;
-  secondary?: boolean;
   pattern?: RegExp;
   formObject: FormObjectProps;
+  children: ReactNode;
+  styleType?: 'default' | 'error';
 }

--- a/src/common/components/Input/types.ts
+++ b/src/common/components/Input/types.ts
@@ -10,14 +10,12 @@ export interface FormObjectProps {
   };
   clearErrors?: UseFormClearErrors<any>;
 }
-export interface TextBoxProps extends Pick<InputHTMLAttributes<HTMLInputElement>, 'type' | 'maxLength'> {
+export interface TextBoxProps
+  extends Pick<InputHTMLAttributes<HTMLInputElement>, 'type' | 'maxLength' | 'placeholder' | 'required' | 'disabled'> {
   label: string;
-  placeholderText: string;
   size?: 'sm' | 'md' | 'lg';
   descriptionText?: string;
   descriptionButton?: ReactNode;
-  isRequired?: boolean;
-  isFixed?: boolean;
   errorText?: string;
   button?: ReactNode;
   secondary?: boolean;

--- a/src/common/components/Input/types.ts
+++ b/src/common/components/Input/types.ts
@@ -6,6 +6,8 @@ export type Inputs = {
   타이틀2: string;
 };
 
+export type SizeType = 'sm' | 'md' | 'lg';
+
 export interface FormObjectProps {
   register: UseFormRegister<any>;
   formState: {
@@ -13,10 +15,10 @@ export interface FormObjectProps {
   };
   clearErrors?: UseFormClearErrors<any>;
 }
-export interface TextBoxProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'pattern'> {
+export interface TextBoxProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'pattern' | 'size'> {
   label: string;
   placeholderText: string;
-  //size?: 'xs' | 'sm' | 'md' | 'lg'; 나중에하겠습니다...
+  size?: 'sm' | 'md' | 'lg';
   descriptionText?: string;
   descriptionButton?: ReactNode;
   isRequired?: boolean;

--- a/src/common/components/Input/types.ts
+++ b/src/common/components/Input/types.ts
@@ -10,7 +10,7 @@ export interface FormObjectProps {
   };
   clearErrors?: UseFormClearErrors<any>;
 }
-export interface TextBoxProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'pattern' | 'size'> {
+export interface TextBoxProps {
   label: string;
   placeholderText: string;
   size?: 'sm' | 'md' | 'lg';

--- a/src/common/components/Input/types.ts
+++ b/src/common/components/Input/types.ts
@@ -4,8 +4,7 @@ import { FieldValues, UseFormReturn, Validate } from 'react-hook-form';
 export type SizeType = 'sm' | 'md' | 'lg';
 
 export type TFormValues = Record<string, string>;
-export interface TextBoxProps
-  extends Pick<InputHTMLAttributes<HTMLInputElement>, 'type' | 'maxLength' | 'placeholder' | 'required' | 'disabled'> {
+export interface TextBoxProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'size' | 'pattern'> {
   label: string;
   size?: 'sm' | 'md' | 'lg';
   errorText?: string;

--- a/src/common/components/Input/types.ts
+++ b/src/common/components/Input/types.ts
@@ -1,4 +1,4 @@
-import { InputHTMLAttributes } from 'react';
+import { InputHTMLAttributes, ReactNode } from 'react';
 
 export interface TextBoxProps
   extends Pick<InputHTMLAttributes<HTMLInputElement>, 'maxLength' | 'type' | 'pattern' | 'required'> {
@@ -11,4 +11,5 @@ export interface TextBoxProps
   errorText?: string;
   buttonText?: string;
   buttonHandler?: () => void;
+  button?: ReactNode;
 }

--- a/src/common/components/Input/types.ts
+++ b/src/common/components/Input/types.ts
@@ -1,4 +1,4 @@
-import { ReactNode } from 'react';
+import { InputHTMLAttributes, ReactNode } from 'react';
 import { FieldErrors, UseFormClearErrors, UseFormRegister } from 'react-hook-form';
 
 export type SizeType = 'sm' | 'md' | 'lg';
@@ -10,7 +10,7 @@ export interface FormObjectProps {
   };
   clearErrors?: UseFormClearErrors<any>;
 }
-export interface TextBoxProps {
+export interface TextBoxProps extends Pick<InputHTMLAttributes<HTMLInputElement>, 'type' | 'maxLength'> {
   label: string;
   placeholderText: string;
   size?: 'sm' | 'md' | 'lg';
@@ -22,6 +22,5 @@ export interface TextBoxProps {
   button?: ReactNode;
   secondary?: boolean;
   pattern?: RegExp;
-  maxLength?: number;
   formObject: FormObjectProps;
 }

--- a/src/common/components/Input/types.ts
+++ b/src/common/components/Input/types.ts
@@ -2,13 +2,13 @@ import { InputHTMLAttributes } from 'react';
 
 export interface TextBoxProps
   extends Pick<InputHTMLAttributes<HTMLInputElement>, 'maxLength' | 'type' | 'pattern' | 'required'> {
-  label: string;
+  label?: string;
   placeholderText: string;
   //size?: 'xs' | 'sm' | 'md' | 'lg'; 나중에하겠습니다...
-  descriptionText: string;
+  descriptionText?: string;
   isRequired?: boolean;
   isFixed?: boolean;
-  errorText: string;
+  errorText?: string;
   buttonText?: string;
   buttonHandler?: () => void;
 }

--- a/src/common/components/Input/types.ts
+++ b/src/common/components/Input/types.ts
@@ -9,6 +9,7 @@ export interface FormObjectProps {
     errors: FieldErrors<any>;
   };
   clearErrors?: UseFormClearErrors<any>;
+  trigger: (name?: string | string[]) => Promise<boolean>;
 }
 export interface TextBoxProps
   extends Pick<InputHTMLAttributes<HTMLInputElement>, 'type' | 'maxLength' | 'placeholder' | 'required' | 'disabled'> {

--- a/src/common/components/Input/types.ts
+++ b/src/common/components/Input/types.ts
@@ -1,7 +1,11 @@
 import { InputHTMLAttributes, ReactNode } from 'react';
-import { UseFormRegister } from 'react-hook-form';
+import { FieldErrors, UseFormRegister } from 'react-hook-form';
 
-export interface TextBoxProps extends InputHTMLAttributes<HTMLInputElement> {
+export type Inputs = {
+  타이틀1: string;
+  타이틀2: string;
+};
+export interface TextBoxProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'pattern'> {
   label: string;
   placeholderText: string;
   //size?: 'xs' | 'sm' | 'md' | 'lg'; 나중에하겠습니다...
@@ -12,6 +16,8 @@ export interface TextBoxProps extends InputHTMLAttributes<HTMLInputElement> {
   errorText?: string;
   button?: ReactNode;
   secondary?: boolean;
+  pattern?: RegExp;
 
-  register?: UseFormRegister<any>;
+  register: UseFormRegister<any>;
+  errors?: FieldErrors<any>;
 }

--- a/src/common/components/Input/types.ts
+++ b/src/common/components/Input/types.ts
@@ -16,7 +16,8 @@ export interface DescriptionProps {
   isError?: boolean;
 }
 
-export interface InputProps extends Pick<InputHTMLAttributes<HTMLInputElement>, 'maxLength' | 'type' | 'pattern'> {
+export interface InputProps
+  extends Pick<InputHTMLAttributes<HTMLInputElement>, 'maxLength' | 'type' | 'pattern' | 'required'> {
   placeholderText: string;
   //size?: 'xs' | 'sm' | 'md' | 'lg'; 나중에하겠습니다...
   isRequired?: boolean;

--- a/src/common/components/Input/types.ts
+++ b/src/common/components/Input/types.ts
@@ -5,6 +5,14 @@ export type Inputs = {
   타이틀1: string;
   타이틀2: string;
 };
+
+export interface FormObjectProps {
+  register: UseFormRegister<any>;
+  formState: {
+    errors: FieldErrors<any>;
+  };
+  clearErrors?: UseFormClearErrors<any>;
+}
 export interface TextBoxProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'pattern'> {
   label: string;
   placeholderText: string;
@@ -17,8 +25,5 @@ export interface TextBoxProps extends Omit<InputHTMLAttributes<HTMLInputElement>
   button?: ReactNode;
   secondary?: boolean;
   pattern?: RegExp;
-
-  register: UseFormRegister<any>;
-  errors?: FieldErrors<any>;
-  clearErrors?: UseFormClearErrors<any>;
+  formObject: FormObjectProps;
 }

--- a/src/common/components/Input/types.ts
+++ b/src/common/components/Input/types.ts
@@ -1,16 +1,9 @@
 import { InputHTMLAttributes, ReactNode } from 'react';
-import { FieldErrors, UseFormClearErrors, UseFormRegister, Validate } from 'react-hook-form';
+import { FieldValues, UseFormReturn, Validate } from 'react-hook-form';
 
 export type SizeType = 'sm' | 'md' | 'lg';
 
-export interface FormObjectProps {
-  register: UseFormRegister<any>;
-  formState: {
-    errors: FieldErrors<any>;
-  };
-  clearErrors?: UseFormClearErrors<any>;
-  trigger: (name?: string | string[]) => Promise<boolean>;
-}
+export type TFormValues = Record<string, string>;
 export interface TextBoxProps
   extends Pick<InputHTMLAttributes<HTMLInputElement>, 'type' | 'maxLength' | 'placeholder' | 'required' | 'disabled'> {
   label: string;
@@ -18,8 +11,8 @@ export interface TextBoxProps
   errorText?: string;
   button?: ReactNode;
   pattern?: RegExp;
-  validate?: Validate | Record<string, Validate>; // <TFieldValue, TFormValues>
-  formObject: FormObjectProps;
+  validate?: Validate<FieldValues, TFormValues>;
+  formObject: Pick<UseFormReturn, 'register' | 'formState' | 'clearErrors' | 'trigger'>;
   children: ReactNode;
   styleType?: 'default' | 'error';
 }

--- a/src/common/components/Input/types.ts
+++ b/src/common/components/Input/types.ts
@@ -1,5 +1,5 @@
 import { InputHTMLAttributes, ReactNode } from 'react';
-import { FieldErrors, UseFormRegister } from 'react-hook-form';
+import { FieldErrors, UseFormClearErrors, UseFormRegister } from 'react-hook-form';
 
 export type Inputs = {
   타이틀1: string;
@@ -20,4 +20,5 @@ export interface TextBoxProps extends Omit<InputHTMLAttributes<HTMLInputElement>
 
   register: UseFormRegister<any>;
   errors?: FieldErrors<any>;
+  clearErrors?: UseFormClearErrors<any>;
 }

--- a/src/common/components/Input/types.ts
+++ b/src/common/components/Input/types.ts
@@ -1,11 +1,6 @@
 import { InputHTMLAttributes, ReactNode } from 'react';
 import { FieldErrors, UseFormClearErrors, UseFormRegister } from 'react-hook-form';
 
-export type Inputs = {
-  타이틀1: string;
-  타이틀2: string;
-};
-
 export type SizeType = 'sm' | 'md' | 'lg';
 
 export interface FormObjectProps {
@@ -27,5 +22,6 @@ export interface TextBoxProps extends Omit<InputHTMLAttributes<HTMLInputElement>
   button?: ReactNode;
   secondary?: boolean;
   pattern?: RegExp;
+  maxLength?: number;
   formObject: FormObjectProps;
 }

--- a/src/common/components/Input/types.ts
+++ b/src/common/components/Input/types.ts
@@ -1,7 +1,8 @@
 import { InputHTMLAttributes, ReactNode } from 'react';
+import { UseFormRegister } from 'react-hook-form';
 
 export interface TextBoxProps extends InputHTMLAttributes<HTMLInputElement> {
-  label?: string;
+  label: string;
   placeholderText: string;
   //size?: 'xs' | 'sm' | 'md' | 'lg'; 나중에하겠습니다...
   descriptionText?: string;
@@ -10,4 +11,7 @@ export interface TextBoxProps extends InputHTMLAttributes<HTMLInputElement> {
   isFixed?: boolean;
   errorText?: string;
   button?: ReactNode;
+  secondary?: boolean;
+
+  register?: UseFormRegister<any>;
 }

--- a/src/common/components/Input/types.ts
+++ b/src/common/components/Input/types.ts
@@ -1,4 +1,4 @@
-import { InputHTMLAttributes, ReactNode } from 'react';
+import { ReactNode } from 'react';
 import { FieldErrors, UseFormClearErrors, UseFormRegister } from 'react-hook-form';
 
 export type SizeType = 'sm' | 'md' | 'lg';

--- a/src/pages/ApplyPage.tsx
+++ b/src/pages/ApplyPage.tsx
@@ -2,8 +2,8 @@ import TextBox from '@components/Input';
 import { TextBoxProps } from '@components/Input/types';
 
 const ApplyPage = () => {
-  const textBoxProps: TextBoxProps = {
-    label: '타이틀',
+  const textBoxProps1: TextBoxProps = {
+    label: '타이틀1',
     placeholderText: '플레이스 홀더 텍스트',
     descriptionText: '더 알아보는 텍스트',
     errorText: '에러 텍스트',
@@ -11,7 +11,16 @@ const ApplyPage = () => {
     buttonText: '더 알아보는 버튼',
     isRequired: true,
   };
-  return <TextBox {...textBoxProps} />;
+
+  return (
+    <form>
+      <TextBox {...textBoxProps1} />
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '10px' }}>
+        <TextBox label="타이틀2" placeholderText="플레이스 홀더 텍스트2" isRequired />
+        <TextBox placeholderText="텍스트" />
+      </div>
+    </form>
+  );
 };
 
 export default ApplyPage;

--- a/src/pages/ApplyPage.tsx
+++ b/src/pages/ApplyPage.tsx
@@ -1,13 +1,17 @@
 import TextBox from '@components/Input';
+import { TextBoxProps } from '@components/Input/types';
 
 const ApplyPage = () => {
-  return (
-    <TextBox.Container>
-      <TextBox.Title>이메일</TextBox.Title>
-      <TextBox.Input placeholderText="인증 번호를 작성해주세요" type="email" maxLength={20} pattern=".+@gmail.com" />
-      <TextBox.Description buttonText="눌러보세요">더 알아보기</TextBox.Description>
-    </TextBox.Container>
-  );
+  const textBoxProps: TextBoxProps = {
+    label: '타이틀',
+    placeholderText: '플레이스 홀더 텍스트',
+    descriptionText: '더 알아보는 텍스트',
+    errorText: '에러 텍스트',
+    buttonHandler: () => console.log('버튼클릭'),
+    buttonText: '더 알아보는 버튼',
+    isRequired: true,
+  };
+  return <TextBox {...textBoxProps} />;
 };
 
 export default ApplyPage;

--- a/src/pages/ApplyPage.tsx
+++ b/src/pages/ApplyPage.tsx
@@ -22,12 +22,7 @@ const CheckButton = () => {
 };
 
 const ApplyPage = () => {
-  const {
-    register,
-    handleSubmit,
-    formState: { errors },
-    clearErrors,
-  } = useForm<any>({ mode: 'onBlur' });
+  const { handleSubmit, ...formObject } = useForm<any>({ mode: 'onBlur' });
 
   const onSubmit: SubmitHandler<any> = (data) => console.log(data);
 
@@ -38,9 +33,7 @@ const ApplyPage = () => {
     descriptionButton: <MoreButton />,
     errorText: '에러 텍스트',
     isRequired: true,
-    register,
-    errors,
-    clearErrors,
+    formObject,
   };
 
   return (
@@ -52,11 +45,9 @@ const ApplyPage = () => {
           placeholderText="플레이스 홀더 텍스트2"
           button={<CheckButton />}
           isRequired
-          register={register}
-          errors={errors}
-          clearErrors={clearErrors}
+          formObject={formObject}
         />
-        <TextBox label="타이틀3" placeholderText="고정 텍스트" isFixed secondary register={register} errors={errors} />
+        <TextBox label="타이틀3" placeholderText="고정 텍스트" isFixed secondary formObject={formObject} />
       </div>
       <input type="submit" value="제출버튼!" style={{ backgroundColor: 'green' }} />
     </form>

--- a/src/pages/ApplyPage.tsx
+++ b/src/pages/ApplyPage.tsx
@@ -29,6 +29,7 @@ const ApplyPage = () => {
   const textBoxProps1: TextBoxProps = {
     label: '타이틀1',
     placeholderText: '플레이스 홀더 텍스트',
+    size: 'lg',
     descriptionText: '더 알아보는 텍스트',
     descriptionButton: <MoreButton />,
     errorText: '에러 텍스트',

--- a/src/pages/ApplyPage.tsx
+++ b/src/pages/ApplyPage.tsx
@@ -21,7 +21,7 @@ const CheckButton = () => {
 };
 
 const ApplyPage = () => {
-  const { handleSubmit, ...formObject } = useForm<any>({ mode: 'onBlur' });
+  const { handleSubmit, ...formObject } = useForm<any>();
 
   const onSubmit: SubmitHandler<any> = (data) => console.log(data);
 

--- a/src/pages/ApplyPage.tsx
+++ b/src/pages/ApplyPage.tsx
@@ -1,5 +1,13 @@
+import TextBox from '@components/Input';
+
 const ApplyPage = () => {
-  return <div>ApplyPage</div>;
+  return (
+    <TextBox.Container>
+      <TextBox.Title>이메일</TextBox.Title>
+      <TextBox.Input placeholderText="인증 번호를 작성해주세요" type="email" maxLength={20} pattern=".+@gmail.com" />
+      <TextBox.Description buttonText="눌러보세요">더 알아보기</TextBox.Description>
+    </TextBox.Container>
+  );
 };
 
 export default ApplyPage;

--- a/src/pages/ApplyPage.tsx
+++ b/src/pages/ApplyPage.tsx
@@ -17,7 +17,7 @@ const ApplyPage = () => {
       <TextBox {...textBoxProps1} />
       <div style={{ display: 'flex', flexDirection: 'column', gap: '10px' }}>
         <TextBox label="타이틀2" placeholderText="플레이스 홀더 텍스트2" isRequired />
-        <TextBox placeholderText="텍스트" />
+        <TextBox placeholderText="고정 텍스트" isFixed />
       </div>
     </form>
   );

--- a/src/pages/ApplyPage.tsx
+++ b/src/pages/ApplyPage.tsx
@@ -1,5 +1,5 @@
 import TextBox from '@components/Input';
-import { Inputs, TextBoxProps } from '@components/Input/types';
+import { TextBoxProps } from '@components/Input/types';
 import { SubmitHandler, useForm } from 'react-hook-form';
 
 const MoreButton = () => {
@@ -26,7 +26,7 @@ const ApplyPage = () => {
     register,
     handleSubmit,
     formState: { errors },
-  } = useForm<Inputs>();
+  } = useForm<any>({ mode: 'onBlur' });
 
   const onSubmit: SubmitHandler<any> = (data) => console.log(data);
 
@@ -38,6 +38,7 @@ const ApplyPage = () => {
     errorText: '에러 텍스트',
     isRequired: true,
     register,
+    errors,
   };
 
   return (
@@ -50,8 +51,9 @@ const ApplyPage = () => {
           button={<CheckButton />}
           isRequired
           register={register}
+          errors={errors}
         />
-        <TextBox label="타이틀2-1" placeholderText="고정 텍스트" isFixed secondary />
+        <TextBox label="타이틀3" placeholderText="고정 텍스트" isFixed secondary register={register} errors={errors} />
       </div>
       <input type="submit" value="제출버튼!" style={{ backgroundColor: 'green' }} />
     </form>

--- a/src/pages/ApplyPage.tsx
+++ b/src/pages/ApplyPage.tsx
@@ -1,4 +1,5 @@
 import TextBox from '@components/Input';
+import { TFormValues } from '@components/Input/types';
 import { SubmitHandler, useForm } from 'react-hook-form';
 
 const MoreButton = () => {
@@ -21,9 +22,9 @@ const CheckButton = () => {
 };
 
 const ApplyPage = () => {
-  const { handleSubmit, ...formObject } = useForm<any>();
+  const { handleSubmit, ...formObject } = useForm();
 
-  const onSubmit: SubmitHandler<any> = (data) => console.log(data);
+  const onSubmit: SubmitHandler<TFormValues> = (data) => console.log(data);
 
   return (
     <form onSubmit={handleSubmit(onSubmit)}>
@@ -38,7 +39,7 @@ const ApplyPage = () => {
         <TextBox.InputLine
           label="인증번호"
           placeholder="인증번호를 입력하세요"
-          validate={(v) => v === '가나다라마바사' || '틀렸어요'}
+          validate={(_, v) => v['이메일'] === '검사조건' || '틀렸어요'}
           errorText="틀렸습니다"
         />
         <TextBox.Description>

--- a/src/pages/ApplyPage.tsx
+++ b/src/pages/ApplyPage.tsx
@@ -1,5 +1,4 @@
 import TextBox from '@components/Input';
-import { TextBoxProps } from '@components/Input/types';
 import { SubmitHandler, useForm } from 'react-hook-form';
 
 const MoreButton = () => {
@@ -26,32 +25,17 @@ const ApplyPage = () => {
 
   const onSubmit: SubmitHandler<any> = (data) => console.log(data);
 
-  const textBoxProps1: TextBoxProps = {
-    label: '타이틀1',
-    placeholder: '플레이스 홀더 텍스트',
-    size: 'lg',
-    descriptionText: '더 알아보는 텍스트',
-    descriptionButton: <MoreButton />,
-    errorText: '에러 텍스트',
-    required: true,
-    formObject,
-  };
-
   return (
     <form onSubmit={handleSubmit(onSubmit)}>
-      <TextBox {...textBoxProps1} />
-      <div style={{ display: 'flex', flexDirection: 'column', gap: '10px' }}>
-        <TextBox
-          label="타이틀2"
-          placeholder="플레이스 홀더 텍스트2"
-          button={<CheckButton />}
-          required
-          maxLength={5}
-          formObject={formObject}
-        />
-        <TextBox label="타이틀3" placeholder="고정 텍스트" disabled secondary formObject={formObject} />
-      </div>
-      <input type="submit" value="제출버튼!" style={{ backgroundColor: 'green' }} />
+      <TextBox.Container label="이메일" required formObject={formObject}>
+        <TextBox.InputLine label="이메일" button={<CheckButton />} placeholder="이메일을 입력하세요" />
+        <TextBox.InputLine label="인증번호" placeholder="인증번호를 입력하세요" disabled />
+        <TextBox.Description>
+          <p>더 알아보는 텍스트</p>
+          <MoreButton />
+        </TextBox.Description>
+      </TextBox.Container>
+      <input type="submit" value="제출버튼!" style={{ backgroundColor: 'green', marginTop: 30 }} />
     </form>
   );
 };

--- a/src/pages/ApplyPage.tsx
+++ b/src/pages/ApplyPage.tsx
@@ -46,6 +46,7 @@ const ApplyPage = () => {
           placeholderText="플레이스 홀더 텍스트2"
           button={<CheckButton />}
           isRequired
+          maxLength={5}
           formObject={formObject}
         />
         <TextBox label="타이틀3" placeholderText="고정 텍스트" isFixed secondary formObject={formObject} />

--- a/src/pages/ApplyPage.tsx
+++ b/src/pages/ApplyPage.tsx
@@ -26,6 +26,7 @@ const ApplyPage = () => {
     register,
     handleSubmit,
     formState: { errors },
+    clearErrors,
   } = useForm<any>({ mode: 'onBlur' });
 
   const onSubmit: SubmitHandler<any> = (data) => console.log(data);
@@ -39,6 +40,7 @@ const ApplyPage = () => {
     isRequired: true,
     register,
     errors,
+    clearErrors,
   };
 
   return (
@@ -52,6 +54,7 @@ const ApplyPage = () => {
           isRequired
           register={register}
           errors={errors}
+          clearErrors={clearErrors}
         />
         <TextBox label="타이틀3" placeholderText="고정 텍스트" isFixed secondary register={register} errors={errors} />
       </div>

--- a/src/pages/ApplyPage.tsx
+++ b/src/pages/ApplyPage.tsx
@@ -28,12 +28,12 @@ const ApplyPage = () => {
 
   const textBoxProps1: TextBoxProps = {
     label: '타이틀1',
-    placeholderText: '플레이스 홀더 텍스트',
+    placeholder: '플레이스 홀더 텍스트',
     size: 'lg',
     descriptionText: '더 알아보는 텍스트',
     descriptionButton: <MoreButton />,
     errorText: '에러 텍스트',
-    isRequired: true,
+    required: true,
     formObject,
   };
 
@@ -43,13 +43,13 @@ const ApplyPage = () => {
       <div style={{ display: 'flex', flexDirection: 'column', gap: '10px' }}>
         <TextBox
           label="타이틀2"
-          placeholderText="플레이스 홀더 텍스트2"
+          placeholder="플레이스 홀더 텍스트2"
           button={<CheckButton />}
-          isRequired
+          required
           maxLength={5}
           formObject={formObject}
         />
-        <TextBox label="타이틀3" placeholderText="고정 텍스트" isFixed secondary formObject={formObject} />
+        <TextBox label="타이틀3" placeholder="고정 텍스트" disabled secondary formObject={formObject} />
       </div>
       <input type="submit" value="제출버튼!" style={{ backgroundColor: 'green' }} />
     </form>

--- a/src/pages/ApplyPage.tsx
+++ b/src/pages/ApplyPage.tsx
@@ -28,8 +28,19 @@ const ApplyPage = () => {
   return (
     <form onSubmit={handleSubmit(onSubmit)}>
       <TextBox.Container label="이메일" required formObject={formObject}>
-        <TextBox.InputLine label="이메일" button={<CheckButton />} placeholder="이메일을 입력하세요" />
-        <TextBox.InputLine label="인증번호" placeholder="인증번호를 입력하세요" disabled />
+        <TextBox.InputLine
+          label="이메일"
+          button={<CheckButton />}
+          placeholder="이메일을 입력하세요"
+          pattern={/^[0-9]*$/}
+          errorText="숫자만 입력해주세요"
+        />
+        <TextBox.InputLine
+          label="인증번호"
+          placeholder="인증번호를 입력하세요"
+          validate={(v) => v === '가나다라마바사' || '틀렸어요'}
+          errorText="틀렸습니다"
+        />
         <TextBox.Description>
           <p>더 알아보는 텍스트</p>
           <MoreButton />

--- a/src/pages/ApplyPage.tsx
+++ b/src/pages/ApplyPage.tsx
@@ -1,14 +1,31 @@
 import TextBox from '@components/Input';
 import { TextBoxProps } from '@components/Input/types';
 
+const MoreButton = () => {
+  return (
+    <button type="button" style={{ cursor: 'pointer' }} onClick={() => console.log('버튼클릭')}>
+      더알아보는버튼
+    </button>
+  );
+};
+
+const CheckButton = () => {
+  return (
+    <button
+      type="button"
+      style={{ cursor: 'pointer', backgroundColor: 'green', padding: 10 }}
+      onClick={() => console.log('버튼클릭')}>
+      인증하기
+    </button>
+  );
+};
 const ApplyPage = () => {
   const textBoxProps1: TextBoxProps = {
     label: '타이틀1',
     placeholderText: '플레이스 홀더 텍스트',
     descriptionText: '더 알아보는 텍스트',
+    descriptionButton: <MoreButton />,
     errorText: '에러 텍스트',
-    buttonHandler: () => console.log('버튼클릭'),
-    buttonText: '더 알아보는 버튼',
     isRequired: true,
   };
 
@@ -16,7 +33,7 @@ const ApplyPage = () => {
     <form>
       <TextBox {...textBoxProps1} />
       <div style={{ display: 'flex', flexDirection: 'column', gap: '10px' }}>
-        <TextBox label="타이틀2" placeholderText="플레이스 홀더 텍스트2" isRequired />
+        <TextBox label="타이틀2" placeholderText="플레이스 홀더 텍스트2" button={<CheckButton />} isRequired />
         <TextBox placeholderText="고정 텍스트" isFixed />
       </div>
     </form>

--- a/src/pages/ApplyPage.tsx
+++ b/src/pages/ApplyPage.tsx
@@ -1,5 +1,6 @@
 import TextBox from '@components/Input';
-import { TextBoxProps } from '@components/Input/types';
+import { Inputs, TextBoxProps } from '@components/Input/types';
+import { SubmitHandler, useForm } from 'react-hook-form';
 
 const MoreButton = () => {
   return (
@@ -19,7 +20,16 @@ const CheckButton = () => {
     </button>
   );
 };
+
 const ApplyPage = () => {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<Inputs>();
+
+  const onSubmit: SubmitHandler<any> = (data) => console.log(data);
+
   const textBoxProps1: TextBoxProps = {
     label: '타이틀1',
     placeholderText: '플레이스 홀더 텍스트',
@@ -27,15 +37,23 @@ const ApplyPage = () => {
     descriptionButton: <MoreButton />,
     errorText: '에러 텍스트',
     isRequired: true,
+    register,
   };
 
   return (
-    <form>
+    <form onSubmit={handleSubmit(onSubmit)}>
       <TextBox {...textBoxProps1} />
       <div style={{ display: 'flex', flexDirection: 'column', gap: '10px' }}>
-        <TextBox label="타이틀2" placeholderText="플레이스 홀더 텍스트2" button={<CheckButton />} isRequired />
-        <TextBox placeholderText="고정 텍스트" isFixed />
+        <TextBox
+          label="타이틀2"
+          placeholderText="플레이스 홀더 텍스트2"
+          button={<CheckButton />}
+          isRequired
+          register={register}
+        />
+        <TextBox label="타이틀2-1" placeholderText="고정 텍스트" isFixed secondary />
       </div>
+      <input type="submit" value="제출버튼!" style={{ backgroundColor: 'green' }} />
     </form>
   );
 };

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -1,17 +1,5 @@
-import TextBox from '@components/Input';
-
-import { container } from '../views/MainPage/style.css';
-
 const MainPage = () => {
-  return (
-    <div className={container}>
-      <TextBox.Container id="email">
-        <TextBox.Title>이메일</TextBox.Title>
-        <TextBox.Input placeholderText="인증 번호를 작성해주세요" type="email" maxLength={10} pattern=".+@gmail.com" />
-        <TextBox.Description buttonText="눌러보세요">더 알아보기</TextBox.Description>
-      </TextBox.Container>
-    </div>
-  );
+  return <div></div>;
 };
 
 export default MainPage;

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -1,7 +1,17 @@
+import TextBox from '@components/Input';
+
 import { container } from '../views/MainPage/style.css';
 
 const MainPage = () => {
-  return <div className={container}>MainPage</div>;
+  return (
+    <div className={container}>
+      <TextBox.Container>
+        <TextBox.Title>이메일</TextBox.Title>
+        <TextBox.Input placeholderText="인증 번호를 작성해주세요" type="email" maxLength={10} pattern=".+@gmail.com" />
+        <TextBox.Description buttonText="눌러보세요">더 알아보기</TextBox.Description>
+      </TextBox.Container>
+    </div>
+  );
 };
 
 export default MainPage;

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -5,7 +5,7 @@ import { container } from '../views/MainPage/style.css';
 const MainPage = () => {
   return (
     <div className={container}>
-      <TextBox.Container>
+      <TextBox.Container id="email">
         <TextBox.Title>이메일</TextBox.Title>
         <TextBox.Input placeholderText="인증 번호를 작성해주세요" type="email" maxLength={10} pattern=".+@gmail.com" />
         <TextBox.Description buttonText="눌러보세요">더 알아보기</TextBox.Description>

--- a/src/styles/theme.css.ts
+++ b/src/styles/theme.css.ts
@@ -44,7 +44,7 @@ export const light = createTheme(color, {
 
   background: colors.white,
   backgroundDimmed: colors.grayAlpha500,
-  subBackground: colors.gray30, // gray20 인데 아직 mds에 미반영 되어서 30으로 임시 저장.
+  subBackground: '#F5F5F5', // gray20 인데 아직 mds에 미반영 되어서 30으로 임시 저장.
 
   baseText: colors.gray950,
   lighterText: colors.gray300,

--- a/src/views/MainPage/style.css.ts
+++ b/src/views/MainPage/style.css.ts
@@ -3,7 +3,5 @@ import { style } from '@vanilla-extract/css';
 import { theme } from 'styles/theme.css';
 
 export const container = style({
-  color: theme.color.primaryDark,
-  backgroundColor: theme.color.primaryDark,
   ...theme.font.BODY_1_18_M,
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2697,6 +2697,11 @@ react-dom@^18.2.0:
     loose-envify "^1.1.0"
     scheduler "^0.23.2"
 
+react-hook-form@^7.51.5:
+  version "7.51.5"
+  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.51.5.tgz#4afbfb819312db9fea23e8237a3a0d097e128b43"
+  integrity sha512-J2ILT5gWx1XUIJRETiA7M19iXHlG74+6O3KApzvqB/w8S5NQR7AbU8HVZrMALdmDgWpRPYiZJl0zx8Z4L2mP6Q==
+
 react-is@^16.13.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"


### PR DESCRIPTION
**Related Issue :** Closes  #15 

---

## 🟢 0610 Update 된 PR 입니다! 
@eonseok-jeon 
코드리뷰 반영하면서 진행한 작업사이즈가 커서 comment말고 PR에 작성하였습니다.
이전 내용은 토클에 숨겨두었어요

### 사용 예시 
`ApplyPage.tsx` 를 참고해주세요 

<details>
<summary><strong>🟢 최초 PR </strong></summary>
<br/>

```tsx
  const { handleSubmit, ...formObject } = useForm<any>({ mode: 'onBlur' });

  const textBoxProps1: TextBoxProps = {
    label: '타이틀1',
    placeholderText: '플레이스 홀더 텍스트',
    size: 'lg',
    descriptionText: '더 알아보는 텍스트',
    descriptionButton: <MoreButton />,
    isRequired: true,
    // isFixed: true,
    errorText: '이러이러한 형식이 잘못됨',
    button: <CheckButton />,
    // secondary: true,
    pattern: /^[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*@[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*\.[a-zA-Z]{2,3}$/i,
    maxLength: 5,
    formObject,
  };

  return (
    <form onSubmit={handleSubmit(onSubmit)}>
      <TextBox {...textBoxProps1} />
```
부연설명이 필요한 친구들만 정리하자면

- `label` : label의 텍스트, input의 id, form(register)에서 name에 들어가는 친구
- `descriptionButton` : 하단 회색 텍스트에 텍스트 버튼이 들어갈 때가 있어요. 여기에 button 컴포넌트 전달 (ex- 비밀번호 찾기)
- `errorText` : 필수항목의 값이 비어있을 경우의 에러 텍스트는 내부적으로 제공돼요. 하지만 그 외의 '비밀번호가 일치하지 않습니다', '인증번호가 일치하지 않습니다' 와 같은 예외 에러 텍스트는 별도로 전달해주어야 합니다. (활용 로직은 아직 완벽히 구현하지 못했습니다) 
- `button` : `이메일 인증` 과 같은 Button으로, 언석님이 만들어주신 공통 Button 컴포넌트 들어갈 자리 만들어두었습니다. 
- `secondary` : 비밀번호 확인 입력창 같이 두번째 줄에 label 없이 들어가는 input을 나타내는 속성입니다. 
만약 한줄짜리 Input이면 
```tsx
<TextBox {...textBoxProps1} />
```
이렇게 사용하면 되고, 두줄짜리 input이면 
```tsx
<div style={{ display: 'flex', flexDirection: 'column', gap: '10px' }}>
        <TextBox {...textBoxProps2} />
        <TextBox {...textBoxProps3} secondary />
      </div>
```
이런식으로` Wrapper Tag + TextBox 2개`로 구현해주셔야 합니다

- `pattern` : 유효성 검증에 쓰이는 정규식을 넣어주는 자리로, **타입은 string 아니고 RegExp** 입니다 
- `formObject` : 페이지(상위) 컴포넌트에서 **useForm을 호출하여 반환받은 객체** 중, form 태그에서 사용하는 `handleSubmit`을 제외한 **나머지**들을 담아주어 TextBox로 전달합니다. TextBox 내에서 쓰이는 속성은 `register`, formState 내의 `errors`, `clearErrors` 인데, 전달하는 props 수를 최소화하고자 객체 통째로 전달 후, TextBox 내부에서 구조분해할당 해서 사용합니다 
---

</details>

**컴포넌트 종류** 
- Container : 전체 컨테이너 + 폼 타이틀 
  - `children`, label, size, required, formObject
- InputLine : input + 같은 줄의 버튼 
  - label, pattern, validate, button, errorText, ...HTML attributes
- Description : input 하단에 들어가는 회색 텍스트 
  - `children`

두줄짜리 input 예시입니다 

```tsx
  <TextBox.Container label="이메일" required formObject={formObject}>
    <TextBox.InputLine
      label="이메일"
      button={<CheckButton />}
      placeholder="이메일을 입력하세요"
      pattern={/^[0-9]*$/}
      errorText="숫자만 입력해주세요"
    />
    <TextBox.InputLine
      label="인증번호"
      placeholder="인증번호를 입력하세요"
      validate={(v) => v === '가나다라마바사' || '틀렸어요'}
    />
    <TextBox.Description>
      <p>더 알아보는 텍스트</p>
      <MoreButton />
    </TextBox.Description>
  </TextBox.Container>
```
- label : 폼 타이틀이자, 각 input의 name 
- formObject : useForm 반환값 전달 (register, formState 등등 포함)
- button : InputLine에 넣어줄 버튼 
- placeholder
- pattern : 입력 형식 체크를 위한 정규식. 타입은 String 아니고 RegExp임을 주의.
- errorText : pattern 값 설정한 경우, 입력 형식 조건 실패 시 나타낼 에러 텍스트
- validate : 필수 여부, 입력 형태 외의 검사 조건. ([공식문서](https://www.react-hook-form.com/api/useform/register/)) 



## 🧑‍🎤 Screenshot

<details>
<summary><strong>🟢 최초 PR </strong></summary>
<br/>

https://github.com/sopt-makers/sopt-recruiting-frontend/assets/81505421/9ef8e1f6-e073-4fa4-81ee-823605ae301a

---

</details>



https://github.com/sopt-makers/sopt-recruiting-frontend/assets/81505421/bd56dab5-b9a5-4868-ac0e-044ba6d8e20f



## 🧑‍🎤 Comment

<details>
<summary><strong>🟢 최초 PR comment </strong></summary>
<br/>
Commit 22개짜리 고민 과정을 모두 서술하는 것은 현재 상황상 불필요한 것 같아서, 대표적인 것 몇가지만 작성해놓고 추가적으로 궁금하신 부분 코멘트 달아주시면 답변드릴게요! 

**Q. 합성 컴포넌트 패턴 쓴다더니?** 
쓰다가 포기하고 통합시켰습니다. 지난 번에 제가 합성 컴포넌트 패턴을 쓰기 위해 고민 중이던 부분은 그때 언급되었던 대로 `context API` 를 사용해서 해결할 수 있습니다. 하지만 합성패턴을 사용하면 페이지 컴포넌트에서 입력창 하나를 위해 아래와 같이 작성해주어야 해요. 
```tsx
<TextBox.Container>
  <TextBox.Title>이메일</TextBox.Title>
  <TextBox.Input placeholderText="인증 번호를 작성해주세요" type="email" maxLength={20} pattern=".+@gmail.com" />
  <TextBox.Description buttonText="눌러보세요">더 알아보기</TextBox.Description>
</TextBox.Container>
```
한 페이지에 수많은 Input이 들어갈텐데 그때마다 이렇게 4-6줄에 걸쳐 작성해주면 공통 컴포넌트로 분리한 의미가 퇴색된다고 생각했어요. 
따라서 **사용부에서 최대한 깔끔에 보이도록** props 한덩어리로 처리해주기로 결정했습니다. 

props 정말정말 많은건 알지만... 계속 줄이려고 노력해보고 있지만... 실제로 prop 하나하나 보시면 불필요한 친구가 하나도 없을거예요. descriptionButton을 ReactNode로 받는 것처럼 일부를 사용하는 쪽으로 책임전가시켜서 prop을 줄여보고 있는데, 또 책임을 너무 많이 넘기고 싶지 않아서.. 일단 요게 최선이었습니다 

**Q. useForm 반환값 때문에 Context API 쓴다더니?** 
drilling해줘야 하는 depth가 깊지는 않지만, 매번 TextBox 내부에서 필요한 속성 여러개를 모든 TextBox 컴포넌트마다 똑같이 prop으로 넘겨줘야해서 중복코드가 너무 많이 발생해요. 그래서 모든 TextBox에서 필요한 속성들은 prop으로 넘겨주는게 아니라 하나의 공통 컴포넌트 내부에서 useContext로 불러올 수 있게 구현하고 싶어서 사용하려고 했었어요. 그런데 언석님은 필요 없다고도 말씀하셨고, 해당 페인포인트는 여러개의 속성을 하나의 객체로 묶어서 전달하는 것으로 어느정도 개선할 수 있다고 생각해서 formObject 뭉탱이로 받아서 넘겨주는걸로 타협했습니다 

---

</details>


> 0610 합성 컴포넌트 패턴 적용 후 추가 comment 

### 1. 합성 컴포넌트 패턴 적용 
코드리뷰 반영하여 합성 컴포넌트 패턴을 다시 적용하였습니다. 
Input 공통 컴포넌트의 sub 컴포넌트를 쪼개보면 
- Container
- Label
- InputLine (input태그와 button 포함) 
- Description 

입니다. 
여기서 제가 우려했던 부분을 최대한 개선하고자 Label을 Container로 포함시켜 컴포넌트 수를 최소화했습니다. 
```tsx
  <div className={containerVar[size]}>
    <label className={title} htmlFor={label}>
      <span>{label}</span>
      {required && <i className={circle} />}
    </label>
    {children}
  </div>
```

- type은 각 컴포넌트마다 일일이 interface를 만들고 export / import 해주고 싶지 않아서 **TextBoxProps interface 하나만 만들고 Omit, Pick을 최대한 활용**하여 타입지정 해주었습니다. 
- 언석오빠의 공통 컴포넌트 구현 방식을 참고하여 사용부에게 책임을 조금 더 전가시켰습니다. `descriptionText` + `descriptionButton` props 를 없애고, **Description 서브 컴포넌트 내에 children**으로 알아서 주입시키도록 수정하였습니다. 
- 패턴 적용함에 따라 secondary prop도 없어졌습니다!

### 2. useContext를 활용하여 props 최소화 
최초에 고민했던 대로 합성컴포넌트 패턴 도입과 함께 useContext도 도입했습니다. 
목적은 모든 sub 컴포넌트에서 필요로 하는 useForm 반환값들을 반복적인 props로 넘겨주지 않기 위해서였습니다. 
기존보다 props 자체가 줄어서 useContext로 관리해줄 데이터는 `required`와 `formObject` 객체 뿐입니다. 

Input.tsx 최상단, 컴포넌트 외부에 context를 생성해주고 

```tsx
const ThemeContext = createContext({} as Pick<TextBoxProps, 'required' | 'formObject'>);
```

Container 컴포넌트에서 Context Provider로 감싸주고 
```tsx
  return (
    <FormContext.Provider value={{ required, formObject }}>
      <div className={containerVar[size]}>
        <label className={title} htmlFor={label}>
          <span>{label}</span>
          {required && <i className={circle} />}
        </label>
        {children}
      </div>
    </FormContext.Provider>
  );
```

InputLine 컴포넌트에서는 useContext로 불러와서 사용합니다. 
```tsx
  const {
    required,
    formObject: { register, formState, clearErrors, trigger },
  } = useContext(FormContext);
```
- 원래 `label`도 반복적인 prop이어서 빼주려고 했으나, label은 각 input의 name 역할을 해주기 때문에 폼 이름 (ex-이름, 번호 등)에 의존하는게 아닌, 모든 input에 고유하게 설정해줘야 하는 값이에요. 그래서 각각 넣어줘야 합니다. 

### 3. 유효성 검사 조건 수정
기존에는 register에서 검사 조건으로 required (필수 항목 여부)와 pattern 만 설정해주었는데요, 
검사 조건을 모두 따져보니 아래와 같았습니다. 
> - 필수 입력 항목 → required
> - 비밀번호 일치하지 않음 → 다른 input 값과 비교해야 하므로 validate
> - 이메일 형식 올바르지 않음 → pattern
> - 인증번호 일치하지 않음 → API 결과로 에러를 실행해야 하므로 validate
> - 입력형식이 올바르지 않음(생년월일 등) → pattern

따라서 required, pattern으로 처리 못하는 유효성 검사를 위해 validate도 추가해줬어요.
![image](https://github.com/sopt-makers/sopt-recruiting-frontend/assets/81505421/778aecaa-3663-4b5d-8bf2-38dcb6dfbd87)


또 기존에는 formState에서 제공하는 errorMessage와 사용자가 prop으로 넘기는 errorText를 섞어서 렌더링 해주었는데요, 
register에서 조건마다 errorMsg를 설정해줄 수 있어서 아래와 같이 errorText를 넣어줬습니다. 
```tsx
    pattern:
      pattern && errorText
        ? {
            value: pattern,
            message: errorText,
          }
        : undefined,
```
렌더링부는 아래와 같이 달라집니다 
```tsx
<p>{errors[label]?.message || errorText}</p> // 요랬는데 
<p>{errors[label]?.message}</p> // 요래됐음당
```

**⚠️대신!** 
라이브러리 API 형태상, validate은 required나 pattern과 같은 형태로 errorText를 넘겨줄 수가 없더라고요. 
따라서 validate 함수를 만들어서 prop으로 넘겨줄 땐, errorText를 **기존의 prop을 활용하지 않고** **validate 함수의 조건부 반환값**으로 넣어줘야합니다. 
```tsx
validate={(v) => v === '입력값은 이래야합니다' || '여기에 에러메시지!'} 
```

정리하자면 에러 텍스트는 아래와 같이 넣어주면 돼요. 
- required 조건 : '필수 입력 항목이에요' 로 고정되어있음 (별도 설정X)
- pattern 조건 : errorText prop 사용 
- validate 조건 : 콜백함수의 반환값에 ` || errorText` 추가 

추가로, 논의되었던 **유효성 검사 시점**도 반영하였습니다. 
- useForm의 mode를 onBlur -> onSubmit(default)로 변경하여, 기본적으로는 제출하기 버튼 클릭 시 검사하도록 하고, 
- **pattern prop이 있을 경우** (입력 형태 조건)에만 `trigger` 메소드를 활용하여 유효성 **검사를 수동 실행**시키도록 구현했습니다.
```tsx
  onBlur: (e) => {
    if (!pattern || e.currentTarget.value === '') return;
    trigger(label);
  },
```

---

### +) 
- [x] any 타입 싹 갈기 -> 완료! 
- Timer는 Input 공통 컴포넌트에서 다루지 않고, 그냥 사용부에서 알아서 InputLine children에 구현해서 넣어주는걸로 하면 좋을 것 같아요!~

