### PR TITLE
[Refactor] Button 공통 컴포넌트를 이용하여 Link를 사용할 수 있게 하기

### DIFF
--- a/src/common/components/Button/index.tsx
+++ b/src/common/components/Button/index.tsx
@@ -26,7 +26,7 @@ const Button = ({
   const Tag = isLink ? Link : 'button';
 
   return (
-    <div className={`${className} ${outsideBox[buttonStyle]}`}>
+    <div className={`${className} ${outsideBox[disabled ? 'disabled' : buttonStyle]}`}>
       <Tag
         to={to as To}
         type={type}

--- a/src/common/components/Button/index.tsx
+++ b/src/common/components/Button/index.tsx
@@ -26,11 +26,11 @@ const Button = ({
   const Tag = isLink ? Link : 'button';
 
   return (
-    <div className={`${className} ${outsideBox[disabled ? 'disabled' : buttonStyle]}`}>
+    <div className={`${className} ${outsideBox[buttonStyle]}`}>
       <Tag
         to={to as To}
         type={type}
-        className={`${container[buttonStyle]} ${paddings[padding]} ${className}`}
+        className={`${container[disabled ? 'disabled' : buttonStyle]} ${paddings[padding]} ${className}`}
         {...buttonElementProps}>
         {children}
       </Tag>

--- a/src/common/components/Button/index.tsx
+++ b/src/common/components/Button/index.tsx
@@ -1,8 +1,8 @@
-import { LinkProps, To } from 'react-router-dom';
+import { Link, To } from 'react-router-dom';
 
 import { container, outsideBox, paddings } from './style.css';
 
-import type { ButtonHTMLAttributes, ForwardRefExoticComponent, ReactNode, RefAttributes } from 'react';
+import type { ButtonHTMLAttributes, ReactNode } from 'react';
 
 interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement | HTMLAnchorElement> {
   children?: ReactNode;
@@ -10,7 +10,7 @@ interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement | HTMLAncho
   buttonStyle?: 'solid' | 'line';
   padding?: '15x32' | '13x20' | '10x24' | '15x25';
   to?: To;
-  Tag?: ForwardRefExoticComponent<LinkProps & RefAttributes<HTMLAnchorElement>> | 'button';
+  isLink?: boolean;
 }
 
 const Button = ({
@@ -19,10 +19,11 @@ const Button = ({
   buttonStyle = 'solid',
   padding = '15x32',
   to,
-  Tag = 'button',
+  isLink = false,
   ...buttonElementProps
 }: ButtonProps) => {
   const { disabled, type = 'button' } = buttonElementProps;
+  const Tag = isLink ? Link : 'button';
 
   return (
     <div className={`${className} ${outsideBox[disabled ? 'disabled' : buttonStyle]}`}>

--- a/src/common/components/Button/index.tsx
+++ b/src/common/components/Button/index.tsx
@@ -1,12 +1,16 @@
+import { LinkProps, To } from 'react-router-dom';
+
 import { container, outsideBox, paddings } from './style.css';
 
-import type { ButtonHTMLAttributes, ReactNode } from 'react';
+import type { ButtonHTMLAttributes, ForwardRefExoticComponent, ReactNode, RefAttributes } from 'react';
 
-interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement | HTMLAnchorElement> {
   children?: ReactNode;
   className?: string;
-  padding?: '15x32' | '13x20' | '10x24' | '15x25';
   buttonStyle?: 'solid' | 'line';
+  padding?: '15x32' | '13x20' | '10x24' | '15x25';
+  to?: To;
+  Tag?: ForwardRefExoticComponent<LinkProps & RefAttributes<HTMLAnchorElement>> | 'button';
 }
 
 const Button = ({
@@ -14,18 +18,21 @@ const Button = ({
   className,
   buttonStyle = 'solid',
   padding = '15x32',
+  to,
+  Tag = 'button',
   ...buttonElementProps
 }: ButtonProps) => {
   const { disabled, type = 'button' } = buttonElementProps;
 
   return (
     <div className={`${className} ${outsideBox[disabled ? 'disabled' : buttonStyle]}`}>
-      <button
+      <Tag
+        to={to as To}
         type={type}
         className={`${container[buttonStyle]} ${paddings[padding]} ${className}`}
         {...buttonElementProps}>
         {children}
-      </button>
+      </Tag>
     </div>
   );
 };

--- a/src/common/components/Button/style.css.ts
+++ b/src/common/components/Button/style.css.ts
@@ -22,12 +22,6 @@ export const outsideBox = styleVariants({
       boxShadow: `0 0 0 1px ${theme.color.primary}`,
     },
   ],
-  disabled: [
-    outsideBoxBase,
-    {
-      boxShadow: 'none',
-    },
-  ],
 });
 
 const containerBase = style({
@@ -107,6 +101,16 @@ export const container = styleVariants({
           whiteSpace: 'nowrap',
         },
       },
+    },
+  ],
+  disabled: [
+    containerBase,
+    {
+      backgroundColor: theme.color.buttonDisable,
+      cursor: 'default',
+      boxShadow: 'none',
+      color: theme.color.white,
+      pointerEvents: 'none',
     },
   ],
 });

--- a/src/common/components/Button/style.css.ts
+++ b/src/common/components/Button/style.css.ts
@@ -22,6 +22,12 @@ export const outsideBox = styleVariants({
       boxShadow: `0 0 0 1px ${theme.color.primary}`,
     },
   ],
+  disabled: [
+    outsideBoxBase,
+    {
+      boxShadow: 'none',
+    },
+  ],
 });
 
 const containerBase = style({

--- a/src/views/CompletePage/index.tsx
+++ b/src/views/CompletePage/index.tsx
@@ -1,3 +1,5 @@
+import { Link } from 'react-router-dom';
+
 import Button from '@components/Button';
 import Callout from '@components/Callout';
 
@@ -19,7 +21,9 @@ const CompletePage = () => {
         style={{
           marginBottom: '50px',
         }}>{`이메일 도착 시점에 차이가 있을 수 있습니다.\n이메일이 오지 않으면 스팸 메일함을 확인해주세요.`}</Callout>
-      <Button>마이페이지로 이동하기</Button>
+      <Button Tag={Link} to="/my">
+        마이페이지로 이동하기
+      </Button>
     </section>
   );
 };

--- a/src/views/CompletePage/index.tsx
+++ b/src/views/CompletePage/index.tsx
@@ -21,7 +21,7 @@ const CompletePage = () => {
         style={{
           marginBottom: '50px',
         }}>{`이메일 도착 시점에 차이가 있을 수 있습니다.\n이메일이 오지 않으면 스팸 메일함을 확인해주세요.`}</Callout>
-      <Button Tag={Link} to="/my">
+      <Button isLink to="/my">
         마이페이지로 이동하기
       </Button>
     </section>

--- a/src/views/CompletePage/index.tsx
+++ b/src/views/CompletePage/index.tsx
@@ -1,5 +1,3 @@
-import { Link } from 'react-router-dom';
-
 import Button from '@components/Button';
 import Callout from '@components/Callout';
 


### PR DESCRIPTION
**Related Issue :** Closes #50 

---

## 🧑‍🎤 Summary
Button 공통 컴포넌트를 이용하여 Link를 사용할 수 있게 하기

## 🧑‍🎤 Comment
### 사용법
```tsx
<Button isLink to="/my">버튼</Button>
```

### 구현
```tsx
interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement | HTMLAnchorElement> {
  ...생략
  to?: To;
  isLink?: boolean;
}

const Button = ({
  ...생략
  to,
  isLink = false,
}: ButtonProps) => {
  const Tag = isLink ? Link : 'button';

  return (
    <div className={`...생략`}>
      <Tag to={to as To} ...생략>
        {children}
      </Tag>
    </div>
  );
};
```

prop to가 optional이라 undefined가 올 수 있는데 속성 to에는 undefined가 올 수 없어 To로 형변환 해줬습니다