### PR TITLE
[Feat] input validation check

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,6 +17,7 @@ import PasswordPage from 'views/PasswordPage';
 import ResultPage from 'views/ResultPage';
 import ReviewPage from 'views/ReviewPage';
 import SignupPage from 'views/SignupPage';
+import TestPage from 'views/TestPage';
 
 const router = createBrowserRouter([
   {
@@ -37,6 +38,7 @@ const router = createBrowserRouter([
       { path: '/result', element: <ResultPage /> },
       { path: '/review', element: <ReviewPage /> },
       { path: '*', element: <ErrorPage code={404} /> },
+      { path: '/test', element: <TestPage /> },
     ],
   },
 ]);

--- a/src/common/components/Checkbox/index.tsx
+++ b/src/common/components/Checkbox/index.tsx
@@ -1,6 +1,6 @@
-import { FieldErrors, FieldValues, Path, UseFormRegister } from 'react-hook-form';
+import { FieldValues, Path, UseFormReturn } from 'react-hook-form';
 
-import { container, checkboxContainer, checkmark, hiddenCheckbox, requireDot, iconStyle, error } from './style.css';
+import { container, checkboxContainer, checkmark, hiddenCheckbox, requireDot, error } from './style.css';
 
 import type { InputHTMLAttributes } from 'react';
 
@@ -8,18 +8,20 @@ interface CheckboxProps<T extends FieldValues> extends InputHTMLAttributes<HTMLI
   children?: string | number;
   label: Path<T>;
   showIcon?: boolean;
-  register: UseFormRegister<T>;
-  errors?: FieldErrors<FieldValues>;
+  formObject: Pick<UseFormReturn, 'register' | 'formState' | 'clearErrors' | 'trigger' | 'watch'>;
 }
 
 const Checkbox = <T extends FieldValues>({
   children,
   label,
-  register,
-  errors,
+  formObject,
   required = false,
   ...checkboxElementProps
 }: CheckboxProps<T>) => {
+  const {
+    register,
+    formState: { errors },
+  } = formObject;
   return (
     <>
       <div className={container}>

--- a/src/common/components/Input/InputLine/index.tsx
+++ b/src/common/components/Input/InputLine/index.tsx
@@ -12,6 +12,8 @@ const InputLine = ({
   pattern,
   validate,
   errorText,
+  maxLength,
+  minLength,
   children,
   ...inputElementProps
 }: Omit<TextBoxProps, 'size' | 'formObject'>) => {
@@ -29,14 +31,19 @@ const InputLine = ({
           className={inputVar[errors?.[label] ? 'error' : 'default']}
           {...inputElementProps}
           {...register(label, {
-            required: required && '필수 입력 항목이에요',
-            pattern:
-              pattern && errorText
-                ? {
-                    value: pattern,
-                    message: errorText,
-                  }
-                : undefined,
+            required: required && '필수 입력 항목이에요.',
+            pattern: {
+              value: pattern || /.*/,
+              message: errorText || '',
+            },
+            maxLength: {
+              value: maxLength || 9999,
+              message: `최대 ${maxLength}자 까지 입력할 수 있어요.`,
+            },
+            minLength: {
+              value: minLength || 0,
+              message: `최소 ${minLength}자 이상 입력해 주세요.`,
+            },
             validate: validate,
             onBlur: (e) => {
               if (!pattern || e.currentTarget.value === '') return;

--- a/src/common/components/Input/InputLine/index.tsx
+++ b/src/common/components/Input/InputLine/index.tsx
@@ -12,8 +12,6 @@ const InputLine = ({
   pattern,
   validate,
   errorText,
-  maxLength,
-  minLength,
   children,
   ...inputElementProps
 }: Omit<TextBoxProps, 'size' | 'formObject'>) => {
@@ -22,6 +20,7 @@ const InputLine = ({
     formObject: { register, formState, clearErrors, trigger },
   } = useContext(FormContext);
   const { errors } = formState;
+  const { maxLength, minLength } = inputElementProps;
 
   return (
     <>

--- a/src/common/components/Input/InputLine/index.tsx
+++ b/src/common/components/Input/InputLine/index.tsx
@@ -1,7 +1,8 @@
 /* eslint-disable indent */
-import { useContext } from 'react';
+import { ChangeEvent, useContext, useState } from 'react';
 
 import { inputLine, inputVar } from './style.css';
+import { formatPhoneNumber } from './utils/formatPhoneNumber';
 import Description from '../Description';
 import { FormContext } from '../TextBox';
 import { TextBoxProps } from '../types';
@@ -15,6 +16,7 @@ const InputLine = ({
   children,
   ...inputElementProps
 }: Omit<TextBoxProps, 'size' | 'formObject'>) => {
+  const [value, setValue] = useState('');
   const {
     required,
     formObject: { register, formState, clearErrors, trigger },
@@ -22,11 +24,20 @@ const InputLine = ({
   const { errors } = formState;
   const { maxLength, minLength } = inputElementProps;
 
+  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+    if (label === '연락처') {
+      const formattedValue = formatPhoneNumber(e.target.value);
+      setValue(formattedValue);
+    }
+    clearErrors && clearErrors(label);
+  };
+
   return (
     <>
       <div className={inputLine}>
         <input
           id={label}
+          value={label === '연락처' ? value : undefined}
           className={inputVar[errors?.[label] ? 'error' : 'default']}
           {...inputElementProps}
           {...register(label, {
@@ -48,7 +59,7 @@ const InputLine = ({
               if (!pattern || e.currentTarget.value === '') return;
               trigger(label);
             },
-            onChange: () => clearErrors && clearErrors(label),
+            onChange: handleChange,
           })}
         />
         {children}

--- a/src/common/components/Input/InputLine/utils/formatPhoneNumber.ts
+++ b/src/common/components/Input/InputLine/utils/formatPhoneNumber.ts
@@ -1,0 +1,20 @@
+export const formatPhoneNumber = (value: string) => {
+  if (!value) return value;
+  const cleaned = value.replace(/[^\d]/g, ''); // 숫자가 아닌 문자는 모두 제거
+  let formatted = cleaned;
+
+  if (cleaned.length > 3) {
+    formatted = cleaned.slice(0, 3) + '-';
+    if (cleaned.length > 7) {
+      formatted += cleaned.slice(3, 7) + '-';
+      formatted += cleaned.slice(7, 11);
+    } else if (cleaned.length > 6) {
+      formatted += cleaned.slice(3, 6) + '-';
+      formatted += cleaned.slice(6, 10);
+    } else {
+      formatted += cleaned.slice(3);
+    }
+  }
+
+  return formatted;
+};

--- a/src/common/components/Input/InputTheme.tsx
+++ b/src/common/components/Input/InputTheme.tsx
@@ -10,7 +10,14 @@ import { TextBoxProps } from './types';
 export const TextBox이름 = ({ formObject }: Pick<TextBoxProps, 'formObject'>) => {
   return (
     <TextBox label="이름" formObject={formObject} required>
-      <InputLine label="이름" placeholder="지원자 이름을 공백 없이 입력해주세요." />
+      <InputLine
+        label="이름"
+        pattern={/^[가-힣]+$/}
+        errorText="잘못된 이름(한글명) 형식이에요. 이름(한글명)을 정확하게 입력해주세요."
+        placeholder="지원자 이름을 공백 없이 한글로 입력해주세요."
+        maxLength={10}
+        minLength={2}
+      />
     </TextBox>
   );
 };

--- a/src/common/components/Input/InputTheme.tsx
+++ b/src/common/components/Input/InputTheme.tsx
@@ -10,7 +10,7 @@ import { TextBoxProps } from './types';
 export const TextBox이름 = ({ formObject }: Pick<TextBoxProps, 'formObject'>) => {
   return (
     <TextBox label="이름" formObject={formObject} required>
-      <InputLine label="이름" placeholder="지원자 이름을 공백 없이 입력해주세요." required />
+      <InputLine label="이름" placeholder="지원자 이름을 공백 없이 입력해주세요." />
     </TextBox>
   );
 };
@@ -25,7 +25,7 @@ export const TextBox이메일 = ({ formObject }: Pick<TextBoxProps, 'formObject'
 
   return (
     <TextBox label="이메일" formObject={formObject} required>
-      <InputLine label="이메일" placeholder="이메일을 입력해주세요." required type="email">
+      <InputLine label="이메일" placeholder="이메일을 입력해주세요." type="email">
         <InputButton text="이메일 인증" onClick={handleClick이메일인증} disabled={isActive} />
         <Timer
           isActive={isActive}
@@ -34,7 +34,7 @@ export const TextBox이메일 = ({ formObject }: Pick<TextBoxProps, 'formObject'
           }}
         />
       </InputLine>
-      <InputLine label="인증번호" placeholder="이메일 인증 번호를 작성해주세요" required>
+      <InputLine label="인증번호" placeholder="이메일 인증 번호를 작성해주세요">
         <InputButton text="확인" onClick={handleClick확인} disabled />
       </InputLine>
     </TextBox>
@@ -47,13 +47,8 @@ export const TextBox비밀번호 = ({ formObject }: Pick<TextBoxProps, 'formObje
 
   return (
     <TextBox label={textVar} formObject={formObject} required>
-      <InputLine label={textVar} placeholder={`${textVar}를 입력해주세요.`} required type="password" />
-      <InputLine
-        label="비밀번호 재확인"
-        placeholder="비밀번호 확인을 위해 다시 한번 입력해주세요."
-        required
-        type="password"
-      />
+      <InputLine label={textVar} placeholder={`${textVar}를 입력해주세요.`} type="password" />
+      <InputLine label="비밀번호 재확인" placeholder="비밀번호 확인을 위해 다시 한번 입력해주세요." type="password" />
     </TextBox>
   );
 };

--- a/src/common/components/Input/InputTheme.tsx
+++ b/src/common/components/Input/InputTheme.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { useLocation } from 'react-router-dom';
 
 import InputButton from './InputButton';

--- a/src/common/components/Input/InputTheme.tsx
+++ b/src/common/components/Input/InputTheme.tsx
@@ -46,7 +46,12 @@ export const TextBox이메일 = ({ formObject }: Pick<TextBoxProps, 'formObject'
           }}
         />
       </InputLine>
-      <InputLine label="인증번호" placeholder="이메일 인증 번호를 작성해주세요">
+      <InputLine
+        label="인증번호"
+        placeholder="이메일 인증 번호를 작성해주세요"
+        pattern={/^0-9$/}
+        errorText="인증 번호가 일치하지 않아요."
+        maxLength={6}>
         <InputButton text="확인" onClick={handleClick확인} disabled />
       </InputLine>
     </TextBox>

--- a/src/common/components/Input/InputTheme.tsx
+++ b/src/common/components/Input/InputTheme.tsx
@@ -61,6 +61,7 @@ export const TextBox이메일 = ({ formObject }: Pick<TextBoxProps, 'formObject'
 export const TextBox비밀번호 = ({ formObject }: Pick<TextBoxProps, 'formObject'>) => {
   const location = useLocation();
   const textVar = location.pathname === '/password' ? '새 비밀번호' : '비밀번호';
+  const { watch } = formObject;
 
   return (
     <TextBox label={textVar} formObject={formObject} required>
@@ -71,7 +72,17 @@ export const TextBox비밀번호 = ({ formObject }: Pick<TextBoxProps, 'formObje
         pattern={/^[a-zA-Z0-9!@#$%^&*()_+[\]{};':="\\|,.<>/?`~-]{4,}$/}
         errorText="비밀번호는 영문 대소문자/숫자/특수 문자 조합, 4자리 이상으로 구성 해주세요."
       />
-      <InputLine label="비밀번호 재확인" placeholder="비밀번호 확인을 위해 다시 한번 입력해주세요." type="password" />
+      <InputLine
+        label="비밀번호 재확인"
+        placeholder="비밀번호 확인을 위해 다시 한번 입력해주세요."
+        type="password"
+        errorText="비밀번호가 일치하지 않아요."
+        validate={(val) => {
+          if (watch(textVar) != val) {
+            return '비밀번호가 일치하지 않아요.';
+          }
+        }}
+      />
     </TextBox>
   );
 };

--- a/src/common/components/Input/InputTheme.tsx
+++ b/src/common/components/Input/InputTheme.tsx
@@ -64,7 +64,13 @@ export const TextBox비밀번호 = ({ formObject }: Pick<TextBoxProps, 'formObje
 
   return (
     <TextBox label={textVar} formObject={formObject} required>
-      <InputLine label={textVar} placeholder={`${textVar}를 입력해주세요.`} type="password" />
+      <InputLine
+        label={textVar}
+        placeholder={`${textVar}를 입력해주세요.`}
+        type="password"
+        pattern={/^[a-zA-Z0-9!@#$%^&*()_+[\]{};':="\\|,.<>/?`~-]{4,}$/}
+        errorText="비밀번호는 영문 대소문자/숫자/특수 문자 조합, 4자리 이상으로 구성 해주세요."
+      />
       <InputLine label="비밀번호 재확인" placeholder="비밀번호 확인을 위해 다시 한번 입력해주세요." type="password" />
     </TextBox>
   );

--- a/src/common/components/Input/InputTheme.tsx
+++ b/src/common/components/Input/InputTheme.tsx
@@ -32,7 +32,12 @@ export const TextBox이메일 = ({ formObject }: Pick<TextBoxProps, 'formObject'
 
   return (
     <TextBox label="이메일" formObject={formObject} required>
-      <InputLine label="이메일" placeholder="이메일을 입력해주세요." type="email">
+      <InputLine
+        label="이메일"
+        placeholder="이메일을 입력해주세요."
+        type="email"
+        pattern={/^[\w-.]+@([\w-]+\.)+[\w-]{2,4}$/}
+        errorText="이메일 형식이 올바르지 않아요.">
         <InputButton text="이메일 인증" onClick={handleClick이메일인증} disabled={isActive} />
         <Timer
           isActive={isActive}

--- a/src/common/components/Input/types.ts
+++ b/src/common/components/Input/types.ts
@@ -10,7 +10,7 @@ export interface TextBoxProps extends Omit<InputHTMLAttributes<HTMLInputElement>
   errorText?: string;
   pattern?: RegExp;
   validate?: Validate<FieldValues, TFormValues>;
-  formObject: Pick<UseFormReturn, 'register' | 'formState' | 'clearErrors' | 'trigger'>;
+  formObject: Pick<UseFormReturn, 'register' | 'formState' | 'clearErrors' | 'trigger' | 'watch'>;
   children?: ReactNode;
   styleType?: 'default' | 'error';
 }

--- a/src/common/components/Radio/index.tsx
+++ b/src/common/components/Radio/index.tsx
@@ -1,18 +1,21 @@
 import { InputHTMLAttributes } from 'react';
-import { FieldErrors, FieldValues, Path, UseFormRegister } from 'react-hook-form';
+import { FieldValues, Path, UseFormReturn } from 'react-hook-form';
 
 import Container from './Container';
 import ErrorMessage from './ErrorMessage';
 import Option from './Option';
 
 interface RadioProps<T extends FieldValues> extends Omit<InputHTMLAttributes<HTMLInputElement>, 'name'> {
-  register: UseFormRegister<T>;
-  errors: FieldErrors<FieldValues>;
+  formObject: Pick<UseFormReturn, 'register' | 'formState' | 'clearErrors' | 'trigger' | 'watch'>;
   label: string[];
   name: Path<T>;
 }
 
-const Radio = <T extends FieldValues>({ register, errors, label, name, ...rest }: RadioProps<T>) => {
+const Radio = <T extends FieldValues>({ label, name, formObject, ...rest }: RadioProps<T>) => {
+  const {
+    register,
+    formState: { errors },
+  } = formObject;
   return (
     <>
       <Container>

--- a/src/common/components/Textarea/index.tsx
+++ b/src/common/components/Textarea/index.tsx
@@ -1,29 +1,30 @@
 import { TextareaHTMLAttributes, useId } from 'react';
-import { FieldErrors, FieldValues, Path, UseFormRegister, UseFormWatch } from 'react-hook-form';
+import { FieldValues, Path, UseFormReturn } from 'react-hook-form';
 
 import Input from './Input';
 import Label from './Label';
 
 interface TextareaProps<T extends FieldValues> extends TextareaHTMLAttributes<HTMLTextAreaElement> {
   label: Path<T>;
-  watch: UseFormWatch<T>;
-  register: UseFormRegister<T>;
-  errors: FieldErrors<FieldValues>;
+  formObject: Pick<UseFormReturn, 'register' | 'formState' | 'clearErrors' | 'trigger' | 'watch'>;
   maxCount: number;
   children: string | number;
 }
 
 const Textarea = <T extends FieldValues>({
   label,
-  register,
-  watch,
-  errors,
+  formObject,
   maxCount,
   children,
   required = false,
   ...textareaElements
 }: TextareaProps<T>) => {
   const id = useId();
+  const {
+    register,
+    watch,
+    formState: { errors },
+  } = formObject;
 
   return (
     <>

--- a/src/views/TestPage/index.tsx
+++ b/src/views/TestPage/index.tsx
@@ -4,7 +4,7 @@ import { Link } from 'react-router-dom';
 import Button from '@components/Button';
 import Callout from '@components/Callout';
 import { Description, InputLine, TextBox } from '@components/Input';
-import { TextBox비밀번호, TextBox이름, TextBox이메일 } from '@components/Input/InputTheme';
+import { TextBox비밀번호, TextBox이름 } from '@components/Input/InputTheme';
 import Title from '@components/Title';
 import FileInput from 'views/ApplyPage/components/FileInput';
 

--- a/src/views/TestPage/index.tsx
+++ b/src/views/TestPage/index.tsx
@@ -3,8 +3,11 @@ import { Link } from 'react-router-dom';
 
 import Button from '@components/Button';
 import Callout from '@components/Callout';
+import Checkbox from '@components/Checkbox';
 import { Description, InputLine, TextBox } from '@components/Input';
 import { TextBox비밀번호, TextBox이름 } from '@components/Input/InputTheme';
+import Radio from '@components/Radio';
+import Textarea from '@components/Textarea';
 import Title from '@components/Title';
 import FileInput from 'views/ApplyPage/components/FileInput';
 
@@ -66,6 +69,15 @@ const TestPage = () => {
           />
         </TextBox>
         <FileInput />
+        <Checkbox label="체크" formObject={formObject} required>
+          체크하기
+        </Checkbox>
+        <Radio label={['재학', '유예']} name="학교" value="재학" formObject={formObject} required />
+        <Textarea
+          label="텍스트에어리어"
+          formObject={formObject}
+          maxCount={700}
+          required>{`3. 최근 1년 이내로 머릿속으로만 생각하고 있던 계획을 행동으로 옮겨본 경험이 있나요? 만약 있다면 어떤. 계획이. 었으며, 행동을 통해 어떤 성장을 이루어냈는지에 대해 구체적으로 서술해 주세요. 만약 없다면, 해당 계획을 행동으로 옮기기 위한 액션 플랜을 서술해 주세요.`}</Textarea>
         <Button type="submit">제출하기</Button>
       </form>
     </>

--- a/src/views/TestPage/index.tsx
+++ b/src/views/TestPage/index.tsx
@@ -1,0 +1,75 @@
+import { useForm } from 'react-hook-form';
+import { Link } from 'react-router-dom';
+
+import Button from '@components/Button';
+import Callout from '@components/Callout';
+import { Description, InputLine, TextBox } from '@components/Input';
+import { TextBox비밀번호, TextBox이름, TextBox이메일 } from '@components/Input/InputTheme';
+import Title from '@components/Title';
+import FileInput from 'views/ApplyPage/components/FileInput';
+
+const TestPage = () => {
+  const { handleSubmit, ...formObject } = useForm();
+  const onSubmit = (data: unknown) => {
+    console.log(data);
+  };
+
+  return (
+    <>
+      <Title>지원하기</Title>
+      <Callout>새 지원서 작성하기</Callout>
+      <br />
+      <form noValidate onSubmit={handleSubmit(onSubmit)}>
+        <TextBox이름 formObject={formObject} />
+        <TextBox label="이메일2" formObject={formObject} required>
+          <InputLine
+            label="이메일2"
+            placeholder="이메일을 입력해주세요"
+            type="email"
+            pattern={/^[\w-.]+@([\w-]+\.)+[\w-]{2,4}$/}
+            errorText="이메일 형식이 올바르지 않아요."
+          />
+        </TextBox>
+        {/* <TextBox이메일 formObject={formObject} /> */}
+        <TextBox label="비밀번호2" formObject={formObject} required>
+          <InputLine
+            label="비밀번호2"
+            placeholder="비밀번호를 입력해주세요"
+            type="password"
+            pattern={/^[a-zA-Z0-9!@#$%^&*()_+[\]{};':="\\|,.<>/?`~-]{4,}$/}
+            errorText="비밀번호는 영문 대소문자/숫자/특수 문자 조합, 4자리 이상으로 구성 해주세요."
+          />
+          <Description>
+            <p>비밀번호를 잃어버리셨나요?</p>
+            <Link to="/password">비밀번호 재설정하기</Link>
+          </Description>
+        </TextBox>
+        <TextBox비밀번호 formObject={formObject} />
+        <TextBox label="연락처" formObject={formObject} required>
+          <InputLine
+            label="연락처"
+            placeholder="010-0000-0000"
+            type="tel"
+            pattern={/^010-?\d{3,4}-?\d{4}$/}
+            errorText="잘못된 휴대폰 번호 형식이에요. 휴대폰 번호를 정확하게 입력해주세요."
+            maxLength={13}
+          />
+        </TextBox>
+        <TextBox label="생년월일" formObject={formObject} required>
+          <InputLine
+            label="생년월일"
+            placeholder="YYYY/MM/DD"
+            type="date"
+            min="1990-01-01"
+            max={new Date().toISOString().split('T')[0]}
+            errorText="잘못된 휴대폰 번호 형식이에요. 휴대폰 번호를 정확하게 입력해주세요."
+          />
+        </TextBox>
+        <FileInput />
+        <Button type="submit">제출하기</Button>
+      </form>
+    </>
+  );
+};
+
+export default TestPage;

--- a/src/views/TestPage/index.tsx
+++ b/src/views/TestPage/index.tsx
@@ -5,7 +5,7 @@ import Button from '@components/Button';
 import Callout from '@components/Callout';
 import Checkbox from '@components/Checkbox';
 import { Description, InputLine, TextBox } from '@components/Input';
-import { TextBox비밀번호, TextBox이름 } from '@components/Input/InputTheme';
+import { TextBox비밀번호, TextBox이름, TextBox이메일 } from '@components/Input/InputTheme';
 import Radio from '@components/Radio';
 import Textarea from '@components/Textarea';
 import Title from '@components/Title';
@@ -33,7 +33,7 @@ const TestPage = () => {
             errorText="이메일 형식이 올바르지 않아요."
           />
         </TextBox>
-        {/* <TextBox이메일 formObject={formObject} /> */}
+        <TextBox이메일 formObject={formObject} />
         <TextBox label="비밀번호2" formObject={formObject} required>
           <InputLine
             label="비밀번호2"


### PR DESCRIPTION
**Related Issue :** Closes #69 

---

## 🧑‍🎤 Summary
인풋값 validation check 완료
Checkbox, Radio, Textarea 공통 컴포넌트 formObject를 prop으로 받도록 통일
휴대폰 번호 입력시 자동으로 - 추가

## 🧑‍🎤 Screenshot
<img width="508" alt="스크린샷 2024-06-27 오전 1 13 35" src="https://github.com/sopt-makers/sopt-recruiting-frontend/assets/121864459/42aca8c0-7016-43b7-a437-d4790722aca7"><img width="486" alt="스크린샷 2024-06-27 오전 1 13 46" src="https://github.com/sopt-makers/sopt-recruiting-frontend/assets/121864459/ae5c9a68-f51b-4b43-b611-ff87adfb23b1">


## 🧑‍🎤 Comment

유효성 정보는 [여기](https://lying-raptorex-3d4.notion.site/4993a8adf5064f2991d41e7f808a1ca2?pvs=4)에 정리되어있습니다!

### 공통 컴포넌트 구조 통일
기존
```tsx
<Checkbox label="체크" register={register} errors={errors} required>
```

변경 후
```
<Checkbox label="체크" formObject={formObject} required>
```
Input 공통 컴포넌트에서 그러하듯 formObject 전체를 넘겨주는 식으로 통일했습니다
Checkbox, Textarea, Radio 모두 다 통일 시켜줬어요 -> 이에 맞춰 기존 PR에 있던 사용법도 수정했습니다

### 생년월일
생년월일은 type="date"로 기본 datepicker 사용해 주었습니다

### 주의사항
```tsx
<form noValidate onSubmit={handleSubmit(onSubmit)}>
```
form에 `noValidate` 옵션을 줘야 브라우저에 기본 내장된 validation check를 무시할 수 있습니다



(+) TextBox비밀번호 이런 식으로 한글 섞어 쓰니까 import 자동 불러오기가 안되네요ㅜ 거기 컴퓨터에선 잘 되나요?
