### PR TITLE
[Fix] body에 background 넣기

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -53,7 +53,7 @@ const App = () => {
     handleChangeMode: (mode: 'light' | 'dark') => {
       setIsLight(mode === 'light' ? true : false);
       const body = document.body;
-      const bodyColor = mode === 'light' ? '#FFFFFF' : '#0F1012';
+      const bodyColor = mode === 'light' ? '#FFFFFF' : '#0F1012'; // theme.color.background
       body.style.backgroundColor = bodyColor;
     },
   };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -52,6 +52,9 @@ const App = () => {
     isLight,
     handleChangeMode: (mode: 'light' | 'dark') => {
       setIsLight(mode === 'light' ? true : false);
+      const body = document.body;
+      const bodyColor = mode === 'light' ? '#FFFFFF' : '#0F1012';
+      body.style.backgroundColor = bodyColor;
     },
   };
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,3 +1,4 @@
+import { colors } from '@sopt-makers/colors';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { useState } from 'react';
@@ -53,7 +54,7 @@ const App = () => {
     handleChangeMode: (mode: 'light' | 'dark') => {
       setIsLight(mode === 'light' ? true : false);
       const body = document.body;
-      const bodyColor = mode === 'light' ? '#FFFFFF' : '#0F1012'; // theme.color.background
+      const bodyColor = mode === 'light' ? colors.white : colors.gray950; // theme.color.background
       body.style.backgroundColor = bodyColor;
     },
   };


### PR DESCRIPTION
**Related Issue :** Closes #51 

---

## 🧑‍🎤 Summary
light/dark mode에 맞춰 body에 background 넣기

## 🧑‍🎤 Comment
### 구현
```tsx
const contextValue = {
  isLight,
  handleChangeMode: (mode: 'light' | 'dark') => {
    setIsLight(mode === 'light' ? true : false);
    const body = document.body;
    const bodyColor = mode === 'light' ? colors.white : colors.gray950; // theme.color.background
    body.style.backgroundColor = bodyColor;
  },
};
```
body는 theme보다 상위 태그라 theme이 적용되지 않아 mds color를 이용하여 직접 구현해줬습니다.