### PR TITLE
[Feat] 제출 확인 dialog에서 checkbox 클릭에 따른 버튼 disabled 상태 변화

### DIFF
--- a/src/common/components/Button/style.css.ts
+++ b/src/common/components/Button/style.css.ts
@@ -44,7 +44,7 @@ const containerBase = style({
   selectors: {
     '&:disabled, &:disabled:hover': {
       backgroundColor: theme.color.buttonDisable,
-      cursor: 'default',
+      cursor: 'not-allowed',
       boxShadow: 'none',
       color: theme.color.white,
     },

--- a/src/common/components/Input/InputLine/style.css.ts
+++ b/src/common/components/Input/InputLine/style.css.ts
@@ -30,6 +30,7 @@ const input = style({
   },
 
   ':disabled': {
+    cursor: 'not-allowed',
     backgroundColor: theme.color.subBackground, // gray30 -> 20으로 수정해야함
     color: theme.color.lighterText,
   },

--- a/src/common/components/Layout/Header/MenuItem/style.css.ts
+++ b/src/common/components/Layout/Header/MenuItem/style.css.ts
@@ -15,6 +15,7 @@ export const menuLink = style({
   selectors: {
     '&:hover:not([disabled])': {
       textDecorationColor: theme.color.primary,
+      cursor: 'not-allowed',
     },
     '&.active': {
       color: theme.color.primary,

--- a/src/common/components/Select/style.css.ts
+++ b/src/common/components/Select/style.css.ts
@@ -62,6 +62,7 @@ export const select = style({
   ':disabled': {
     backgroundColor: theme.color.subBackground, // gray30 -> 20으로 수정해야함
     color: theme.color.lighterText,
+    cursor: 'not-allowed',
   },
 });
 
@@ -91,6 +92,7 @@ export const icon = style({
     },
     [`${select}:disabled+&`]: {
       display: 'none',
+      cursor: 'not-allowed',
     },
   },
 });

--- a/src/common/components/Textarea/Input/style.css.ts
+++ b/src/common/components/Textarea/Input/style.css.ts
@@ -24,6 +24,7 @@ const textareaBase = style({
   ':disabled': {
     color: theme.color.lighterText,
     backgroundColor: theme.color.subBackground,
+    cursor: 'not-allowed',
   },
 
   '::placeholder': {

--- a/src/views/ApplyPage/components/FileInput/style.css.ts
+++ b/src/views/ApplyPage/components/FileInput/style.css.ts
@@ -32,7 +32,7 @@ export const fileLabel = style({
     [`${fileInput}:disabled ~ &`]: {
       color: theme.color.lighterText,
       backgroundColor: theme.color.subBackground,
-      cursor: 'default',
+      cursor: 'not-allowed',
     },
   },
 });
@@ -67,6 +67,7 @@ const fileName = style({
   selectors: {
     [`${fileInput}:disabled ~ label > div > &`]: {
       color: theme.color.lighterText,
+      cursor: 'not-allowed',
     },
   },
 });
@@ -105,7 +106,7 @@ export const fileIcon = style({
 
   ':disabled': {
     backgroundColor: theme.color.buttonDisable,
-    cursor: 'default',
+    cursor: 'not-allowed',
   },
 
   selectors: {
@@ -123,6 +124,7 @@ const fileIconSvg = style({
   selectors: {
     [`${fileIcon}:disabled &`]: {
       backgroundColor: theme.color.buttonDisable,
+      cursor: 'not-allowed',
     },
   },
 });

--- a/src/views/MainPage/index.tsx
+++ b/src/views/MainPage/index.tsx
@@ -1,3 +1,4 @@
+import { useRef } from 'react';
 import { useForm } from 'react-hook-form';
 import { Link } from 'react-router-dom';
 
@@ -5,14 +6,23 @@ import Button from '@components/Button';
 import Callout from '@components/Callout';
 import { Description, InputLine, TextBox } from '@components/Input';
 import Title from '@components/Title';
+import { SubmitDialog } from 'views/dialogs';
 
 import { calloutButton, calloutWrapper, container } from './style.css';
 
 const MainPage = () => {
+  const dialog = useRef<HTMLDialogElement>(null);
+
+  const handleOpenDialog = () => {
+    dialog.current?.showModal();
+  };
+
   const { handleSubmit, ...formObject } = useForm();
 
   return (
     <div className={container}>
+      <button onClick={handleOpenDialog}>CLICK THIS TO SHOW THE DIALOG</button>
+      <SubmitDialog ref={dialog} />
       <Title>지원하기</Title>
       <Callout>
         <div className={calloutWrapper}>

--- a/src/views/dialogs/SubmitDialog/index.tsx
+++ b/src/views/dialogs/SubmitDialog/index.tsx
@@ -1,4 +1,4 @@
-import { forwardRef } from 'react';
+import { type ChangeEvent, forwardRef, useState } from 'react';
 
 import Dialog from '@components/Dialog';
 
@@ -24,7 +24,11 @@ const MyInfoItem = ({ label, value }: { label: string; value: string }) => {
 };
 
 const SubmitDialog = forwardRef<HTMLDialogElement>((_, ref) => {
-  const disabled = true;
+  const [isChecked, setIsChecked] = useState(false);
+
+  const handleCheck = (e: ChangeEvent<HTMLInputElement>) => {
+    setIsChecked(e.target.checked);
+  };
 
   return (
     <Dialog ref={ref}>
@@ -38,7 +42,7 @@ const SubmitDialog = forwardRef<HTMLDialogElement>((_, ref) => {
       </ol>
       <div className={checkboxContainer}>
         <label className={checkboxWrapper}>
-          <input type="checkbox" className={hiddenCheckbox} />
+          <input type="checkbox" className={hiddenCheckbox} onChange={handleCheck} />
           <span className={checkmark} />
           <span>확인했습니다.</span>
         </label>
@@ -47,8 +51,8 @@ const SubmitDialog = forwardRef<HTMLDialogElement>((_, ref) => {
         <form method="dialog" className={buttonOutside.line}>
           <button className={buttonInside.line}>검토하기</button>
         </form>
-        <div className={buttonOutside[disabled ? 'disabled' : 'solid']}>
-          <button className={buttonInside.solid} disabled={disabled}>
+        <div className={buttonOutside[!isChecked ? 'disabled' : 'solid']}>
+          <button className={buttonInside.solid} disabled={!isChecked}>
             제출하기
           </button>
         </div>

--- a/src/views/dialogs/style.css.ts
+++ b/src/views/dialogs/style.css.ts
@@ -71,7 +71,7 @@ const buttonInsideBase = style({
   selectors: {
     '&:disabled, &:disabled:hover': {
       backgroundColor: colors.gray50,
-      cursor: 'default',
+      cursor: 'not-allowed',
       boxShadow: 'none',
       color: colors.white,
     },


### PR DESCRIPTION
**Related Issue :** Closes #95 

---

## 🧑‍🎤 Summary
- [x] 제출 확인 dialog 버튼 로직 구현
- [x] 버튼 disabled 시 마우스 cursor not-allowed로 변경

## 🧑‍🎤 Screenshot
<img width="565" alt="스크린샷 2024-07-01 오후 8 35 25" src="https://github.com/sopt-makers/sopt-recruiting-frontend/assets/121864459/36404f02-1622-4d3c-b50d-8cbfae119ed9">
<img width="377" alt="스크린샷 2024-07-01 오후 8 35 47" src="https://github.com/sopt-makers/sopt-recruiting-frontend/assets/121864459/3716912b-b6f9-4e78-b0a9-98bb7da18ba4">


## 🧑‍🎤 Comment
### 마우스 커서 변경
<img width="309" alt="스크린샷 2024-07-01 오후 8 36 21" src="https://github.com/sopt-makers/sopt-recruiting-frontend/assets/121864459/3b75a053-2f12-4a01-aa09-480ac4e833de">

disabled 되었을 때 위의 예시처럼 not-allowed 되도록 수정했습니다

### 더미 코드
보기 편하시라고 / mainPage에 더미 코드 추가해놨고, 확인 후 지운 뒤 pr merge 하겠습니다
