### PR TITLE
[Fix] 헤더 스크롤 안 되는 에러 해결

### DIFF
--- a/src/common/components/Layout/Header/style.css.ts
+++ b/src/common/components/Layout/Header/style.css.ts
@@ -7,7 +7,7 @@ export const container = style({
   justifyContent: 'space-between',
   alignItems: 'center',
 
-  position: 'fixed',
+  position: 'sticky',
   top: 0,
   width: 1440,
   margin: '0 auto',

--- a/src/common/components/Layout/style.css.ts
+++ b/src/common/components/Layout/style.css.ts
@@ -7,7 +7,6 @@ export const container = style({
   flexDirection: 'column',
   alignItems: 'center',
   minWidth: 1440,
-  paddingTop: 74,
   backgroundColor: theme.color.background,
 });
 


### PR DESCRIPTION
**Related Issue :** Closes #91 

---

## 🧑‍🎤 Summary
가로 scroll 시 header도 같이 움직이도록 수정

## 🧑‍🎤 Screenshot
### 전
![스크린샷 2024-07-01 오후 4 41 27](https://github.com/sopt-makers/sopt-recruiting-frontend/assets/121864459/88707fbd-07cc-40a2-bcf6-1c1eb48b1e86)

### 후
<img width="831" alt="스크린샷 2024-07-01 오후 4 42 05" src="https://github.com/sopt-makers/sopt-recruiting-frontend/assets/121864459/a337ab53-8df8-45f7-9e48-813eb24f20c8">

## 🧑‍🎤 Comment
header `position: 'sticky'`로 변경해줬습니다