### PR TITLE
[Fix] /sign-up 페이지 오류

### DIFF
--- a/src/common/components/Input/InputButton/index.tsx
+++ b/src/common/components/Input/InputButton/index.tsx
@@ -1,11 +1,12 @@
 import Button from '@components/Button';
 
+import { textWidth } from './style.css';
 import { InputButtonProps } from '../types';
 
 // TextBox 내부 InputLine 우측 버튼
 const InputButton = ({ text, ...props }: InputButtonProps) => {
   return (
-    <Button style={{ width: '148px' }} {...props}>
+    <Button className={textWidth} {...props}>
       {text}
     </Button>
   );

--- a/src/common/components/Input/InputButton/style.css.ts
+++ b/src/common/components/Input/InputButton/style.css.ts
@@ -1,0 +1,5 @@
+import { style } from '@vanilla-extract/css';
+
+export const textWidth = style({
+  width: 148,
+});

--- a/src/views/SignupPage/index.tsx
+++ b/src/views/SignupPage/index.tsx
@@ -23,7 +23,7 @@ const SignupPage = () => {
       <TextBox이메일 formObject={formObject} />
       <TextBox비밀번호 formObject={formObject} />
       <div>
-        <Checkbox required label="check1" register={formObject.register} errors={formObject.formState.errors}>
+        <Checkbox required label="check1" formObject={formObject}>
           개인정보 수집 ‧ 이용에 동의합니다.
         </Checkbox>
         <Contentbox>{PRIVACY_POLICY}</Contentbox>


### PR DESCRIPTION
**Related Issue :** Closes #84 

---

## 🧑‍🎤 Summary
- [x] Checkbox에서 formObject 받는 방식이 변경됨에 따른 페이지 오류 해결
- [x] 확인버튼 width 수정
<img width="269" alt="스크린샷 2024-07-01 오후 4 13 39" src="https://github.com/sopt-makers/sopt-recruiting-frontend/assets/121864459/ae1c4393-ae4e-4272-88df-8017cab2c12e">

## 🧑‍🎤 Comment
```tsx
<Checkbox required label="check1" formObject={formObject}>
```

<img width="441" alt="스크린샷 2024-07-01 오후 4 14 18" src="https://github.com/sopt-makers/sopt-recruiting-frontend/assets/121864459/4bd2d196-58be-4327-8540-066880119102">

수정 완료