### PR TITLE
[Feat] GNB에 유저 이름 띄우기

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import { RouterProvider, createBrowserRouter } from 'react-router-dom';
 
 import Layout from '@components/Layout';
 import { ThemeContext } from '@store/themeContext';
+import { UserInfoContext, UserInfoType } from '@store/userInfoContext';
 import { dark, light } from 'styles/theme.css';
 import 'styles/reset.css';
 import ApplyPage from 'views/ApplyPage';
@@ -45,6 +46,7 @@ const router = createBrowserRouter([
 
 const App = () => {
   const [isLight, setIsLight] = useState(true);
+  const [userInfo, setUserInfo] = useState<UserInfoType>({});
   const queryClient = new QueryClient({
     defaultOptions: {
       queries: {
@@ -57,7 +59,7 @@ const App = () => {
     },
   });
 
-  const contextValue = {
+  const themeContextValue = {
     isLight,
     handleChangeMode: (mode: 'light' | 'dark') => {
       setIsLight(mode === 'light' ? true : false);
@@ -67,14 +69,23 @@ const App = () => {
     },
   };
 
+  const userInfoContextValue = {
+    userInfo,
+    handleSaveUserInfo: (obj: object) => {
+      setUserInfo(obj);
+    },
+  };
+
   return (
-    <ThemeContext.Provider value={contextValue}>
-      <QueryClientProvider client={queryClient}>
-        <ReactQueryDevtools />
-        <div className={isLight ? light : dark}>
-          <RouterProvider router={router} />
-        </div>
-      </QueryClientProvider>
+    <ThemeContext.Provider value={themeContextValue}>
+      <UserInfoContext.Provider value={userInfoContextValue}>
+        <QueryClientProvider client={queryClient}>
+          <ReactQueryDevtools />
+          <div className={isLight ? light : dark}>
+            <RouterProvider router={router} />
+          </div>
+        </QueryClientProvider>
+      </UserInfoContext.Provider>
     </ThemeContext.Provider>
   );
 };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,7 +5,7 @@ import { useState } from 'react';
 import { RouterProvider, createBrowserRouter } from 'react-router-dom';
 
 import Layout from '@components/Layout';
-import { ThemeContext } from '@store/themeContext';
+import { ModeType, ThemeContext } from '@store/themeContext';
 import { UserInfoContext, UserInfoType } from '@store/userInfoContext';
 import { dark, light } from 'styles/theme.css';
 import 'styles/reset.css';
@@ -61,7 +61,7 @@ const App = () => {
 
   const themeContextValue = {
     isLight,
-    handleChangeMode: (mode: 'light' | 'dark') => {
+    handleChangeMode: (mode: ModeType) => {
       setIsLight(mode === 'light' ? true : false);
       const body = document.body;
       const bodyColor = mode === 'light' ? colors.white : colors.gray950; // theme.color.background
@@ -71,7 +71,7 @@ const App = () => {
 
   const userInfoContextValue = {
     userInfo,
-    handleSaveUserInfo: (obj: object) => {
+    handleSaveUserInfo: (obj: UserInfoType) => {
       setUserInfo(obj);
     },
   };

--- a/src/common/components/Layout/Header/contants.ts
+++ b/src/common/components/Layout/Header/contants.ts
@@ -15,11 +15,4 @@ export const MENU_ITEMS: menuItemsTypes[] = [
     path: 'https://pf.kakao.com/_JdTKd',
     target: '_blank',
   },
-  {
-    text: '로그인',
-    path: '/',
-  },
-  {
-    text: '김솝트님',
-  },
 ];

--- a/src/common/components/Layout/Header/index.tsx
+++ b/src/common/components/Layout/Header/index.tsx
@@ -1,10 +1,18 @@
+import { useContext } from 'react';
+
 import NowsoptLogo from '@assets/NowsoptLogo';
+import { UserInfoContext, UserInfoContextType } from '@store/userInfoContext';
 
 import { MENU_ITEMS } from './contants';
 import MenuItem from './MenuItem';
 import { container, menuList } from './style.css';
 
 const Header = () => {
+  const isSignedIn = localStorage.getItem('soptApplyAccessToken');
+  const {
+    userInfo: { name },
+  }: UserInfoContextType = useContext(UserInfoContext);
+
   return (
     <header className={container}>
       <NowsoptLogo />
@@ -13,6 +21,11 @@ const Header = () => {
           {MENU_ITEMS.map(({ text, path, target }) => (
             <MenuItem key={text} text={text} path={path} target={target} />
           ))}
+          {isSignedIn ? (
+            <MenuItem key="로그인완료" text={`${name}님`} />
+          ) : (
+            <MenuItem key="로그인" text="로그인" path="/" />
+          )}
         </ul>
       </nav>
     </header>

--- a/src/common/store/themeContext.ts
+++ b/src/common/store/themeContext.ts
@@ -1,6 +1,13 @@
 import { createContext } from 'react';
 
-export const ThemeContext = createContext({
+export type ModeType = 'light' | 'dark';
+
+export interface ThemeContextType {
+  isLight: boolean;
+  handleChangeMode: (mode: ModeType) => void;
+}
+
+export const ThemeContext = createContext<ThemeContextType>({
   isLight: true,
-  handleChangeMode: (mode: 'light' | 'dark') => {},
+  handleChangeMode: () => {},
 });

--- a/src/common/store/userInfoContext.ts
+++ b/src/common/store/userInfoContext.ts
@@ -1,0 +1,13 @@
+import { createContext } from 'react';
+
+export type UserInfoType = { name?: string; phone?: string; email?: string; season?: number; group?: string };
+
+export interface UserInfoContextType {
+  userInfo: UserInfoType;
+  handleSaveUserInfo: (obj: UserInfoType) => void;
+}
+
+export const UserInfoContext = createContext<UserInfoContextType>({
+  userInfo: {},
+  handleSaveUserInfo: () => {},
+});

--- a/src/views/ApplyPage/components/ApplyHeader/index.tsx
+++ b/src/views/ApplyPage/components/ApplyHeader/index.tsx
@@ -1,12 +1,21 @@
+import { useContext } from 'react';
+
 import Button from '@components/Button';
 import Title from '@components/Title';
+import { UserInfoContext, UserInfoContextType } from '@store/userInfoContext';
 
 import { buttonWrapper, headerContainer } from './style.css';
 
 const ApplyHeader = ({ isLoading, onSaveDraft }: { isLoading: boolean; onSaveDraft: () => void }) => {
+  const {
+    userInfo: { season, group },
+  }: UserInfoContextType = useContext(UserInfoContext);
+
   return (
     <header className={headerContainer}>
-      <Title>35기 YB 지원서</Title>
+      <Title>
+        {season}기 {group} 지원서
+      </Title>
       <div className={buttonWrapper}>
         <Button isLoading={isLoading} onClick={onSaveDraft} buttonStyle="line" padding="10x24">
           임시저장

--- a/src/views/ApplyPage/index.tsx
+++ b/src/views/ApplyPage/index.tsx
@@ -1,10 +1,11 @@
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { AxiosError, AxiosResponse } from 'axios';
-import { useCallback, useRef, useState } from 'react';
+import { useCallback, useContext, useEffect, useRef, useState } from 'react';
 import { useForm, SubmitHandler } from 'react-hook-form';
 
 import Button from '@components/Button';
 import { TFormValues } from '@constants/defaultValues';
+import { UserInfoContext } from '@store/userInfoContext';
 import { DraftDialog } from 'views/dialogs';
 import BigLoading from 'views/loadings/BigLoding';
 
@@ -54,6 +55,17 @@ const ApplyPage = () => {
   });
 
   const { handleSubmit, ...formObject } = useForm();
+  const { handleSaveUserInfo } = useContext(UserInfoContext);
+
+  useEffect(() => {
+    handleSaveUserInfo({
+      name: data?.data.applicant.name,
+      phone: data?.data.applicant.phone,
+      email: data?.data.applicant.email,
+      season: data?.data.applicant.season,
+      group: data?.data.applicant.group,
+    });
+  }, [data, handleSaveUserInfo]);
 
   if (isLoading) return <BigLoading />;
 


### PR DESCRIPTION
**Related Issue :** Closes #112 

---

## 🧑‍🎤 Summary
- [x] 로그인 성공 시 유저 정보 context에서 관리
- [x] GNB 유저 이름 동적으로 렌더링
- [x] /apply 페이지 기수와 yb/ob 동적으로 렌더링

## 🧑‍🎤 Screenshot
![스크린샷 2024-07-10 오전 1 53 17](https://github.com/sopt-makers/sopt-recruiting-frontend/assets/121864459/e6345d74-024b-49d3-8efd-0222a15a1664)

## 🧑‍🎤 Comment
원래는 /apply 페이지 진입 시 유저 정보를 받을 수 있는
새로운 api 요청을 요구하려 했지만

로그인을 성공하면 임시저장 data를 받아오는데
여기에는 무조건 이름, 연락처, 이메일, 기수, 그룹(yb/ob)에 대한 정보가 있어서
이를 이용해주기로 결정했어요

data가 들어오면 context에 연결된 setState 함수를 이용해 user info를 업데이트 해주고
이를 헤더와 /apply 페이지 타이틀에 뿌려주었습니다~
