### PR TITLE
Feat/#152 after submita[Feat] 제출 완료 후 flow 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,8 +9,6 @@ import Layout from '@components/Layout';
 import { RecruitingInfoContext, RecruitingInfoType } from '@store/recruitingInfoContext';
 import { ModeType, ThemeContext } from '@store/themeContext';
 import { dark, light } from 'styles/theme.css';
-import 'styles/reset.css';
-import CompletePage from 'views/CompletePage';
 import SessionExpiredDialog from 'views/dialogs/SessionExpiredDialog';
 import ErrorPage from 'views/ErrorPage';
 import MainPage from 'views/MainPage';
@@ -19,6 +17,8 @@ import PasswordPage from 'views/PasswordPage';
 import ResultPage from 'views/ResultPage';
 import ReviewPage from 'views/ReviewPage';
 import SignupPage from 'views/SignupPage';
+
+import 'styles/reset.css';
 
 const router = createBrowserRouter([
   {
@@ -33,7 +33,6 @@ const router = createBrowserRouter([
       { index: true, element: <MainPage /> },
       { path: '/sign-up', element: <SignupPage /> },
       { path: '/password', element: <PasswordPage /> },
-      { path: '/complete', element: <CompletePage /> },
       { path: '/my', element: <MyPage /> },
       { path: '/result', element: <ResultPage /> },
       { path: '/review', element: <ReviewPage /> },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,10 +12,8 @@ import { dark, light } from 'styles/theme.css';
 import SessionExpiredDialog from 'views/dialogs/SessionExpiredDialog';
 import ErrorPage from 'views/ErrorPage';
 import MainPage from 'views/MainPage';
-import MyPage from 'views/MyPage';
 import PasswordPage from 'views/PasswordPage';
 import ResultPage from 'views/ResultPage';
-import ReviewPage from 'views/ReviewPage';
 import SignupPage from 'views/SignupPage';
 
 import 'styles/reset.css';
@@ -33,9 +31,7 @@ const router = createBrowserRouter([
       { index: true, element: <MainPage /> },
       { path: '/sign-up', element: <SignupPage /> },
       { path: '/password', element: <PasswordPage /> },
-      { path: '/my', element: <MyPage /> },
       { path: '/result', element: <ResultPage /> },
-      { path: '/review', element: <ReviewPage /> },
       { path: '/error', element: <ErrorPage code={500} /> },
       { path: '*', element: <ErrorPage code={404} /> },
     ],

--- a/src/views/ApplyPage/apis.ts
+++ b/src/views/ApplyPage/apis.ts
@@ -13,12 +13,6 @@ export const getQuestions = async ({ season, group }: { season?: number; group?:
   return res;
 };
 
-export const getDraft = async () => {
-  const res = await tokenInstance.get('/recruiting-answer/store');
-
-  return res;
-};
-
 export const sendData = async (api: string, formValues: ApplyRequest) => {
   const res = await tokenInstance.post(api, formValues, {
     headers: {

--- a/src/views/ApplyPage/components/ApplyHeader/index.tsx
+++ b/src/views/ApplyPage/components/ApplyHeader/index.tsx
@@ -6,7 +6,13 @@ import { RecruitingInfoContext } from '@store/recruitingInfoContext';
 
 import { buttonWrapper, headerContainer } from './style.css';
 
-const ApplyHeader = ({ isLoading, onSaveDraft }: { isLoading: boolean; onSaveDraft: () => void }) => {
+interface ApplyHeaderProps {
+  isReview: boolean;
+  isLoading: boolean;
+  onSaveDraft: () => void;
+}
+
+const ApplyHeader = ({ isReview, isLoading, onSaveDraft }: ApplyHeaderProps) => {
   const {
     recruitingInfo: { season, group },
   } = useContext(RecruitingInfoContext);
@@ -16,14 +22,16 @@ const ApplyHeader = ({ isLoading, onSaveDraft }: { isLoading: boolean; onSaveDra
       <Title>
         {season}기 {group} 지원서
       </Title>
-      <div className={buttonWrapper}>
-        <Button isLoading={isLoading} onClick={onSaveDraft} buttonStyle="line" padding="10x24">
-          임시저장
-        </Button>
-        <Button isLoading={isLoading} padding="10x24" type="submit">
-          제출하기
-        </Button>
-      </div>
+      {!isReview && (
+        <div className={buttonWrapper}>
+          <Button isLoading={isLoading} onClick={onSaveDraft} buttonStyle="line" padding="10x24">
+            임시저장
+          </Button>
+          <Button isLoading={isLoading} padding="10x24" type="submit">
+            제출하기
+          </Button>
+        </div>
+      )}
     </header>
   );
 };

--- a/src/views/ApplyPage/components/ApplyInfo/index.tsx
+++ b/src/views/ApplyPage/components/ApplyInfo/index.tsx
@@ -15,7 +15,7 @@ import {
 } from './style.css';
 import { APPLY_INFO } from '../../constant';
 
-const ApplyInfo = () => {
+const ApplyInfo = ({ isReview }: { isReview: boolean }) => {
   const {
     recruitingInfo: {
       applicationStart,
@@ -29,39 +29,47 @@ const ApplyInfo = () => {
 
   return (
     <section className={infoContainer}>
-      <ul className={infoWrapper}>
-        {APPLY_INFO.sections.map(({ id, content }) => (
-          <li key={id}>
-            &#183;{' '}
-            {content.map(({ text, weight }) => (
-              <span key={text} className={weight === 'normal' ? infoItems : infoItemsBold}>
-                {text}
-              </span>
-            ))}
-          </li>
-        ))}
-      </ul>
-      <Callout size="lg">{`마감 시간 이후에는 지원 제출을 받지 않습니다.
+      {!isReview && (
+        <ul className={infoWrapper}>
+          {APPLY_INFO.sections.map(({ id, content }) => (
+            <li key={id}>
+              &#183;{' '}
+              {content.map(({ text, weight }) => (
+                <span key={text} className={weight === 'normal' ? infoItems : infoItemsBold}>
+                  {text}
+                </span>
+              ))}
+            </li>
+          ))}
+        </ul>
+      )}
+      <Callout size="lg">
+        {!isReview
+          ? `마감 시간 이후에는 지원 제출을 받지 않습니다.
       제출하신 서류와 포트폴리오는 반환하지 않습니다.
-      서버 오류를 대비해 지원서를 백업해 두시길 바랍니다.`}</Callout>
-      <ol className={dateWrapper}>
-        <li className={dateItems}>
-          <span className={dateLabel}>지원 기간</span>
-          <span className={dateText}>{`${applicationStart} - ${applicationEnd}`}</span>
-        </li>
-        <li className={dateItems}>
-          <span className={dateLabel}>서류 발표</span>
-          <span className={dateText}>{applicationPassConfirmStart}</span>
-        </li>
-        <li className={dateItems}>
-          <span className={dateLabel}>면접 평가</span>
-          <span className={dateText}>{`${interviewStart} - ${interviewEnd} (오프라인 면접)`}</span>
-        </li>
-        <li className={dateItems}>
-          <span className={dateLabel}>최종 발표</span>
-          <span className={dateText}>{finalPassConfirmStart}</span>
-        </li>
-      </ol>
+      서버 오류를 대비해 지원서를 백업해 두시길 바랍니다.`
+          : '지원서 제출 이후 어떠한 경우에도 수정은 불가합니다.'}
+      </Callout>
+      {!isReview && (
+        <ol className={dateWrapper}>
+          <li className={dateItems}>
+            <span className={dateLabel}>지원 기간</span>
+            <span className={dateText}>{`${applicationStart} - ${applicationEnd}`}</span>
+          </li>
+          <li className={dateItems}>
+            <span className={dateLabel}>서류 발표</span>
+            <span className={dateText}>{applicationPassConfirmStart}</span>
+          </li>
+          <li className={dateItems}>
+            <span className={dateLabel}>면접 평가</span>
+            <span className={dateText}>{`${interviewStart} - ${interviewEnd} (오프라인 면접)`}</span>
+          </li>
+          <li className={dateItems}>
+            <span className={dateLabel}>최종 발표</span>
+            <span className={dateText}>{finalPassConfirmStart}</span>
+          </li>
+        </ol>
+      )}
     </section>
   );
 };

--- a/src/views/ApplyPage/components/BottomSection/index.tsx
+++ b/src/views/ApplyPage/components/BottomSection/index.tsx
@@ -8,13 +8,13 @@ import { SELECT_OPTIONS } from 'views/ApplyPage/constant';
 
 import { doubleLineCheck, label, line, sectionContainer } from './style.css';
 
-const BottomSection = ({
-  knownPath,
-  formObject,
-}: {
+interface BottomSectionProps {
+  isReview: boolean;
   knownPath?: string;
   formObject: Pick<UseFormReturn, 'register' | 'formState' | 'clearErrors' | 'trigger' | 'setValue' | 'watch'>;
-}) => {
+}
+
+const BottomSection = ({ isReview, knownPath, formObject }: BottomSectionProps) => {
   return (
     <section className={sectionContainer}>
       <hr className={line} />
@@ -26,15 +26,16 @@ const BottomSection = ({
         options={SELECT_OPTIONS.경로}
         formObject={formObject}
         required
+        disabled={isReview}
       />
       <div id="check-necessary" className={doubleLineCheck}>
         <p className={label}>SOPT의 행사 및 세미나는 매주 토요일에 진행됩니다.</p>
-        <Checkbox name="attendance" formObject={formObject} required>
+        <Checkbox checked={isReview} name="attendance" formObject={formObject} required>
           참석 가능합니다.
         </Checkbox>
       </div>
       <div>
-        <Checkbox required name="personalInformation" formObject={formObject}>
+        <Checkbox checked={isReview} required name="personalInformation" formObject={formObject}>
           개인정보 수집 ‧ 이용에 동의합니다.
         </Checkbox>
         <Contentbox>{PRIVACY_POLICY}</Contentbox>

--- a/src/views/ApplyPage/components/CommonSection/index.tsx
+++ b/src/views/ApplyPage/components/CommonSection/index.tsx
@@ -5,17 +5,15 @@ import { Answers, Questions } from 'views/ApplyPage/types';
 
 import { sectionContainer, title } from './style.css';
 
-const CommonSection = ({
-  refCallback,
-  questions,
-  commonQuestionsDraft,
-  formObject,
-}: {
+interface CommonSectionProps {
+  isReview: boolean;
   refCallback: (elem: HTMLSelectElement) => void;
   questions?: Questions[];
   commonQuestionsDraft?: Answers[];
   formObject: Pick<UseFormReturn, 'register' | 'formState' | 'watch' | 'clearErrors' | 'trigger'>;
-}) => {
+}
+
+const CommonSection = ({ isReview, refCallback, questions, commonQuestionsDraft, formObject }: CommonSectionProps) => {
   const commonQuestionsById = commonQuestionsDraft?.reduce(
     (acc, draft) => {
       acc ? (acc[draft.id] = draft) : undefined;
@@ -38,7 +36,8 @@ const CommonSection = ({
               defaultValue={defaultValue}
               formObject={formObject}
               maxCount={charLimit}
-              required>
+              required
+              disabled={isReview}>
               {value}
             </Textarea>
           </div>

--- a/src/views/ApplyPage/components/DefaultSection/components/Postcode/index.tsx
+++ b/src/views/ApplyPage/components/DefaultSection/components/Postcode/index.tsx
@@ -42,7 +42,7 @@ const Postcode = ({ disabled, addressDraft, formObject }: PostcodeProps) => {
         placeholder="예) 서울특별시 관악구 신림동"
         onClick={handleOpenPostcode}
         value={address || addressDraft}
-        style={{ cursor: 'pointer', caretColor: 'transparent' }}
+        style={{ cursor: disabled ? 'not-allowed' : 'pointer', caretColor: 'transparent' }}
         disabled={disabled}
       />
     </TextBox>

--- a/src/views/ApplyPage/components/DefaultSection/components/Postcode/index.tsx
+++ b/src/views/ApplyPage/components/DefaultSection/components/Postcode/index.tsx
@@ -4,16 +4,16 @@ import { UseFormReturn } from 'react-hook-form';
 
 import { InputLine, TextBox } from '@components/Input';
 
-const Postcode = ({
-  addressDraft,
-  formObject,
-}: {
+interface PostcodeProps {
+  disabled: boolean;
   addressDraft?: string;
   formObject: Pick<
     UseFormReturn,
     'register' | 'formState' | 'clearErrors' | 'trigger' | 'watch' | 'setValue' | 'getValues' | 'setError'
   >;
-}) => {
+}
+
+const Postcode = ({ disabled, addressDraft, formObject }: PostcodeProps) => {
   const [address, setAddress] = useState('');
 
   const { clearErrors } = formObject;
@@ -43,6 +43,7 @@ const Postcode = ({
         onClick={handleOpenPostcode}
         value={address || addressDraft}
         style={{ cursor: 'pointer', caretColor: 'transparent' }}
+        disabled={disabled}
       />
     </TextBox>
   );

--- a/src/views/ApplyPage/components/DefaultSection/index.tsx
+++ b/src/views/ApplyPage/components/DefaultSection/index.tsx
@@ -23,16 +23,16 @@ import {
   title,
 } from './style.css';
 
-const ProfileImage = ({
-  pic,
-  formObject,
-}: {
+interface ProfileImageProps {
+  disabled: boolean;
   pic?: string;
   formObject: Pick<
     UseFormReturn,
     'register' | 'formState' | 'clearErrors' | 'trigger' | 'watch' | 'setValue' | 'getValues' | 'setError'
   >;
-}) => {
+}
+
+const ProfileImage = ({ disabled, pic, formObject }: ProfileImageProps) => {
   const {
     register,
     clearErrors,
@@ -84,6 +84,7 @@ const ProfileImage = ({
           type="file"
           accept="image/png, image/jpg, image/jpeg"
           style={{ display: 'none' }}
+          disabled={disabled}
           {...register('picture', {
             required: !pic && true && '필수 입력 항목이에요.',
             onChange: handleChangeImage,
@@ -107,18 +108,17 @@ const ProfileImage = ({
   );
 };
 
-const DefaultSection = ({
-  refCallback,
-  applicantDraft,
-  formObject,
-}: {
+interface DefaultSectionProps {
+  isReview: boolean;
   refCallback?: (elem: HTMLSelectElement) => void;
   applicantDraft?: Applicant;
   formObject: Pick<
     UseFormReturn,
     'register' | 'formState' | 'clearErrors' | 'trigger' | 'watch' | 'setValue' | 'getValues' | 'setError'
   >;
-}) => {
+}
+
+const DefaultSection = ({ isReview, refCallback, applicantDraft, formObject }: DefaultSectionProps) => {
   const {
     address,
     birthday,
@@ -138,10 +138,10 @@ const DefaultSection = ({
   return (
     <section ref={refCallback} id="default" className={sectionContainer}>
       <h2 className={title}>기본 인적사항</h2>
-      <ProfileImage pic={pic} formObject={formObject} />
+      <ProfileImage pic={pic} formObject={formObject} disabled={isReview} />
       <div className={doubleWrapper}>
         <TextBox label="이름" name="name" formObject={formObject} required size="sm">
-          <InputLine value={name} name="name" readOnly />
+          <InputLine value={name} name="name" readOnly disabled={isReview} />
         </TextBox>
         <SelectBox
           defaultValue={gender}
@@ -151,6 +151,7 @@ const DefaultSection = ({
           options={SELECT_OPTIONS.성별}
           formObject={formObject}
           required
+          disabled={isReview}
         />
       </div>
       <div className={doubleWrapper}>
@@ -165,16 +166,17 @@ const DefaultSection = ({
             pattern={VALIDATION_CHECK.birthdate.pattern}
             errorText={VALIDATION_CHECK.birthdate.errorText}
             validate={VALIDATION_CHECK.birthdate.validate}
+            disabled={isReview}
           />
         </TextBox>
         <TextBox label="연락처" name="phone" formObject={formObject} required size="sm">
-          <InputLine value={phone} name="phone" readOnly />
+          <InputLine value={phone} name="phone" readOnly disabled={isReview} />
         </TextBox>
       </div>
       <TextBox label="이메일" name="email" formObject={formObject} required size="lg">
-        <InputLine value={email} name="email" readOnly />
+        <InputLine value={email} name="email" readOnly disabled={isReview} />
       </TextBox>
-      <Postcode addressDraft={address} formObject={formObject} />
+      <Postcode addressDraft={address} formObject={formObject} disabled={isReview} />
       <TextBox label="지하철역" name="nearestStation" formObject={formObject} required size="lg">
         <InputLine
           defaultValue={nearestStation}
@@ -183,6 +185,7 @@ const DefaultSection = ({
           maxLength={VALIDATION_CHECK.subway.maxLength}
           pattern={VALIDATION_CHECK.subway.pattern}
           errorText={VALIDATION_CHECK.subway.errorText}
+          disabled={isReview}
         />
       </TextBox>
       <div className={doubleWrapper}>
@@ -194,6 +197,7 @@ const DefaultSection = ({
             maxLength={VALIDATION_CHECK.textInput.maxLength}
             pattern={VALIDATION_CHECK.textInput.pattern}
             errorText={VALIDATION_CHECK.textInput.errorText}
+            disabled={isReview}
           />
         </TextBox>
         <div style={{ margin: '52px 0 0 22px' }}>
@@ -203,6 +207,7 @@ const DefaultSection = ({
             label={['재학', '휴학 ‧ 수료 ‧ 유예 ‧ 졸업']}
             name="leaveAbsence"
             required
+            disabled={isReview}
           />
         </div>
       </div>
@@ -215,6 +220,7 @@ const DefaultSection = ({
             maxLength={VALIDATION_CHECK.textInput.maxLength}
             pattern={VALIDATION_CHECK.textInput.pattern}
             errorText={VALIDATION_CHECK.textInput.errorText}
+            disabled={isReview}
           />
         </TextBox>
         <SelectBox
@@ -225,6 +231,7 @@ const DefaultSection = ({
           options={SELECT_OPTIONS.학년}
           formObject={formObject}
           required
+          disabled={isReview}
         />
       </div>
       <SelectBox
@@ -236,6 +243,7 @@ const DefaultSection = ({
         formObject={formObject}
         required
         size="lg"
+        disabled={isReview}
       />
     </section>
   );

--- a/src/views/ApplyPage/components/DefaultSection/index.tsx
+++ b/src/views/ApplyPage/components/DefaultSection/index.tsx
@@ -91,7 +91,7 @@ const ProfileImage = ({ disabled, pic, formObject }: ProfileImageProps) => {
           })}
         />
         <div>
-          <label htmlFor="picture" className={profileLabelVar[isError ? 'error' : 'default']}>
+          <label htmlFor="picture" className={profileLabelVar[disabled ? 'disabled' : isError ? 'error' : 'default']}>
             {pic || image ? <img src={image || pic} alt="지원서 프로필 사진" className={profileImage} /> : <IconUser />}
             {isError && <p className={errorText}>{isFileSizeExceeded || (errors.picture?.message as string)}</p>}
           </label>

--- a/src/views/ApplyPage/components/DefaultSection/style.css.ts
+++ b/src/views/ApplyPage/components/DefaultSection/style.css.ts
@@ -53,6 +53,12 @@ export const profileLabelVar = styleVariants({
       borderColor: theme.color.error,
     },
   ],
+  disabled: [
+    profileLabel,
+    {
+      cursor: 'not-allowed',
+    },
+  ],
 });
 
 export const errorText = style({

--- a/src/views/ApplyPage/components/PartSection/index.tsx
+++ b/src/views/ApplyPage/components/PartSection/index.tsx
@@ -7,13 +7,8 @@ import { Answers, Questions } from 'views/ApplyPage/types';
 
 import { sectionContainer, title } from './style.css';
 
-const PartSection = ({
-  refCallback,
-  part,
-  questions,
-  partQuestionsDraft,
-  formObject,
-}: {
+interface PartSectionProps {
+  isReview: boolean;
   refCallback: (elem: HTMLSelectElement) => void;
   part?: string;
   questions?: {
@@ -26,7 +21,9 @@ const PartSection = ({
     UseFormReturn,
     'register' | 'formState' | 'watch' | 'clearErrors' | 'setValue' | 'getValues' | 'watch' | 'trigger'
   >;
-}) => {
+}
+
+const PartSection = ({ isReview, refCallback, part, questions, partQuestionsDraft, formObject }: PartSectionProps) => {
   const { getValues } = formObject;
 
   let selectedPart: string = getValues('part');
@@ -52,6 +49,7 @@ const PartSection = ({
         formObject={formObject}
         size="lg"
         required
+        disabled={isReview}
       />
       {filteredQuestions?.map(({ value, charLimit, id }) => {
         const draftItem = partQuestionsById?.[id];
@@ -65,7 +63,8 @@ const PartSection = ({
               defaultValue={defaultValue}
               formObject={formObject}
               maxCount={charLimit}
-              required>
+              required
+              disabled={isReview}>
               {value}
             </Textarea>
           </div>

--- a/src/views/ApplyPage/hooks/useMutateSubmit.tsx
+++ b/src/views/ApplyPage/hooks/useMutateSubmit.tsx
@@ -5,13 +5,14 @@ import { sendData } from '../apis';
 import type { ApplyError, ApplyRequest, ApplyResponse } from '../types';
 import type { AxiosError, AxiosResponse } from 'axios';
 
-const useMutateSubmit = () => {
+const useMutateSubmit = ({ onSuccess }: { onSuccess: () => void }) => {
   const { mutate: submitMutate, isPending: submitIsPending } = useMutation<
     AxiosResponse<ApplyResponse, ApplyRequest>,
     AxiosError<ApplyError, ApplyRequest>,
     ApplyRequest
   >({
     mutationFn: (formData) => sendData('/recruiting-answer', formData),
+    onSuccess,
   });
 
   return { submitMutate, submitIsPending };

--- a/src/views/ApplyPage/index.tsx
+++ b/src/views/ApplyPage/index.tsx
@@ -33,6 +33,7 @@ const ApplyPage = () => {
   const [isInView, setIsInView] = useState([true, false, false]);
   const [sectionsUpdated, setSectionsUpdated] = useState(false);
   const [isComplete, setIsComplete] = useState(false);
+  const [isReview, setIsReview] = useState(false);
 
   const navigate = useNavigate();
   const {
@@ -240,9 +241,9 @@ const ApplyPage = () => {
 
   return (
     <>
-      {isComplete && <CompletePage userInfo={{ name, season, group }} />}
-      {!isComplete && isSubmit && <MyPage />}
-      {!isComplete && !isSubmit && (
+      {!isReview && isComplete && <CompletePage userInfo={{ name, season, group }} />}
+      {!isReview && !isComplete && isSubmit && <MyPage onShowReview={() => setIsReview(true)} />}
+      {(isReview || (!isComplete && !isSubmit)) && (
         <>
           <DraftDialog ref={draftDialog} />
           <SubmitDialog
@@ -260,36 +261,49 @@ const ApplyPage = () => {
             }}
           />
           <form onSubmit={handleSubmit(handleApplySubmit)} className={formContainer}>
-            <ApplyHeader isLoading={draftIsPending || submitIsPending} onSaveDraft={() => handleSendData('draft')} />
-            <ApplyInfo />
+            <ApplyHeader
+              isReview={isReview}
+              isLoading={draftIsPending || submitIsPending}
+              onSaveDraft={() => handleSendData('draft')}
+            />
+            <ApplyInfo isReview={isReview} />
             <ApplyCategory minIndex={minIndex} />
             <div className={sectionContainer}>
-              <DefaultSection refCallback={refCallback} applicantDraft={applicantDraft} formObject={formObject} />
+              <DefaultSection
+                isReview={isReview}
+                refCallback={refCallback}
+                applicantDraft={applicantDraft}
+                formObject={formObject}
+              />
               <CommonSection
+                isReview={isReview}
                 refCallback={refCallback}
                 questions={commonQuestions?.questions}
                 commonQuestionsDraft={commonQuestionsDraft}
                 formObject={formObject}
               />
               <PartSection
+                isReview={isReview}
                 refCallback={refCallback}
                 part={applicantDraft?.part}
                 questions={partQuestions}
                 partQuestionsDraft={partQuestionsDraft}
                 formObject={formObject}
               />
-              <BottomSection knownPath={applicantDraft?.knownPath} formObject={formObject} />
-              <div className={buttonWrapper}>
-                <Button
-                  isLoading={draftIsPending || submitIsPending}
-                  onClick={() => handleSendData('draft')}
-                  buttonStyle="line">
-                  임시저장
-                </Button>
-                <Button isLoading={draftIsPending || submitIsPending} type="submit">
-                  제출하기
-                </Button>
-              </div>
+              <BottomSection isReview={isReview} knownPath={applicantDraft?.knownPath} formObject={formObject} />
+              {!isReview && (
+                <div className={buttonWrapper}>
+                  <Button
+                    isLoading={draftIsPending || submitIsPending}
+                    onClick={() => handleSendData('draft')}
+                    buttonStyle="line">
+                    임시저장
+                  </Button>
+                  <Button isLoading={draftIsPending || submitIsPending} type="submit">
+                    제출하기
+                  </Button>
+                </div>
+              )}
             </div>
           </form>
         </>

--- a/src/views/ApplyPage/index.tsx
+++ b/src/views/ApplyPage/index.tsx
@@ -7,6 +7,7 @@ import { RecruitingInfoContext } from '@store/recruitingInfoContext';
 import CompletePage from 'views/CompletePage';
 import { DraftDialog, SubmitDialog } from 'views/dialogs';
 import BigLoading from 'views/loadings/BigLoding';
+import MyPage from 'views/MyPage';
 
 import ApplyCategory from './components/ApplyCategory';
 import ApplyHeader from './components/ApplyHeader';
@@ -31,7 +32,7 @@ const ApplyPage = () => {
 
   const [isInView, setIsInView] = useState([true, false, false]);
   const [sectionsUpdated, setSectionsUpdated] = useState(false);
-  const [isSubmit, setIsSubmit] = useState(false);
+  const [isComplete, setIsComplete] = useState(false);
 
   const navigate = useNavigate();
   const {
@@ -47,12 +48,13 @@ const ApplyPage = () => {
     applicant: applicantDraft,
     commonQuestions: commonQuestionsDraft,
     partQuestions: partQuestionsDraft,
+    isSubmit,
   } = draftData?.data || {};
   const { questionsData, questionsIsLoading } = useGetQuestions(applicantDraft);
   const { commonQuestions, partQuestions, questionTypes } = questionsData?.data || {};
 
   const { draftMutate, draftIsPending } = useMutateDraft({ onSuccess: () => draftDialog.current?.showModal() });
-  const { submitMutate, submitIsPending } = useMutateSubmit({ onSuccess: () => setIsSubmit(true) });
+  const { submitMutate, submitIsPending } = useMutateSubmit({ onSuccess: () => setIsComplete(true) });
 
   const { handleSubmit, ...formObject } = useForm({ mode: 'onBlur' });
   const {
@@ -229,15 +231,18 @@ const ApplyPage = () => {
     submitDialog.current?.showModal();
   };
 
-  window.addEventListener('beforeunload', (e) => {
-    e.preventDefault();
-    e.returnValue = true; // Included for legacy support, e.g. Chrome/Edge < 119
-  });
+  if (!isComplete) {
+    window.addEventListener('beforeunload', (e) => {
+      !isComplete && e.preventDefault();
+      e.returnValue = true; // Included for legacy support, e.g. Chrome/Edge < 119
+    });
+  }
 
   return (
     <>
-      {isSubmit && <CompletePage userInfo={{ name, season, group }} />}
-      {!isSubmit && (
+      {isComplete && <CompletePage userInfo={{ name, season, group }} />}
+      {!isComplete && isSubmit && <MyPage />}
+      {!isComplete && !isSubmit && (
         <>
           <DraftDialog ref={draftDialog} />
           <SubmitDialog

--- a/src/views/ApplyPage/index.tsx
+++ b/src/views/ApplyPage/index.tsx
@@ -1,9 +1,8 @@
-import { useCallback, useContext, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { useNavigate } from 'react-router-dom';
 
 import Button from '@components/Button';
-import { RecruitingInfoContext } from '@store/recruitingInfoContext';
 import { DraftDialog, SubmitDialog } from 'views/dialogs';
 import BigLoading from 'views/loadings/BigLoding';
 
@@ -38,7 +37,7 @@ const ApplyPage = ({ isComplete, isReview, onSetComplete, draftData }: ApplyPage
   const [sectionsUpdated, setSectionsUpdated] = useState(false);
 
   const navigate = useNavigate();
-  const { handleSaveRecruitingInfo } = useContext(RecruitingInfoContext);
+
   const minIndex = isInView.findIndex((value) => value === true);
 
   useScrollToHash(); // scrollTo 카테고리
@@ -86,15 +85,11 @@ const ApplyPage = ({ isComplete, isReview, onSetComplete, draftData }: ApplyPage
   } = getValues();
 
   useEffect(() => {
-    handleSaveRecruitingInfo({
-      name: applicantDraft?.name,
-    });
-
     if (applicantDraft?.part) {
       setValue('part', applicantDraft?.part);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [applicantDraft, handleSaveRecruitingInfo]);
+  }, [applicantDraft]);
 
   const refCallback = useCallback(
     (element: HTMLSelectElement) => {

--- a/src/views/ApplyPage/index.tsx
+++ b/src/views/ApplyPage/index.tsx
@@ -4,6 +4,7 @@ import { useNavigate } from 'react-router-dom';
 
 import Button from '@components/Button';
 import { RecruitingInfoContext } from '@store/recruitingInfoContext';
+import CompletePage from 'views/CompletePage';
 import { DraftDialog, SubmitDialog } from 'views/dialogs';
 import BigLoading from 'views/loadings/BigLoding';
 
@@ -30,10 +31,13 @@ const ApplyPage = () => {
 
   const [isInView, setIsInView] = useState([true, false, false]);
   const [sectionsUpdated, setSectionsUpdated] = useState(false);
+  const [isSubmit, setIsSubmit] = useState(false);
 
   const navigate = useNavigate();
-  const { handleSaveRecruitingInfo } = useContext(RecruitingInfoContext);
-
+  const {
+    recruitingInfo: { season, group },
+    handleSaveRecruitingInfo,
+  } = useContext(RecruitingInfoContext);
   const minIndex = isInView.findIndex((value) => value === true);
 
   useScrollToHash(); // scrollTo 카테고리
@@ -44,12 +48,11 @@ const ApplyPage = () => {
     commonQuestions: commonQuestionsDraft,
     partQuestions: partQuestionsDraft,
   } = draftData?.data || {};
-
   const { questionsData, questionsIsLoading } = useGetQuestions(applicantDraft);
   const { commonQuestions, partQuestions, questionTypes } = questionsData?.data || {};
 
   const { draftMutate, draftIsPending } = useMutateDraft({ onSuccess: () => draftDialog.current?.showModal() });
-  const { submitMutate, submitIsPending } = useMutateSubmit();
+  const { submitMutate, submitIsPending } = useMutateSubmit({ onSuccess: () => setIsSubmit(true) });
 
   const { handleSubmit, ...formObject } = useForm({ mode: 'onBlur' });
   const {
@@ -233,54 +236,59 @@ const ApplyPage = () => {
 
   return (
     <>
-      <DraftDialog ref={draftDialog} />
-      <SubmitDialog
-        userInfo={{
-          name,
-          email,
-          phone,
-          part,
-        }}
-        dataIsPending={submitIsPending}
-        ref={submitDialog}
-        onSendData={() => {
-          handleSendData('submit');
-          submitDialog.current?.close();
-        }}
-      />
-      <form onSubmit={handleSubmit(handleApplySubmit)} className={formContainer}>
-        <ApplyHeader isLoading={draftIsPending || submitIsPending} onSaveDraft={() => handleSendData('draft')} />
-        <ApplyInfo />
-        <ApplyCategory minIndex={minIndex} />
-        <div className={sectionContainer}>
-          <DefaultSection refCallback={refCallback} applicantDraft={applicantDraft} formObject={formObject} />
-          <CommonSection
-            refCallback={refCallback}
-            questions={commonQuestions?.questions}
-            commonQuestionsDraft={commonQuestionsDraft}
-            formObject={formObject}
+      {isSubmit && <CompletePage userInfo={{ name, season, group }} />}
+      {!isSubmit && (
+        <>
+          <DraftDialog ref={draftDialog} />
+          <SubmitDialog
+            userInfo={{
+              name,
+              email,
+              phone,
+              part,
+            }}
+            dataIsPending={submitIsPending}
+            ref={submitDialog}
+            onSendData={() => {
+              handleSendData('submit');
+              submitDialog.current?.close();
+            }}
           />
-          <PartSection
-            refCallback={refCallback}
-            part={applicantDraft?.part}
-            questions={partQuestions}
-            partQuestionsDraft={partQuestionsDraft}
-            formObject={formObject}
-          />
-          <BottomSection knownPath={applicantDraft?.knownPath} formObject={formObject} />
-          <div className={buttonWrapper}>
-            <Button
-              isLoading={draftIsPending || submitIsPending}
-              onClick={() => handleSendData('draft')}
-              buttonStyle="line">
-              임시저장
-            </Button>
-            <Button isLoading={draftIsPending || submitIsPending} type="submit">
-              제출하기
-            </Button>
-          </div>
-        </div>
-      </form>
+          <form onSubmit={handleSubmit(handleApplySubmit)} className={formContainer}>
+            <ApplyHeader isLoading={draftIsPending || submitIsPending} onSaveDraft={() => handleSendData('draft')} />
+            <ApplyInfo />
+            <ApplyCategory minIndex={minIndex} />
+            <div className={sectionContainer}>
+              <DefaultSection refCallback={refCallback} applicantDraft={applicantDraft} formObject={formObject} />
+              <CommonSection
+                refCallback={refCallback}
+                questions={commonQuestions?.questions}
+                commonQuestionsDraft={commonQuestionsDraft}
+                formObject={formObject}
+              />
+              <PartSection
+                refCallback={refCallback}
+                part={applicantDraft?.part}
+                questions={partQuestions}
+                partQuestionsDraft={partQuestionsDraft}
+                formObject={formObject}
+              />
+              <BottomSection knownPath={applicantDraft?.knownPath} formObject={formObject} />
+              <div className={buttonWrapper}>
+                <Button
+                  isLoading={draftIsPending || submitIsPending}
+                  onClick={() => handleSendData('draft')}
+                  buttonStyle="line">
+                  임시저장
+                </Button>
+                <Button isLoading={draftIsPending || submitIsPending} type="submit">
+                  제출하기
+                </Button>
+              </div>
+            </div>
+          </form>
+        </>
+      )}
     </>
   );
 };

--- a/src/views/ApplyPage/types.ts
+++ b/src/views/ApplyPage/types.ts
@@ -112,4 +112,5 @@ export interface ApplyResponse {
   applicant: Applicant;
   commonQuestions: Answers[];
   partQuestions: Answers[];
+  isSubmit: boolean;
 }

--- a/src/views/CompletePage/index.tsx
+++ b/src/views/CompletePage/index.tsx
@@ -1,17 +1,18 @@
+import { useContext } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import Button from '@components/Button';
 import Callout from '@components/Callout';
+import { RecruitingInfoContext } from '@store/recruitingInfoContext';
 
 import IconCheckmark from './icons/IconCheckmark';
 import { container, icon, mainText, subText } from './style.css';
 
-const CompletePage = ({
-  userInfo: { name, season, group },
-}: {
-  userInfo: { name: string; season?: number; group?: string };
-}) => {
+const CompletePage = () => {
   const navigate = useNavigate();
+  const {
+    recruitingInfo: { name, season, group },
+  } = useContext(RecruitingInfoContext);
 
   return (
     <section className={container}>

--- a/src/views/CompletePage/index.tsx
+++ b/src/views/CompletePage/index.tsx
@@ -1,27 +1,30 @@
+import { useNavigate } from 'react-router-dom';
+
 import Button from '@components/Button';
 import Callout from '@components/Callout';
 
 import IconCheckmark from './icons/IconCheckmark';
 import { container, icon, mainText, subText } from './style.css';
 
-const CompletePage = () => {
-  const name = '000';
-  const th = '00';
+const CompletePage = ({
+  userInfo: { name, season, group },
+}: {
+  userInfo: { name: string; season?: number; group?: string };
+}) => {
+  const navigate = useNavigate();
 
   return (
     <section className={container}>
       <div className={icon}>
         <IconCheckmark />
       </div>
-      <p className={mainText}>{`${name}님의\n${th}기 지원서가 접수되었습니다.`}</p>
+      <p className={mainText}>{`${name}님의\n${season}기 ${group} 지원서가 접수되었습니다.`}</p>
       <p className={subText}>이메일로 지원 접수 완료 알림이 발송되었습니다.</p>
       <Callout
         style={{
           marginBottom: 50,
         }}>{`이메일 도착 시점에 차이가 있을 수 있습니다.\n이메일이 오지 않으면 스팸 메일함을 확인해주세요.`}</Callout>
-      <Button isLink to="/my">
-        마이페이지로 이동하기
-      </Button>
+      <Button onClick={() => navigate(0)}>마이페이지로 이동하기</Button>
     </section>
   );
 };

--- a/src/views/MainPage/index.tsx
+++ b/src/views/MainPage/index.tsx
@@ -4,8 +4,8 @@ import { useContext, useEffect } from 'react';
 
 import useGetRecruitingInfo from '@hooks/useGetRecruitingInfo';
 import { RecruitingInfoContext } from '@store/recruitingInfoContext';
-import ApplyPage from 'views/ApplyPage';
 import BigLoading from 'views/loadings/BigLoding';
+import SignedInPage from 'views/SignedInPage';
 import SignInPage from 'views/SignInPage';
 
 const MainPage = () => {
@@ -91,7 +91,7 @@ const MainPage = () => {
 
   if (isLoading) return <BigLoading />;
 
-  return <>{isSignedIn ? <ApplyPage /> : <SignInPage />}</>;
+  return <>{isSignedIn ? <SignedInPage /> : <SignInPage />}</>;
 };
 
 export default MainPage;

--- a/src/views/MyPage/index.tsx
+++ b/src/views/MyPage/index.tsx
@@ -28,7 +28,7 @@ const MyInfoItem = ({ label, value }: { label: string; value?: string | number |
   );
 };
 
-const MyPage = () => {
+const MyPage = ({ onShowReview }: { onShowReview: () => void }) => {
   const { myInfoData, myInfoIsLoading } = useGetMyInfo();
 
   if (myInfoIsLoading) return <BigLoading />;
@@ -46,7 +46,9 @@ const MyPage = () => {
         <MyInfoItem label="지원상태" value={submit} />
         <li className={lastItemWrapper}>
           <span className={infoLabel}>지원서</span>
-          <Button padding="15x25">지원서 확인</Button>
+          <Button onClick={onShowReview} padding="15x25">
+            지원서 확인
+          </Button>
         </li>
       </ol>
     </section>

--- a/src/views/ReviewPage/index.tsx
+++ b/src/views/ReviewPage/index.tsx
@@ -1,5 +1,0 @@
-const ReviewPage = () => {
-  return <div>ReviewPage</div>;
-};
-
-export default ReviewPage;

--- a/src/views/SignedInPage/apis.ts
+++ b/src/views/SignedInPage/apis.ts
@@ -1,0 +1,7 @@
+import tokenInstance from '@apis/tokenInstance';
+
+export const getDraft = async () => {
+  const res = await tokenInstance.get('/recruiting-answer/store');
+
+  return res;
+};

--- a/src/views/SignedInPage/hooks/useGetDraft.tsx
+++ b/src/views/SignedInPage/hooks/useGetDraft.tsx
@@ -2,7 +2,7 @@ import { useQuery } from '@tanstack/react-query';
 
 import { getDraft } from '../apis';
 
-import type { ApplyError, ApplyResponse } from '../types';
+import type { ApplyError, ApplyResponse } from '../../ApplyPage/types';
 import type { AxiosError, AxiosResponse } from 'axios';
 
 const useGetDraft = () => {

--- a/src/views/SignedInPage/index.tsx
+++ b/src/views/SignedInPage/index.tsx
@@ -1,5 +1,6 @@
-import { useState } from 'react';
+import { useContext, useEffect, useState } from 'react';
 
+import { RecruitingInfoContext } from '@store/recruitingInfoContext';
 import ApplyPage from 'views/ApplyPage';
 import CompletePage from 'views/CompletePage';
 import BigLoading from 'views/loadings/BigLoding';
@@ -12,7 +13,15 @@ const SignedInPage = () => {
   const [isReview, setIsReview] = useState(false);
 
   const { draftData, draftIsLoading } = useGetDraft();
-  const { isSubmit } = draftData?.data || {};
+  const { applicant, isSubmit } = draftData?.data || {};
+
+  const { handleSaveRecruitingInfo } = useContext(RecruitingInfoContext);
+
+  useEffect(() => {
+    handleSaveRecruitingInfo({
+      name: applicant?.name,
+    });
+  }, [applicant, handleSaveRecruitingInfo]);
 
   if (draftIsLoading) return <BigLoading />;
 

--- a/src/views/SignedInPage/index.tsx
+++ b/src/views/SignedInPage/index.tsx
@@ -1,0 +1,35 @@
+import { useState } from 'react';
+
+import ApplyPage from 'views/ApplyPage';
+import CompletePage from 'views/CompletePage';
+import BigLoading from 'views/loadings/BigLoding';
+import MyPage from 'views/MyPage';
+
+import useGetDraft from './hooks/useGetDraft';
+
+const SignedInPage = () => {
+  const [isComplete, setIsComplete] = useState(false);
+  const [isReview, setIsReview] = useState(false);
+
+  const { draftData, draftIsLoading } = useGetDraft();
+  const { isSubmit } = draftData?.data || {};
+
+  if (draftIsLoading) return <BigLoading />;
+
+  return (
+    <>
+      {!isReview && isComplete && <CompletePage />}
+      {!isReview && !isComplete && isSubmit && <MyPage onShowReview={() => setIsReview(true)} />}
+      {(isReview || (!isComplete && !isSubmit)) && (
+        <ApplyPage
+          isComplete={isComplete}
+          isReview={isReview}
+          onSetComplete={() => setIsComplete(true)}
+          draftData={draftData}
+        />
+      )}
+    </>
+  );
+};
+
+export default SignedInPage;


### PR DESCRIPTION
**Related Issue :** Closes #152 

---

## 🧑‍🎤 Summary
- [x] 제출 완료 시 complete 페이지 등장
- [x] 제출 완료 후 접속 시 my page 렌더링
- [x] 지원서 확인 기능 구현

## 🧑‍🎤 Comment
### url 통일
`/complete` `/my` 로 나눠져있는 걸 `apply` 페이지와 같이 `/` 에서 렌더링 되도록 했어요
다른 페이지로 이동시 state가 초기화 되는데 그럼 데이터를 다시 얻기 위해 api 요청을 보내야 하거든요
불필요한 서버 리소스를 줄이기 위해 한 페이지에 한 번만 api 요청 보내고 이를 여러 군데 재사용 하는 방식을 택했습니다
이를 위해 context나 prop을 이용해줬습니다

### SIgnedIn Page에서 위의 3개 컴포넌트 관리
`/` 에서 렌더링 되는 컴포넌트는 `SignInPage`, `ApplyPage`, `CompletePage`, `MyPage` 이렇게 총 4개예요
그 중 `ApplyPage`, `CompletePage`, `MyPage`를 `SignedInPage`에서 관리하고,
`SignInPage`와 나머지 3개를 묶은 `SignedInPage`를 `MainPage`에서 관리하고 있어요
`MainPage`에서는 api 요청시 token이 필요 없는 반면 `SignedInPage`는 token이 필요하거든요
그래서 분리해줬습니다
