### PR TITLE
[Fix] Textarea에서 required 점이 아래로 내려가는 에러 해결

### DIFF
--- a/src/common/components/Textarea/Label/index.tsx
+++ b/src/common/components/Textarea/Label/index.tsx
@@ -14,8 +14,11 @@ const Label = ({ children, maxCount, required, label, ...headerElementProps }: L
     <h4 className={`${labelStyle}`} {...headerElementProps}>
       <label htmlFor={label}>
         <span>{children}</span>
-        <span> ({maxCount}자) </span>
-        {required && <i className={requireDot} />}
+        <span style={{ position: 'relative' }}>
+          {' '}
+          ({maxCount}자)
+          {required && <i className={requireDot} />}
+        </span>
       </label>
     </h4>
   );

--- a/src/common/components/Textarea/Label/style.css.ts
+++ b/src/common/components/Textarea/Label/style.css.ts
@@ -3,7 +3,6 @@ import { style } from '@vanilla-extract/css';
 import { theme } from 'styles/theme.css';
 
 export const labelStyle = style({
-  position: 'relative',
   width: 720,
   marginBottom: 8,
   wordBreak: 'keep-all',
@@ -11,6 +10,9 @@ export const labelStyle = style({
 });
 
 export const requireDot = style({
+  position: 'absolute',
+  bottom: 5,
+  right: -10,
   display: 'inline-block',
   borderRadius: '100%',
   width: 8,


### PR DESCRIPTION
**Related Issue :** Closes  

---

## 🧑‍🎤 Summary
Textarea에서 required 점이 아래로 내려가는 에러 해결

## 🧑‍🎤 Screenshot
![스크린샷 2024-06-27 오후 4 51 27](https://github.com/sopt-makers/sopt-recruiting-frontend/assets/121864459/0c382585-1dfe-4409-b65e-adbd18397228)

## 🧑‍🎤 Comment
점의 위치를 absolute로 해줬고, 최대 텍스트에 relative 줬습니다
질문 전체에 relative 주면 right 값을 주기가 애매해 지거든요
질문 전체는 width가 100%인데 질문이 100% 중 어디서 끝날 지 몰라서요
```
~~질문 끝 (700자) .            <- right: 30px
~~~~~~~~~~~~질문 끝 (500자) .  <- right: 5px
```
이런 식으로 말이죠