### PR TITLE
[Fix] 500에러 페이지 뒤로가기 navigation

### DIFF
--- a/src/views/ErrorPage/index.tsx
+++ b/src/views/ErrorPage/index.tsx
@@ -1,4 +1,4 @@
-import { Link } from 'react-router-dom';
+import { Link, To } from 'react-router-dom';
 
 import ErrorCode from './components/ErrorCode';
 import { ERROR_MESSAGE } from './constants';
@@ -12,7 +12,7 @@ const ErrorPage = ({ code }: { code: 404 | 500 }) => {
       <article className={article}>
         <ErrorCode code={code} />
         <p className={errorText}>{ERROR_MESSAGE[CODE_KEY]?.text}</p>
-        <Link className={errorButton} to={code === 404 ? '/' : '-1'}>
+        <Link className={errorButton} to={code === 404 ? '/' : (-1 as To)}>
           {ERROR_MESSAGE[CODE_KEY]?.button}
         </Link>
       </article>

--- a/src/views/ErrorPage/index.tsx
+++ b/src/views/ErrorPage/index.tsx
@@ -1,10 +1,22 @@
-import { Link, To } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 
 import ErrorCode from './components/ErrorCode';
 import { ERROR_MESSAGE } from './constants';
 import { article, contactButton, container, errorButton, errorText, instruction } from './style.css';
 
 const ErrorPage = ({ code }: { code: 404 | 500 }) => {
+  const navigate = useNavigate();
+
+  const handleGoBack = (code: 404 | 500) => {
+    const hasPreviousPage = window.history.length > 1;
+
+    if (code === 404 || !hasPreviousPage) {
+      navigate('/');
+    } else {
+      navigate(-1);
+    }
+  };
+
   const CODE_KEY: 'CODE404' | 'CODE500' = `CODE${code}`;
 
   return (
@@ -12,9 +24,9 @@ const ErrorPage = ({ code }: { code: 404 | 500 }) => {
       <article className={article}>
         <ErrorCode code={code} />
         <p className={errorText}>{ERROR_MESSAGE[CODE_KEY]?.text}</p>
-        <Link className={errorButton} to={code === 404 ? '/' : (-1 as To)}>
+        <button className={errorButton} onClick={() => handleGoBack(code)}>
           {ERROR_MESSAGE[CODE_KEY]?.button}
-        </Link>
+        </button>
       </article>
       <p className={instruction}>{`문제가 지속적으로 발생하거나 문의사항이 있다면\n아래 ‘문의하기’를 이용해 주세요`}</p>
       <a id="chat-channel-button" href="javascript:chatChannel()" className={contactButton}>


### PR DESCRIPTION
**Related Issue :** Closes #85 

---

## 🧑‍🎤 Summary
- [x] 뒤로가기 안 되는 에러 해결
- [x] 뒤로 갈 페이지 없을 때 처리

## 🧑‍🎤 Comment
첫 진입시 500 에러가 뜨게 되면 -1을 넘겨줬을 때 이에 해당하는 페이지가 없어서
뒤로 갈 수가 없습니다

따라서 이를 구분 해줬어요

```tsx
  const handleGoBack = (code: 404 | 500) => {
    const hasPreviousPage = window.history.length > 1;

    if (code === 404 || !hasPreviousPage) {
      navigate('/');
    } else {
      navigate(-1);
    }
  };

<button className={errorButton} onClick={() => handleGoBack(code)}>
  {ERROR_MESSAGE[CODE_KEY]?.button}
</button>
```