### PR TITLE
[Feat] 페이지 이탈 시 dialog 표시

### DIFF
--- a/src/views/ApplyPage/index.tsx
+++ b/src/views/ApplyPage/index.tsx
@@ -29,6 +29,11 @@ const ApplyPage = () => {
 
   useScrollToHash(); // scrollTo 카테고리
 
+  window.addEventListener('beforeunload', (e) => {
+    e.preventDefault();
+    e.returnValue = true; // Included for legacy support, e.g. Chrome/Edge < 119
+  });
+
   return (
     <form onSubmit={handleSubmit(onSubmit)} className={formContainer}>
       <ApplyHeader />


### PR DESCRIPTION
**Related Issue :** Closes #119 

---

## 🧑‍🎤 Summary
- [x] 페이지 이탈 시 dialog 대신 브라우저 기본 warning popup 표시
- [x] 해당 변경 부분 PM 이정이와 의견 공유 완료
- [x] 뒤로가기/앞으로가기, 새로고침, 페이지 닫기 테스트 완료

## 🧑‍🎤 Screenshot
Firefox
![스크린샷 2024-07-09 오전 3 01 02](https://github.com/sopt-makers/sopt-recruiting-frontend/assets/121864459/0193655d-81cd-473c-a170-68dd48931993)

Chrome
<img width="273" alt="스크린샷 2024-07-09 오전 3 01 11" src="https://github.com/sopt-makers/sopt-recruiting-frontend/assets/121864459/519ba621-fc88-4496-a93b-8f25ffb97342">

Safari
![스크린샷 2024-07-09 오전 3 01 42](https://github.com/sopt-makers/sopt-recruiting-frontend/assets/121864459/f5369b8f-2d10-4990-83aa-4db042c0238e)

Arc
<img width="265" alt="스크린샷 2024-07-09 오전 3 02 12" src="https://github.com/sopt-makers/sopt-recruiting-frontend/assets/121864459/cdc0c617-9056-459d-ac2e-3292900b84ee">

## 🧑‍🎤 Comment
좀 아쉽습니다ㅜㅜ

기본 경고창 대신 dialog 띄우고 싶었는데
아무리 찾아도 해당 방법을 찾을 수가 없었어요
library 뒤져봐도 찾을 수 없었습니다ㅜ

오히려 그게 불가능하다는 얘기는 많이 볼 수가 있었네여,,

다른 사이트들은 어떻게 되나 참고해봐도 대부분 기본 경고창 띄워주더라고요
(예, code sandbox, postman)

url 변경을 통한 페이지 이동은 잡아내도 GNB 등의 링크 버튼을 이용한 페이지 이동은 또 못 잡더라고요?
근데 이거 잡으려면 `useBlocker`나 `unstable_usePrompt` 써야 하는데 얘네는 또 warning popup이 아닌 prompt가 뜨더라고요
<img width="478" alt="스크린샷 2024-07-09 오전 3 11 42" src="https://github.com/sopt-makers/sopt-recruiting-frontend/assets/121864459/29fb396a-8b5c-4246-8f6c-00b69a0c4f29">

근데 가만 생각해보니 `/apply` 페이지에는 다른 페이지로 이동시킬 수 있는 링크 버튼이 없어서 이에 대한 고려는 안 해줘도 되었습니다
