### PR TITLE
[Feat] api 에러 처리

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,7 +3,7 @@ import { MutationCache, QueryCache, QueryClient, QueryClientProvider } from '@ta
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { AxiosError } from 'axios';
 import { useCallback, useRef, useState } from 'react';
-import { RouterProvider, createBrowserRouter, useNavigate } from 'react-router-dom';
+import { RouterProvider, createBrowserRouter } from 'react-router-dom';
 
 import Layout from '@components/Layout';
 import { ModeType, ThemeContext } from '@store/themeContext';
@@ -49,8 +49,6 @@ const App = () => {
   const [isLight, setIsLight] = useState(true);
   const [userInfo, setUserInfo] = useState<UserInfoType>({});
 
-  const navigate = useNavigate();
-
   const queryClient = new QueryClient({
     defaultOptions: {
       queries: {
@@ -68,7 +66,7 @@ const App = () => {
         if (axiosError.response?.status === 401) {
           sessionRef.current?.showModal();
         } else if (axiosError.response?.status === 500) {
-          navigate('/error');
+          window.location.href = '/error';
         }
       },
     }),
@@ -79,7 +77,7 @@ const App = () => {
         if (axiosError.response?.status === 401) {
           sessionRef.current?.showModal();
         } else if (axiosError.response?.status === 500) {
-          navigate('/error');
+          window.location.href = '/error';
         }
       },
     }),

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,7 +3,7 @@ import { MutationCache, QueryCache, QueryClient, QueryClientProvider } from '@ta
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { AxiosError } from 'axios';
 import { useCallback, useRef, useState } from 'react';
-import { RouterProvider, createBrowserRouter } from 'react-router-dom';
+import { RouterProvider, createBrowserRouter, useNavigate } from 'react-router-dom';
 
 import Layout from '@components/Layout';
 import { ModeType, ThemeContext } from '@store/themeContext';
@@ -37,6 +37,7 @@ const router = createBrowserRouter([
       { path: '/my', element: <MyPage /> },
       { path: '/result', element: <ResultPage /> },
       { path: '/review', element: <ReviewPage /> },
+      { path: '/error', element: <ErrorPage code={500} /> },
       { path: '*', element: <ErrorPage code={404} /> },
     ],
   },
@@ -47,6 +48,9 @@ const App = () => {
 
   const [isLight, setIsLight] = useState(true);
   const [userInfo, setUserInfo] = useState<UserInfoType>({});
+
+  const navigate = useNavigate();
+
   const queryClient = new QueryClient({
     defaultOptions: {
       queries: {
@@ -59,15 +63,23 @@ const App = () => {
     },
     queryCache: new QueryCache({
       onError: (error) => {
-        if ((error as AxiosError).response?.status === 401) {
+        const axiosError = error as AxiosError;
+
+        if (axiosError.response?.status === 401) {
           sessionRef.current?.showModal();
+        } else if (axiosError.response?.status === 500) {
+          navigate('/error');
         }
       },
     }),
     mutationCache: new MutationCache({
       onError: (error) => {
-        if ((error as AxiosError).response?.status === 401) {
+        const axiosError = error as AxiosError;
+
+        if (axiosError.response?.status === 401) {
           sessionRef.current?.showModal();
+        } else if (axiosError.response?.status === 500) {
+          navigate('/error');
         }
       },
     }),

--- a/src/views/dialogs/SessionExpiredDialog/index.tsx
+++ b/src/views/dialogs/SessionExpiredDialog/index.tsx
@@ -1,0 +1,31 @@
+import { forwardRef } from 'react';
+
+import Dialog from '@components/Dialog';
+
+import { buttonInside, buttonOutside, buttonWrapper, mainText } from '../style.css';
+
+const SessionExpiredDialog = forwardRef<HTMLDialogElement>((_, ref) => {
+  const handleLogout = () => {
+    localStorage.removeItem('soptApplyAccessToken');
+    if (window.location.pathname === '/') {
+      location.reload();
+    } else {
+      window.location.href = '/';
+    }
+  };
+
+  return (
+    <Dialog ref={ref}>
+      <p className={mainText}>로그인 세션이 만료되었어요.</p>
+      <form method="dialog" className={`${buttonWrapper} ${buttonOutside.solid}`}>
+        <button className={buttonInside.solid} onClick={handleLogout}>
+          다시 로그인 하기
+        </button>
+      </form>
+    </Dialog>
+  );
+});
+
+SessionExpiredDialog.displayName = 'SessionExpiredDialog';
+
+export default SessionExpiredDialog;


### PR DESCRIPTION
**Related Issue :** Closes #125 

---

## 🧑‍🎤 Summary
- [x] 세션 만료 시 모달창 띄우기
- [x] 500 에러 발생 시 500 페이지로 이동시키기

## 🧑‍🎤 Screenshot
![스크린샷 2024-07-15 오후 2 58 08](https://github.com/user-attachments/assets/af64c40f-6825-49ff-ae4c-298cd34bb4e7)


## 🧑‍🎤 Comment
### 글로벌 설정
queryClient의 글로벌 설정을 이용하여 에러 핸들링 해줬어요
Router 밖에 위치하고 있어 useNavigate를 사용할 수 없어서
window 객체를 이용해줬습니다~

```tsx
queryCache: new QueryCache({
  onError: (error) => {
    const axiosError = error as AxiosError;

    if (axiosError.response?.status === 401) {
      sessionRef.current?.showModal();
    } else if (axiosError.response?.status === 500) {
      window.location.href = '/error';
    }
  },
}),
mutationCache: new MutationCache({
  onError: (error) => {
    const axiosError = error as AxiosError;

    if (axiosError.response?.status === 401) {
      sessionRef.current?.showModal();
    } else if (axiosError.response?.status === 500) {
      window.location.href = '/error';
    }
  },
}),
```
