### PR TITLE
[Refactor] 인풋 렌더링 최적화 하기

### DIFF
--- a/src/common/components/Checkbox/index.tsx
+++ b/src/common/components/Checkbox/index.tsx
@@ -1,4 +1,4 @@
-import { FieldValues, Path, UseFormReturn } from 'react-hook-form';
+import { FieldValues, Path, useFormContext } from 'react-hook-form';
 
 import { container, checkboxContainer, checkmark, hiddenCheckbox, requireDot, error } from './style.css';
 
@@ -8,20 +8,18 @@ interface CheckboxProps<T extends FieldValues> extends InputHTMLAttributes<HTMLI
   children?: string | number;
   name: Path<T>;
   showIcon?: boolean;
-  formObject: Pick<UseFormReturn, 'register' | 'formState' | 'clearErrors' | 'trigger' | 'watch'>;
 }
 
 const Checkbox = <T extends FieldValues>({
   children,
   name,
-  formObject,
   required = false,
   ...checkboxElementProps
 }: CheckboxProps<T>) => {
   const {
     register,
     formState: { errors },
-  } = formObject;
+  } = useFormContext();
 
   return (
     <>

--- a/src/common/components/Input/InputLine/index.tsx
+++ b/src/common/components/Input/InputLine/index.tsx
@@ -25,13 +25,12 @@ const InputLine = ({
   const { defaultValue } = inputElementProps;
 
   const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
-    clearErrors && clearErrors(name);
+    clearErrors && errors[name] && clearErrors(name);
 
     if (name === 'birthday') {
       const formattedValue = formatBirthdate(e.target.value);
       setValue('birthday', formattedValue);
     }
-
     if (name === 'phone') {
       const formattedValue = formatPhoneNumber(e.target.value);
       setValue('phone', formattedValue);

--- a/src/common/components/Input/InputLine/index.tsx
+++ b/src/common/components/Input/InputLine/index.tsx
@@ -1,4 +1,5 @@
 import { ChangeEvent, useContext } from 'react';
+import { useFormContext } from 'react-hook-form';
 
 import { inputLine, inputVar } from './style.css';
 import { formatBirthdate } from './utils/formatBirthdate';
@@ -15,12 +16,15 @@ const InputLine = ({
   errorText,
   children,
   ...inputElementProps
-}: Omit<TextBoxProps, 'label' | 'size' | 'formObject'>) => {
+}: Omit<TextBoxProps, 'label' | 'size'>) => {
   const {
-    required,
-    formObject: { register, formState, clearErrors, trigger, setValue },
-  } = useContext(FormContext);
-  const { errors } = formState;
+    register,
+    formState: { errors },
+    clearErrors,
+    trigger,
+    setValue,
+  } = useFormContext();
+  const { required } = useContext(FormContext);
   const { maxLength, minLength } = inputElementProps;
   const { defaultValue } = inputElementProps;
 
@@ -43,7 +47,7 @@ const InputLine = ({
         <input
           id={name}
           defaultValue={defaultValue}
-          className={inputVar[errors?.[name] ? 'error' : 'default']}
+          className={inputVar[errors[name] ? 'error' : 'default']}
           {...inputElementProps}
           {...register(name, {
             required: required && '필수 입력 항목이에요.',

--- a/src/common/components/Input/InputTheme.tsx
+++ b/src/common/components/Input/InputTheme.tsx
@@ -1,6 +1,7 @@
 import { useMutation } from '@tanstack/react-query';
 import { AxiosError, AxiosResponse } from 'axios';
 import { useCallback, useEffect, useState } from 'react';
+import { useFormContext } from 'react-hook-form';
 import { useLocation } from 'react-router-dom';
 
 import { VALIDATION_CHECK } from '@constants/validationCheck';
@@ -16,14 +17,13 @@ import type {
   CheckUserRequest,
   CheckVerificationCodeRequest,
   SendVerificationCodeRequest,
-  TextBoxProps,
   EmailResponse,
 } from './types';
 import type { ErrorResponse } from '@type/errorResponse';
 
-export const TextBox이름 = ({ formObject }: Pick<TextBoxProps, 'formObject'>) => {
+export const TextBox이름 = () => {
   return (
-    <TextBox label="이름" name="name" formObject={formObject} required>
+    <TextBox label="이름" name="name" required>
       <InputLine
         name="name"
         pattern={VALIDATION_CHECK.name.pattern}
@@ -38,14 +38,12 @@ export const TextBox이름 = ({ formObject }: Pick<TextBoxProps, 'formObject'>) 
 
 interface TextBox이메일Props {
   recruitingInfo: { season?: number; group?: string };
-  formObject: TextBoxProps['formObject'];
   isVerified: boolean;
   onChangeVerification: (bool: boolean) => void;
 }
 
 export const TextBox이메일 = ({
   recruitingInfo: { season, group },
-  formObject,
   isVerified,
   onChangeVerification,
 }: TextBox이메일Props) => {
@@ -58,7 +56,7 @@ export const TextBox이메일 = ({
     setValue,
     watch,
     formState: { errors },
-  } = formObject;
+  } = useFormContext();
   const { email, name, code } = getValues();
 
   const { mutate: sendVerificationCodeMutate, isPending: sendVerificationCodeIsPending } = useMutation<
@@ -178,7 +176,7 @@ export const TextBox이메일 = ({
   }, [watch('email')]);
 
   return (
-    <TextBox label="이메일" name="email" formObject={formObject} required>
+    <TextBox label="이메일" name="email" required>
       <InputLine
         style={{ paddingRight: isActive ? 50 : 16 }}
         name="email"
@@ -212,11 +210,11 @@ export const TextBox이메일 = ({
   );
 };
 
-export const TextBox비밀번호 = ({ formObject }: Pick<TextBoxProps, 'formObject'>) => {
+export const TextBox비밀번호 = () => {
   const location = useLocation();
   const textVar = location.pathname === '/password' ? '새 비밀번호' : '비밀번호';
   const name = location.pathname === '/password' ? 'newPassword' : 'password';
-  const { watch, trigger } = formObject;
+  const { watch, trigger } = useFormContext();
 
   const password = watch(name);
   const passwordConfirm = watch('passwordCheck');
@@ -226,7 +224,7 @@ export const TextBox비밀번호 = ({ formObject }: Pick<TextBoxProps, 'formObje
   }, [password, passwordConfirm, trigger]);
 
   return (
-    <TextBox label={textVar} name={name} formObject={formObject} required>
+    <TextBox label={textVar} name={name} required>
       <InputLine
         name={name}
         placeholder={`${textVar}를 입력해주세요.`}

--- a/src/common/components/Input/InputTheme.tsx
+++ b/src/common/components/Input/InputTheme.tsx
@@ -11,13 +11,15 @@ import InputLine from './InputLine';
 import { success } from './style.css';
 import { TextBox } from './TextBox';
 import Timer from './Timer';
-import {
+
+import type {
   CheckUserRequest,
   CheckVerificationCodeRequest,
   SendVerificationCodeRequest,
   TextBoxProps,
   EmailResponse,
 } from './types';
+import type { ErrorResponse } from '@type/errorResponse';
 
 export const TextBox이름 = ({ formObject }: Pick<TextBoxProps, 'formObject'>) => {
   return (
@@ -61,7 +63,7 @@ export const TextBox이메일 = ({
 
   const { mutate: sendVerificationCodeMutate, isPending: sendVerificationCodeIsPending } = useMutation<
     AxiosResponse<EmailResponse, SendVerificationCodeRequest>,
-    AxiosError<EmailResponse, SendVerificationCodeRequest>,
+    AxiosError<ErrorResponse, SendVerificationCodeRequest>,
     SendVerificationCodeRequest
   >({
     mutationFn: ({ email, season, group, isSignup }: SendVerificationCodeRequest) =>
@@ -82,7 +84,7 @@ export const TextBox이메일 = ({
 
   const { mutate: checkUserMutate, isPending: checkUserIsPending } = useMutation<
     AxiosResponse<EmailResponse, CheckUserRequest>,
-    AxiosError<EmailResponse, CheckUserRequest>,
+    AxiosError<ErrorResponse, CheckUserRequest>,
     CheckUserRequest
   >({
     mutationFn: (userInfo: CheckUserRequest) => checkUser(userInfo),
@@ -107,7 +109,7 @@ export const TextBox이메일 = ({
 
   const { mutate: checkVerificationCodeMutate, isPending: checkVerificationCodeIsPending } = useMutation<
     AxiosResponse<EmailResponse, CheckVerificationCodeRequest>,
-    AxiosError<EmailResponse, CheckVerificationCodeRequest>,
+    AxiosError<ErrorResponse, CheckVerificationCodeRequest>,
     CheckVerificationCodeRequest
   >({
     mutationFn: ({ email, code }: CheckVerificationCodeRequest) => checkVerificationCode(email, code),

--- a/src/common/components/Input/TextBox/index.tsx
+++ b/src/common/components/Input/TextBox/index.tsx
@@ -3,7 +3,7 @@ import { createContext } from 'react';
 import { circle, containerVar, title } from './style.css';
 import { TextBoxProps } from '../types';
 
-export const FormContext = createContext({} as Pick<TextBoxProps, 'required' | 'formObject'>);
+export const FormContext = createContext({} as Pick<TextBoxProps, 'required'>);
 
 // TextBox Container
 export const TextBox = ({
@@ -12,10 +12,9 @@ export const TextBox = ({
   name,
   size = 'md',
   required,
-  formObject,
-}: Pick<TextBoxProps, 'children' | 'label' | 'name' | 'size' | 'required' | 'formObject'>) => {
+}: Pick<TextBoxProps, 'children' | 'label' | 'name' | 'size' | 'required'>) => {
   return (
-    <FormContext.Provider value={{ required, formObject }}>
+    <FormContext.Provider value={{ required }}>
       <div className={containerVar[size]}>
         <label className={title} htmlFor={name}>
           <span>{label}</span>

--- a/src/common/components/Input/types.ts
+++ b/src/common/components/Input/types.ts
@@ -1,5 +1,5 @@
 import { InputHTMLAttributes, ReactNode } from 'react';
-import { FieldValues, UseFormReturn, Validate } from 'react-hook-form';
+import { FieldValues, Validate } from 'react-hook-form';
 
 export type SizeType = 'sm' | 'md' | 'lg';
 export interface TextBoxProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'size' | 'pattern'> {
@@ -9,10 +9,6 @@ export interface TextBoxProps extends Omit<InputHTMLAttributes<HTMLInputElement>
   errorText?: string;
   pattern?: RegExp;
   validate?: Validate<FieldValues, FieldValues>;
-  formObject: Pick<
-    UseFormReturn,
-    'register' | 'formState' | 'clearErrors' | 'trigger' | 'watch' | 'setError' | 'getValues' | 'setValue'
-  >;
   children?: ReactNode;
   styleType?: 'default' | 'error';
 }

--- a/src/common/components/Radio/index.tsx
+++ b/src/common/components/Radio/index.tsx
@@ -1,23 +1,22 @@
 import { InputHTMLAttributes, useEffect } from 'react';
-import { FieldValues, Path, UseFormReturn } from 'react-hook-form';
+import { FieldValues, Path, useFormContext } from 'react-hook-form';
 
 import Container from './Container';
 import ErrorMessage from './ErrorMessage';
 import Option from './Option';
 
 interface RadioProps<T extends FieldValues> extends Omit<InputHTMLAttributes<HTMLInputElement>, 'name'> {
-  formObject: Pick<UseFormReturn, 'register' | 'formState' | 'clearErrors' | 'trigger' | 'watch' | 'setValue'>;
   label: string[];
   name: Path<T>;
   defaultValue?: string;
 }
 
-const Radio = <T extends FieldValues>({ label, name, defaultValue, formObject, ...rest }: RadioProps<T>) => {
+const Radio = <T extends FieldValues>({ label, name, defaultValue, ...rest }: RadioProps<T>) => {
   const {
     register,
     formState: { errors },
     setValue,
-  } = formObject;
+  } = useFormContext();
 
   useEffect(() => {
     setValue(name as string, defaultValue);

--- a/src/common/components/Select/index.tsx
+++ b/src/common/components/Select/index.tsx
@@ -1,5 +1,6 @@
 import { IconChevronDown } from '@sopt-makers/icons';
 import { ChangeEvent } from 'react';
+import { useFormContext } from 'react-hook-form';
 
 import {
   circle,
@@ -14,16 +15,8 @@ import {
 } from './style.css';
 import { SelectBoxProps } from './type';
 
-const SelectBox = ({
-  label,
-  name,
-  options,
-  size = 'sm',
-  formObject,
-  required,
-  ...inputElementProps
-}: SelectBoxProps) => {
-  const { register, formState, clearErrors, setValue } = formObject;
+const SelectBox = ({ label, name, options, size = 'sm', required, ...inputElementProps }: SelectBoxProps) => {
+  const { register, formState, clearErrors, setValue } = useFormContext();
   const { errors } = formState;
 
   const handleChange = (e: ChangeEvent<HTMLInputElement>) => {

--- a/src/common/components/Select/type.ts
+++ b/src/common/components/Select/type.ts
@@ -1,10 +1,8 @@
 import { InputHTMLAttributes } from 'react';
-import { UseFormReturn } from 'react-hook-form';
 
 export interface SelectBoxProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'size'> {
   label: string;
   name: string;
   options: string[];
   size?: 'sm' | 'lg';
-  formObject: Pick<UseFormReturn, 'register' | 'setValue' | 'formState' | 'clearErrors'>;
 }

--- a/src/common/components/Textarea/index.tsx
+++ b/src/common/components/Textarea/index.tsx
@@ -1,5 +1,5 @@
 import { ReactNode, TextareaHTMLAttributes, useId } from 'react';
-import { FieldValues, Path, UseFormReturn } from 'react-hook-form';
+import { type FieldValues, type Path, useFormContext } from 'react-hook-form';
 
 import Input from './Input';
 import Label from './Label';
@@ -7,7 +7,6 @@ import { container } from './style.css';
 
 interface TextareaProps<T extends FieldValues> extends TextareaHTMLAttributes<HTMLTextAreaElement> {
   name: Path<T>;
-  formObject: Pick<UseFormReturn, 'register' | 'formState' | 'clearErrors' | 'trigger' | 'watch'>;
   maxCount: number;
   children: string | number;
   extraInput?: ReactNode;
@@ -15,7 +14,6 @@ interface TextareaProps<T extends FieldValues> extends TextareaHTMLAttributes<HT
 
 const Textarea = <T extends FieldValues>({
   name,
-  formObject,
   maxCount,
   children,
   required = false,
@@ -27,7 +25,7 @@ const Textarea = <T extends FieldValues>({
     register,
     watch,
     formState: { errors },
-  } = formObject;
+  } = useFormContext();
 
   return (
     <div className={container}>

--- a/src/common/hooks/useGetRecruitingInfo.tsx
+++ b/src/common/hooks/useGetRecruitingInfo.tsx
@@ -2,13 +2,14 @@ import { useQuery } from '@tanstack/react-query';
 
 import { getRecruitingInfo } from '@apis/getRecruitingInfo';
 
-import type { RecruitingError, RecruitingResponse } from '@type/types';
+import type { ErrorResponse } from '@type/errorResponse';
+import type { RecruitingResponse } from '@type/recruitingInfo';
 import type { AxiosError, AxiosResponse } from 'axios';
 
 const useGetRecruitingInfo = () => {
   const { data, isLoading } = useQuery<
     AxiosResponse<RecruitingResponse, null>,
-    AxiosError<RecruitingError, null>,
+    AxiosError<ErrorResponse, null>,
     AxiosResponse<RecruitingResponse, null>,
     string[]
   >({

--- a/src/common/type/errorResponse.ts
+++ b/src/common/type/errorResponse.ts
@@ -1,0 +1,4 @@
+export interface ErrorResponse {
+  err: boolean;
+  userMessage: string;
+}

--- a/src/common/type/recruitingInfo.ts
+++ b/src/common/type/recruitingInfo.ts
@@ -30,8 +30,3 @@ export interface RecruitingResponse {
     group: string;
   };
 }
-
-export interface RecruitingError {
-  err: boolean;
-  userMessage: string;
-}

--- a/src/common/type/seasonAndGroup.ts
+++ b/src/common/type/seasonAndGroup.ts
@@ -1,0 +1,4 @@
+export interface SeasonGroupType {
+  season?: number;
+  group?: string;
+}

--- a/src/views/ApplyPage/components/ApplyCategory/index.tsx
+++ b/src/views/ApplyPage/components/ApplyCategory/index.tsx
@@ -1,3 +1,4 @@
+import { memo } from 'react';
 import { Link } from 'react-router-dom';
 
 import { CATEGORY } from './constant';
@@ -6,7 +7,7 @@ import { activeLinkStyle, categoryLinkStyle, categoryList, container } from './s
 interface ApplyCategoryProps {
   minIndex: number;
 }
-const ApplyCategory = ({ minIndex }: ApplyCategoryProps) => {
+const ApplyCategory = memo(({ minIndex }: ApplyCategoryProps) => {
   return (
     <nav className={container}>
       <ul className={categoryList}>
@@ -20,6 +21,8 @@ const ApplyCategory = ({ minIndex }: ApplyCategoryProps) => {
       </ul>
     </nav>
   );
-};
+});
+
+ApplyCategory.displayName = 'ApplyCategory';
 
 export default ApplyCategory;

--- a/src/views/ApplyPage/components/ApplyInfo/index.tsx
+++ b/src/views/ApplyPage/components/ApplyInfo/index.tsx
@@ -1,6 +1,6 @@
 import { format } from 'date-fns';
 import { ko } from 'date-fns/locale';
-import { useContext } from 'react';
+import { memo, useContext } from 'react';
 
 import Callout from '@components/Callout';
 import { RecruitingInfoContext } from '@store/recruitingInfoContext';
@@ -17,7 +17,7 @@ import {
 } from './style.css';
 import { APPLY_INFO } from '../../constant';
 
-const ApplyInfo = ({ isReview }: { isReview: boolean }) => {
+const ApplyInfo = memo(({ isReview }: { isReview: boolean }) => {
   const {
     recruitingInfo: {
       applicationStart,
@@ -94,6 +94,8 @@ const ApplyInfo = ({ isReview }: { isReview: boolean }) => {
       )}
     </section>
   );
-};
+});
+
+ApplyInfo.displayName = 'ApplyInfo';
 
 export default ApplyInfo;

--- a/src/views/ApplyPage/components/BottomSection/index.tsx
+++ b/src/views/ApplyPage/components/BottomSection/index.tsx
@@ -1,5 +1,3 @@
-import { UseFormReturn } from 'react-hook-form';
-
 import Checkbox from '@components/Checkbox';
 import Contentbox from '@components/Checkbox/Contentbox';
 import SelectBox from '@components/Select';
@@ -11,10 +9,9 @@ import { doubleLineCheck, label, line, sectionContainer } from './style.css';
 interface BottomSectionProps {
   isReview: boolean;
   knownPath?: string;
-  formObject: Pick<UseFormReturn, 'register' | 'formState' | 'clearErrors' | 'trigger' | 'setValue' | 'watch'>;
 }
 
-const BottomSection = ({ isReview, knownPath, formObject }: BottomSectionProps) => {
+const BottomSection = ({ isReview, knownPath }: BottomSectionProps) => {
   return (
     <section className={sectionContainer}>
       <hr className={line} />
@@ -24,18 +21,17 @@ const BottomSection = ({ isReview, knownPath, formObject }: BottomSectionProps) 
         defaultValue={knownPath}
         placeholder="지원 경로를 선택해 주세요."
         options={SELECT_OPTIONS.경로}
-        formObject={formObject}
         required
         disabled={isReview}
       />
       <div id="check-necessary" className={doubleLineCheck}>
         <p className={label}>SOPT의 행사 및 세미나는 매주 토요일에 진행됩니다.</p>
-        <Checkbox checked={isReview ? true : undefined} name="attendance" formObject={formObject} required>
+        <Checkbox checked={isReview ? true : undefined} name="attendance" required>
           참석 가능합니다.
         </Checkbox>
       </div>
       <div>
-        <Checkbox checked={isReview ? true : undefined} required name="personalInformation" formObject={formObject}>
+        <Checkbox checked={isReview ? true : undefined} required name="personalInformation">
           개인정보 수집 ‧ 이용에 동의합니다.
         </Checkbox>
         <Contentbox>{PRIVACY_POLICY}</Contentbox>

--- a/src/views/ApplyPage/components/CommonSection/index.tsx
+++ b/src/views/ApplyPage/components/CommonSection/index.tsx
@@ -1,5 +1,3 @@
-import { UseFormReturn } from 'react-hook-form';
-
 import Textarea from '@components/Textarea';
 import { Answers, Questions } from 'views/ApplyPage/types';
 
@@ -12,13 +10,9 @@ interface CommonSectionProps {
   refCallback: (elem: HTMLSelectElement) => void;
   questions?: Questions[];
   commonQuestionsDraft?: Answers[];
-  formObject: Pick<
-    UseFormReturn,
-    'register' | 'formState' | 'watch' | 'clearErrors' | 'trigger' | 'setValue' | 'getValues'
-  >;
 }
 
-const CommonSection = ({ isReview, refCallback, questions, commonQuestionsDraft, formObject }: CommonSectionProps) => {
+const CommonSection = ({ isReview, refCallback, questions, commonQuestionsDraft }: CommonSectionProps) => {
   const commonQuestionsById = commonQuestionsDraft?.reduce(
     (acc, draft) => {
       acc ? (acc[draft.id] = draft) : undefined;
@@ -40,11 +34,10 @@ const CommonSection = ({ isReview, refCallback, questions, commonQuestionsDraft,
             <Textarea
               name={`common${id}`}
               defaultValue={defaultValue}
-              formObject={formObject}
               maxCount={charLimit}
               extraInput={
                 isFile ? (
-                  <FileInput id={id} isReview={isReview} formObject={formObject} defaultFile={defaultFile} />
+                  <FileInput id={id} isReview={isReview} defaultFile={defaultFile} />
                 ) : urls ? (
                   <LinkInput urls={urls} />
                 ) : null

--- a/src/views/ApplyPage/components/DefaultSection/components/Postcode/index.tsx
+++ b/src/views/ApplyPage/components/DefaultSection/components/Postcode/index.tsx
@@ -1,22 +1,18 @@
 import { useState } from 'react';
 import { Address } from 'react-daum-postcode';
-import { UseFormReturn } from 'react-hook-form';
+import { useFormContext } from 'react-hook-form';
 
 import { InputLine, TextBox } from '@components/Input';
 
 interface PostcodeProps {
   disabled: boolean;
   addressDraft?: string;
-  formObject: Pick<
-    UseFormReturn,
-    'register' | 'formState' | 'clearErrors' | 'trigger' | 'watch' | 'setValue' | 'getValues' | 'setError'
-  >;
 }
 
-const Postcode = ({ disabled, addressDraft, formObject }: PostcodeProps) => {
+const Postcode = ({ disabled, addressDraft }: PostcodeProps) => {
   const [address, setAddress] = useState('');
 
-  const { clearErrors } = formObject;
+  const { clearErrors } = useFormContext();
 
   const handleOpenPostcode = () => {
     window.daum &&
@@ -36,7 +32,7 @@ const Postcode = ({ disabled, addressDraft, formObject }: PostcodeProps) => {
   };
 
   return (
-    <TextBox label="거주지" name="address" formObject={formObject} required size="lg">
+    <TextBox label="거주지" name="address" required size="lg">
       <InputLine
         name="address"
         placeholder="예) 서울특별시 관악구 신림동"

--- a/src/views/ApplyPage/components/DefaultSection/index.tsx
+++ b/src/views/ApplyPage/components/DefaultSection/index.tsx
@@ -1,5 +1,5 @@
 import { ChangeEvent, useState } from 'react';
-import { UseFormReturn } from 'react-hook-form';
+import { useFormContext } from 'react-hook-form';
 
 import { InputLine, TextBox } from '@components/Input';
 import Radio from '@components/Radio';
@@ -26,19 +26,15 @@ import {
 interface ProfileImageProps {
   disabled: boolean;
   pic?: string;
-  formObject: Pick<
-    UseFormReturn,
-    'register' | 'formState' | 'clearErrors' | 'trigger' | 'watch' | 'setValue' | 'getValues' | 'setError'
-  >;
 }
 
-const ProfileImage = ({ disabled, pic, formObject }: ProfileImageProps) => {
+const ProfileImage = ({ disabled, pic }: ProfileImageProps) => {
   const {
     register,
     clearErrors,
     setValue,
     formState: { errors },
-  } = formObject;
+  } = useFormContext();
   const [image, setImage] = useState('');
   const [isFileSizeExceeded, setIsFileSizeExceeded] = useState('');
   const isError = isFileSizeExceeded || errors.picture;
@@ -77,7 +73,7 @@ const ProfileImage = ({ disabled, pic, formObject }: ProfileImageProps) => {
   };
 
   return (
-    <TextBox label="사진" name="picture" formObject={formObject} size="lg" required>
+    <TextBox label="사진" name="picture" size="lg" required>
       <div className={profileWrapper}>
         <input
           id="picture"
@@ -112,13 +108,9 @@ interface DefaultSectionProps {
   isReview: boolean;
   refCallback?: (elem: HTMLSelectElement) => void;
   applicantDraft?: Applicant;
-  formObject: Pick<
-    UseFormReturn,
-    'register' | 'formState' | 'clearErrors' | 'trigger' | 'watch' | 'setValue' | 'getValues' | 'setError'
-  >;
 }
 
-const DefaultSection = ({ isReview, refCallback, applicantDraft, formObject }: DefaultSectionProps) => {
+const DefaultSection = ({ isReview, refCallback, applicantDraft }: DefaultSectionProps) => {
   const {
     address,
     birthday,
@@ -138,9 +130,9 @@ const DefaultSection = ({ isReview, refCallback, applicantDraft, formObject }: D
   return (
     <section ref={refCallback} id="default" className={sectionContainer}>
       <h2 className={title}>기본 인적사항</h2>
-      <ProfileImage pic={pic} formObject={formObject} disabled={isReview} />
+      <ProfileImage pic={pic} disabled={isReview} />
       <div className={doubleWrapper}>
-        <TextBox label="이름" name="name" formObject={formObject} required size="sm">
+        <TextBox label="이름" name="name" required size="sm">
           <InputLine value={name} name="name" readOnly disabled={isReview} />
         </TextBox>
         <SelectBox
@@ -149,13 +141,12 @@ const DefaultSection = ({ isReview, refCallback, applicantDraft, formObject }: D
           label="성별"
           name="gender"
           options={SELECT_OPTIONS.성별}
-          formObject={formObject}
           required
           disabled={isReview}
         />
       </div>
       <div className={doubleWrapper}>
-        <TextBox label="생년월일" name="birthday" formObject={formObject} required size="sm">
+        <TextBox label="생년월일" name="birthday" required size="sm">
           <InputLine
             name="birthday"
             placeholder="YYYY/MM/DD"
@@ -169,15 +160,15 @@ const DefaultSection = ({ isReview, refCallback, applicantDraft, formObject }: D
             disabled={isReview}
           />
         </TextBox>
-        <TextBox label="연락처" name="phone" formObject={formObject} required size="sm">
+        <TextBox label="연락처" name="phone" required size="sm">
           <InputLine value={phone} name="phone" readOnly disabled={isReview} />
         </TextBox>
       </div>
-      <TextBox label="이메일" name="email" formObject={formObject} required size="lg">
+      <TextBox label="이메일" name="email" required size="lg">
         <InputLine value={email} name="email" readOnly disabled={isReview} />
       </TextBox>
-      <Postcode addressDraft={address} formObject={formObject} disabled={isReview} />
-      <TextBox label="지하철역" name="nearestStation" formObject={formObject} required size="lg">
+      <Postcode addressDraft={address} disabled={isReview} />
+      <TextBox label="지하철역" name="nearestStation" required size="lg">
         <InputLine
           defaultValue={nearestStation}
           name="nearestStation"
@@ -189,7 +180,7 @@ const DefaultSection = ({ isReview, refCallback, applicantDraft, formObject }: D
         />
       </TextBox>
       <div className={doubleWrapper}>
-        <TextBox label="학교" name="college" formObject={formObject} required size="sm">
+        <TextBox label="학교" name="college" required size="sm">
           <InputLine
             defaultValue={college}
             name="college"
@@ -203,7 +194,6 @@ const DefaultSection = ({ isReview, refCallback, applicantDraft, formObject }: D
         <div style={{ margin: '52px 0 0 22px' }}>
           <Radio
             defaultValue={leaveAbsence == undefined ? undefined : leaveAbsence ? '휴학 ‧ 수료 ‧ 유예 ‧ 졸업' : '재학'}
-            formObject={formObject}
             label={['재학', '휴학 ‧ 수료 ‧ 유예 ‧ 졸업']}
             name="leaveAbsence"
             required
@@ -212,7 +202,7 @@ const DefaultSection = ({ isReview, refCallback, applicantDraft, formObject }: D
         </div>
       </div>
       <div className={doubleWrapper}>
-        <TextBox label="학과" name="major" formObject={formObject} required size="sm">
+        <TextBox label="학과" name="major" required size="sm">
           <InputLine
             defaultValue={major}
             name="major"
@@ -229,7 +219,6 @@ const DefaultSection = ({ isReview, refCallback, applicantDraft, formObject }: D
           name="univYear"
           placeholder="학년을 선택해주세요."
           options={SELECT_OPTIONS.학년}
-          formObject={formObject}
           required
           disabled={isReview}
         />
@@ -240,7 +229,6 @@ const DefaultSection = ({ isReview, refCallback, applicantDraft, formObject }: D
         name="mostRecentSeason"
         placeholder="가장 최근에 활동했던 기수를 선택해주세요."
         options={SELECT_OPTIONS.이전기수}
-        formObject={formObject}
         required
         size="lg"
         disabled={isReview}

--- a/src/views/ApplyPage/components/FileInput/index.tsx
+++ b/src/views/ApplyPage/components/FileInput/index.tsx
@@ -1,6 +1,6 @@
 import { nanoid } from 'nanoid';
 import { ChangeEvent, useEffect, useRef, useState } from 'react';
-import { UseFormReturn } from 'react-hook-form';
+import { useFormContext } from 'react-hook-form';
 
 import 'firebase/compat/storage';
 import { STATE_CHANGED, storage } from '@constants/firebase.ts';
@@ -12,23 +12,21 @@ interface FileInputProps {
   id: number;
   isReview: boolean;
   disabled?: boolean;
-  formObject: Pick<
-    UseFormReturn,
-    'register' | 'formState' | 'watch' | 'clearErrors' | 'trigger' | 'setValue' | 'getValues'
-  >;
   defaultFile?: { id: number; file?: string; fileName?: string };
 }
 
 const LIMIT_SIZE = 1024 ** 2 * 50; // 50MB
 const ACCEPTED_FORMATS = '.pdf, .pptx';
 
-const FileInput = ({ id, isReview, disabled, formObject, defaultFile }: FileInputProps) => {
+const FileInput = ({ id, isReview, disabled, defaultFile }: FileInputProps) => {
   const [isError, setIsError] = useState(false);
   const [uploadPercent, setUploadPercent] = useState(-1);
   const [file, setFile] = useState<File | null>(null);
+
   const fileName = file ? file.name : '';
   const inputRef = useRef<HTMLInputElement>(null);
-  const { register, setValue, getValues } = formObject;
+
+  const { register, setValue, getValues } = useFormContext();
   const { id: defaultFileId, file: defaultFileUrl, fileName: defaultFileName } = defaultFile || {};
 
   const handleFileUpload = (file: File, id: number) => {

--- a/src/views/ApplyPage/components/PartSection/index.tsx
+++ b/src/views/ApplyPage/components/PartSection/index.tsx
@@ -1,4 +1,4 @@
-import { UseFormReturn } from 'react-hook-form';
+import { useFormContext } from 'react-hook-form';
 
 import SelectBox from '@components/Select';
 import Textarea from '@components/Textarea';
@@ -19,14 +19,10 @@ interface PartSectionProps {
     questions: Questions[];
   }[];
   partQuestionsDraft?: Answers[];
-  formObject: Pick<
-    UseFormReturn,
-    'register' | 'formState' | 'watch' | 'clearErrors' | 'setValue' | 'getValues' | 'watch' | 'trigger'
-  >;
 }
 
-const PartSection = ({ isReview, refCallback, part, questions, partQuestionsDraft, formObject }: PartSectionProps) => {
-  const { getValues } = formObject;
+const PartSection = ({ isReview, refCallback, part, questions, partQuestionsDraft }: PartSectionProps) => {
+  const { getValues } = useFormContext();
 
   let selectedPart: string = getValues('part');
   if (selectedPart === '기획') selectedPart = 'PM';
@@ -48,7 +44,6 @@ const PartSection = ({ isReview, refCallback, part, questions, partQuestionsDraf
         name="part"
         placeholder="지원하고 싶은 파트를 선택해주세요."
         options={SELECT_OPTIONS.지원파트}
-        formObject={formObject}
         size="lg"
         required
         disabled={isReview}
@@ -63,11 +58,10 @@ const PartSection = ({ isReview, refCallback, part, questions, partQuestionsDraf
             <Textarea
               name={`part${id}`}
               defaultValue={defaultValue}
-              formObject={formObject}
               maxCount={charLimit}
               extraInput={
                 isFile ? (
-                  <FileInput id={id} isReview={isReview} formObject={formObject} defaultFile={defaultFile} />
+                  <FileInput id={id} isReview={isReview} defaultFile={defaultFile} />
                 ) : urls ? (
                   <LinkInput urls={urls} />
                 ) : null

--- a/src/views/ApplyPage/hooks/useGetQuestions.tsx
+++ b/src/views/ApplyPage/hooks/useGetQuestions.tsx
@@ -2,13 +2,14 @@ import { useQuery } from '@tanstack/react-query';
 
 import { getQuestions } from '../apis';
 
-import type { Applicant, ApplyError, QuestionsRequest, QuestionsResponse } from '../types';
+import type { Applicant, QuestionsRequest, QuestionsResponse } from '../types';
+import type { ErrorResponse } from '@type/errorResponse';
 import type { AxiosError, AxiosResponse } from 'axios';
 
 const useGetQuestions = (applicantDraft: Applicant | undefined) => {
   const { data: questionsData, isLoading: questionsIsLoading } = useQuery<
     AxiosResponse<QuestionsResponse, QuestionsRequest>,
-    AxiosError<ApplyError, QuestionsRequest>,
+    AxiosError<ErrorResponse, QuestionsRequest>,
     AxiosResponse<QuestionsResponse, QuestionsRequest>,
     string[]
   >({

--- a/src/views/ApplyPage/hooks/useMutateDraft.tsx
+++ b/src/views/ApplyPage/hooks/useMutateDraft.tsx
@@ -2,13 +2,14 @@ import { useMutation } from '@tanstack/react-query';
 
 import { sendData } from '../apis';
 
-import type { ApplyError, ApplyRequest, ApplyResponse } from '../types';
+import type { ApplyRequest, ApplyResponse } from '../types';
+import type { ErrorResponse } from '@type/errorResponse';
 import type { AxiosError, AxiosResponse } from 'axios';
 
 const useMutateDraft = ({ onSuccess }: { onSuccess: () => void }) => {
   const { mutate: draftMutate, isPending: draftIsPending } = useMutation<
     AxiosResponse<ApplyResponse, ApplyRequest>,
-    AxiosError<ApplyError, ApplyRequest>,
+    AxiosError<ErrorResponse, ApplyRequest>,
     ApplyRequest
   >({
     mutationFn: (formData) => sendData('/recruiting-answer/store', formData),

--- a/src/views/ApplyPage/hooks/useMutateSubmit.tsx
+++ b/src/views/ApplyPage/hooks/useMutateSubmit.tsx
@@ -2,13 +2,14 @@ import { useMutation } from '@tanstack/react-query';
 
 import { sendData } from '../apis';
 
-import type { ApplyError, ApplyRequest, ApplyResponse } from '../types';
+import type { ApplyRequest, ApplyResponse } from '../types';
+import type { ErrorResponse } from '@type/errorResponse';
 import type { AxiosError, AxiosResponse } from 'axios';
 
 const useMutateSubmit = ({ onSuccess }: { onSuccess: () => void }) => {
   const { mutate: submitMutate, isPending: submitIsPending } = useMutation<
     AxiosResponse<ApplyResponse, ApplyRequest>,
-    AxiosError<ApplyError, ApplyRequest>,
+    AxiosError<ErrorResponse, ApplyRequest>,
     ApplyRequest
   >({
     mutationFn: (formData) => sendData('/recruiting-answer', formData),

--- a/src/views/ApplyPage/index.tsx
+++ b/src/views/ApplyPage/index.tsx
@@ -168,39 +168,25 @@ const ApplyPage = ({ isReview, onSetComplete, draftData }: ApplyPageProps) => {
   }, [isReview]);
 
   if (questionsIsLoading || isLoading) return <BigLoading />;
-
   if (!isReview && NoMoreApply) return <NoMore content="모집 기간이 아니에요" />;
 
   let selectedPart: string = getValues('part');
   if (selectedPart === '기획') selectedPart = 'PM';
+
   const selectedPartId = questionTypes?.find((type) => type.typeKr === selectedPart)?.id;
   const partQuestionsData = partQuestions?.find((part) => part.recruitingQuestionTypeId === selectedPartId);
   const partQuestionIds = partQuestionsData?.questions.map((question) => question.id);
   const commonQuestionIds = commonQuestions?.questions.map((question) => question.id);
+
   const handleSendData = (type: 'draft' | 'submit') => {
     const mostRecentSeason = mostRecentSeasonValue === '해당사항 없음' ? 0 : mostRecentSeasonValue;
     const leaveAbsence =
       leaveAbsenceValue === '재학' ? false : leaveAbsenceValue === '휴학 ‧ 수료 ‧ 유예 ‧ 졸업' ? true : undefined;
-    const univYear =
-      univYearValue === '1학년'
-        ? 1
-        : univYearValue === '2학년'
-          ? 2
-          : univYearValue === '3학년'
-            ? 3
-            : univYearValue === '4학년'
-              ? 4
-              : univYearValue === '수료 ‧ 유예 ‧ 졸업'
-                ? 5
-                : undefined;
+    const univYear = ['1학년', '2학년', '3학년', '4학년', '수료 ‧ 유예 ‧ 졸업'].indexOf(univYearValue) + 1 || undefined;
 
-    const fileValues: { file: string; fileName: string; recruitingQuestionId: number }[] = [];
-
-    for (const key in getValues()) {
-      if (key.startsWith('file') && getValues()[key] != undefined) {
-        fileValues.push(getValues()[key]);
-      }
-    }
+    const fileValues: { file: string; fileName: string; recruitingQuestionId: number }[] = Object.values(
+      getValues(),
+    ).filter((value) => typeof value === 'object' && value !== null);
 
     let answersValue: { recruitingQuestionId: number; answer: string; file?: string; fileName?: string }[] = [];
 
@@ -215,6 +201,7 @@ const ApplyPage = ({ isReview, onSetComplete, draftData }: ApplyPageProps) => {
             fileName: fileObject ? fileObject.fileName : undefined,
           };
         }) ?? [];
+
       const partAnswers =
         partQuestionIds?.map((id) => {
           const fileObject = fileValues?.find((obj) => obj.recruitingQuestionId === id);
@@ -260,12 +247,6 @@ const ApplyPage = ({ isReview, onSetComplete, draftData }: ApplyPageProps) => {
       answers,
       willAppjam: false,
     };
-
-    for (const key in getValues()) {
-      if (key.startsWith('file')) {
-        formValues[key] = getValues()[key];
-      }
-    }
 
     type === 'draft' ? draftMutate(formValues) : submitMutate(formValues);
   };

--- a/src/views/ApplyPage/index.tsx
+++ b/src/views/ApplyPage/index.tsx
@@ -94,18 +94,15 @@ const ApplyPage = ({ isReview, onSetComplete, draftData }: ApplyPageProps) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [applicantDraft]);
 
-  const refCallback = useCallback(
-    (element: HTMLSelectElement) => {
-      if (element) {
-        sectionsRef.current.push(element);
+  const refCallback = useCallback((element: HTMLSelectElement) => {
+    if (element) {
+      sectionsRef.current.push(element);
 
-        if (sectionsRef.current.length === 3) {
-          setSectionsUpdated(true);
-        }
+      if (sectionsRef.current.length === 3) {
+        setSectionsUpdated(true);
       }
-    },
-    [sectionsRef],
-  );
+    }
+  }, []);
 
   useEffect(() => {
     if (!sectionsUpdated) return;

--- a/src/views/ApplyPage/index.tsx
+++ b/src/views/ApplyPage/index.tsx
@@ -19,7 +19,7 @@ import useGetQuestions from './hooks/useGetQuestions';
 import useMutateDraft from './hooks/useMutateDraft';
 import useMutateSubmit from './hooks/useMutateSubmit';
 import useScrollToHash from './hooks/useScrollToHash';
-import { buttonWrapper, formContainer, sectionContainer } from './style.css';
+import { buttonWrapper, container, formContainer } from './style.css';
 
 import type { ApplyRequest, ApplyResponse } from './types';
 
@@ -272,7 +272,7 @@ const ApplyPage = ({ isReview, onSetComplete, draftData }: ApplyPageProps) => {
           submitDialog.current?.close();
         }}
       />
-      <form onSubmit={handleSubmit(handleApplySubmit)} className={formContainer}>
+      <div className={container}>
         <ApplyHeader
           isReview={isReview}
           isLoading={draftIsPending || submitIsPending}
@@ -280,7 +280,7 @@ const ApplyPage = ({ isReview, onSetComplete, draftData }: ApplyPageProps) => {
         />
         <ApplyInfo isReview={isReview} />
         <ApplyCategory minIndex={minIndex} />
-        <div className={sectionContainer}>
+        <form onSubmit={handleSubmit(handleApplySubmit)} className={formContainer}>
           <DefaultSection
             isReview={isReview}
             refCallback={refCallback}
@@ -316,8 +316,8 @@ const ApplyPage = ({ isReview, onSetComplete, draftData }: ApplyPageProps) => {
               </Button>
             </div>
           )}
-        </div>
-      </form>
+        </form>
+      </div>
     </>
   );
 };

--- a/src/views/ApplyPage/index.tsx
+++ b/src/views/ApplyPage/index.tsx
@@ -126,6 +126,10 @@ const ApplyPage = ({ isReview, onSetComplete, draftData }: ApplyPageProps) => {
     sectionsRef.current.forEach((section) => {
       observer.observe(section);
     });
+
+    return () => {
+      sectionsRef.current.forEach((section) => observer.unobserve(section));
+    };
   }, [sectionsUpdated]);
 
   useEffect(() => {

--- a/src/views/ApplyPage/index.tsx
+++ b/src/views/ApplyPage/index.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { useForm } from 'react-hook-form';
+import { FormProvider, useForm } from 'react-hook-form';
 import { useNavigate } from 'react-router-dom';
 
 import Button from '@components/Button';
@@ -56,13 +56,14 @@ const ApplyPage = ({ isReview, onSetComplete, draftData }: ApplyPageProps) => {
   const { draftMutate, draftIsPending } = useMutateDraft({ onSuccess: () => draftDialog.current?.showModal() });
   const { submitMutate, submitIsPending } = useMutateSubmit({ onSuccess: onSetComplete });
 
-  const { handleSubmit, ...formObject } = useForm({ mode: 'onBlur' });
+  const methods = useForm({ mode: 'onBlur' });
   const {
+    handleSubmit,
     getValues,
     setValue,
     formState: { errors },
     clearErrors,
-  } = formObject;
+  } = methods;
 
   const {
     address,
@@ -256,7 +257,7 @@ const ApplyPage = ({ isReview, onSetComplete, draftData }: ApplyPageProps) => {
   };
 
   return (
-    <>
+    <FormProvider {...methods}>
       <DraftDialog ref={draftDialog} />
       <SubmitDialog
         userInfo={{
@@ -281,18 +282,12 @@ const ApplyPage = ({ isReview, onSetComplete, draftData }: ApplyPageProps) => {
         <ApplyInfo isReview={isReview} />
         <ApplyCategory minIndex={minIndex} />
         <form onSubmit={handleSubmit(handleApplySubmit)} className={formContainer}>
-          <DefaultSection
-            isReview={isReview}
-            refCallback={refCallback}
-            applicantDraft={applicantDraft}
-            formObject={formObject}
-          />
+          <DefaultSection isReview={isReview} refCallback={refCallback} applicantDraft={applicantDraft} />
           <CommonSection
             isReview={isReview}
             refCallback={refCallback}
             questions={commonQuestions?.questions}
             commonQuestionsDraft={commonQuestionsDraft}
-            formObject={formObject}
           />
           <PartSection
             isReview={isReview}
@@ -300,9 +295,8 @@ const ApplyPage = ({ isReview, onSetComplete, draftData }: ApplyPageProps) => {
             part={applicantDraft?.part}
             questions={partQuestions}
             partQuestionsDraft={partQuestionsDraft}
-            formObject={formObject}
           />
-          <BottomSection isReview={isReview} knownPath={applicantDraft?.knownPath} formObject={formObject} />
+          <BottomSection isReview={isReview} knownPath={applicantDraft?.knownPath} />
           {!isReview && (
             <div className={buttonWrapper}>
               <Button
@@ -318,7 +312,7 @@ const ApplyPage = ({ isReview, onSetComplete, draftData }: ApplyPageProps) => {
           )}
         </form>
       </div>
-    </>
+    </FormProvider>
   );
 };
 

--- a/src/views/ApplyPage/style.css.ts
+++ b/src/views/ApplyPage/style.css.ts
@@ -1,14 +1,14 @@
 import { style } from '@vanilla-extract/css';
 
 // ApplyPage.tsx
-export const formContainer = style({
+export const container = style({
   display: 'flex',
   flexDirection: 'column',
   justifyContent: 'center',
   alignItems: 'center',
 });
 
-export const sectionContainer = style({
+export const formContainer = style({
   display: 'flex',
   flexDirection: 'column',
   gap: 50,

--- a/src/views/ApplyPage/types.ts
+++ b/src/views/ApplyPage/types.ts
@@ -52,11 +52,6 @@ export interface QuestionsResponse {
   }[];
 }
 
-export interface ApplyError {
-  err: boolean;
-  userMessage: string;
-}
-
 export interface Applicant {
   id: number;
   group: string;

--- a/src/views/MyPage/hooks/useGetMyInfo.tsx
+++ b/src/views/MyPage/hooks/useGetMyInfo.tsx
@@ -2,13 +2,14 @@ import { useQuery } from '@tanstack/react-query';
 
 import { getMyInfo } from '../apis';
 
-import type { MyError, MyResponse } from '../types';
+import type { MyResponse } from '../types';
+import type { ErrorResponse } from '@type/errorResponse';
 import type { AxiosError, AxiosResponse } from 'axios';
 
 const useGetMyInfo = () => {
   const { data: myInfoData, isLoading: myInfoIsLoading } = useQuery<
     AxiosResponse<MyResponse, null>,
-    AxiosError<MyError, null>,
+    AxiosError<ErrorResponse, null>,
     AxiosResponse<MyResponse, null>,
     string[]
   >({

--- a/src/views/MyPage/types.ts
+++ b/src/views/MyPage/types.ts
@@ -5,11 +5,6 @@ export interface MyRequest {
   password: string;
 }
 
-export interface MyError {
-  err: boolean;
-  userMessage: string;
-}
-
 export interface MyResponse {
   err: boolean;
   season: number;

--- a/src/views/PasswordPage/components/PasswordForm/index.tsx
+++ b/src/views/PasswordPage/components/PasswordForm/index.tsx
@@ -8,12 +8,9 @@ import useMutateChangePassword from 'views/PasswordPage/hooks/useMutateChangePas
 
 import { formWrapper } from './style.css';
 
-interface PasswordFormProps {
-  season?: number;
-  group?: string;
-}
+import type { SeasonGroupType } from '@type/seasonAndGroup';
 
-const PasswordForm = ({ season, group }: PasswordFormProps) => {
+const PasswordForm = ({ season, group }: SeasonGroupType) => {
   const { isVerified, handleVerified } = useVerificationStatus();
   const { handleSubmit, ...formObject } = useForm({ mode: 'onBlur' });
   const { setError } = formObject;

--- a/src/views/PasswordPage/components/PasswordForm/index.tsx
+++ b/src/views/PasswordPage/components/PasswordForm/index.tsx
@@ -1,4 +1,4 @@
-import { useForm, type FieldValues } from 'react-hook-form';
+import { FormProvider, useForm, type FieldValues } from 'react-hook-form';
 
 import Button from '@components/Button';
 import { TextBox비밀번호, TextBox이름, TextBox이메일 } from '@components/Input/InputTheme';
@@ -12,8 +12,8 @@ import type { SeasonGroupType } from '@type/seasonAndGroup';
 
 const PasswordForm = ({ season, group }: SeasonGroupType) => {
   const { isVerified, handleVerified } = useVerificationStatus();
-  const { handleSubmit, ...formObject } = useForm({ mode: 'onBlur' });
-  const { setError } = formObject;
+  const methods = useForm({ mode: 'onBlur' });
+  const { handleSubmit, setError } = methods;
 
   const { changePasswordMutate, changePasswordIsPending } = useMutateChangePassword();
 
@@ -39,23 +39,24 @@ const PasswordForm = ({ season, group }: SeasonGroupType) => {
   };
 
   return (
-    <form noValidate onSubmit={handleSubmit(handleChangePassword)} className={formWrapper}>
-      <TextBox이름 formObject={formObject} />
-      <TextBox이메일
-        recruitingInfo={{ season, group }}
-        isVerified={isVerified}
-        onChangeVerification={handleVerified}
-        formObject={formObject}
-      />
-      {isVerified && (
-        <>
-          <TextBox비밀번호 formObject={formObject} />
-          <Button isLoading={changePasswordIsPending} type="submit" style={{ marginTop: 30 }}>
-            저장하기
-          </Button>
-        </>
-      )}
-    </form>
+    <FormProvider {...methods}>
+      <form noValidate onSubmit={handleSubmit(handleChangePassword)} className={formWrapper}>
+        <TextBox이름 />
+        <TextBox이메일
+          recruitingInfo={{ season, group }}
+          isVerified={isVerified}
+          onChangeVerification={handleVerified}
+        />
+        {isVerified && (
+          <>
+            <TextBox비밀번호 />
+            <Button isLoading={changePasswordIsPending} type="submit" style={{ marginTop: 30 }}>
+              저장하기
+            </Button>
+          </>
+        )}
+      </form>
+    </FormProvider>
   );
 };
 

--- a/src/views/PasswordPage/components/PasswordForm/index.tsx
+++ b/src/views/PasswordPage/components/PasswordForm/index.tsx
@@ -1,0 +1,65 @@
+import { useForm, type FieldValues } from 'react-hook-form';
+
+import Button from '@components/Button';
+import { TextBox비밀번호, TextBox이름, TextBox이메일 } from '@components/Input/InputTheme';
+import { VALIDATION_CHECK } from '@constants/validationCheck';
+import useVerificationStatus from '@hooks/useVerificationStatus';
+import useMutateChangePassword from 'views/PasswordPage/hooks/useMutateChangePassword';
+
+import { formWrapper } from './style.css';
+
+interface PasswordFormProps {
+  season?: number;
+  group?: string;
+}
+
+const PasswordForm = ({ season, group }: PasswordFormProps) => {
+  const { isVerified, handleVerified } = useVerificationStatus();
+  const { handleSubmit, ...formObject } = useForm({ mode: 'onBlur' });
+  const { setError } = formObject;
+
+  const { changePasswordMutate, changePasswordIsPending } = useMutateChangePassword();
+
+  const handleChangePassword = ({ email, newPassword: password, passwordCheck }: FieldValues) => {
+    if (!isVerified) {
+      setError('code', {
+        type: 'not-match',
+        message: VALIDATION_CHECK.verificationCode.errorText,
+      });
+
+      return;
+    }
+
+    if (!season || !group) return;
+
+    changePasswordMutate({
+      email,
+      password,
+      passwordCheck,
+      season,
+      group,
+    });
+  };
+
+  return (
+    <form noValidate onSubmit={handleSubmit(handleChangePassword)} className={formWrapper}>
+      <TextBox이름 formObject={formObject} />
+      <TextBox이메일
+        recruitingInfo={{ season, group }}
+        isVerified={isVerified}
+        onChangeVerification={handleVerified}
+        formObject={formObject}
+      />
+      {isVerified && (
+        <>
+          <TextBox비밀번호 formObject={formObject} />
+          <Button isLoading={changePasswordIsPending} type="submit" style={{ marginTop: 30 }}>
+            저장하기
+          </Button>
+        </>
+      )}
+    </form>
+  );
+};
+
+export default PasswordForm;

--- a/src/views/PasswordPage/components/PasswordForm/style.css.ts
+++ b/src/views/PasswordPage/components/PasswordForm/style.css.ts
@@ -1,0 +1,7 @@
+import { style } from '@vanilla-extract/css';
+
+export const formWrapper = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 50,
+});

--- a/src/views/PasswordPage/hooks/useMutateChangePassword.tsx
+++ b/src/views/PasswordPage/hooks/useMutateChangePassword.tsx
@@ -4,14 +4,15 @@ import { useNavigate } from 'react-router-dom';
 
 import { sendPasswordChange } from '../apis';
 
-import type { PasswordError, PasswordRequest, PasswordResponse } from '../types';
+import type { PasswordRequest, PasswordResponse } from '../types';
+import type { ErrorResponse } from '@type/errorResponse';
 
 const useMutateChangePassword = () => {
   const navigate = useNavigate();
 
   const { mutate: changePasswordMutate, isPending: changePasswordIsPending } = useMutation<
     AxiosResponse<PasswordResponse, PasswordRequest>,
-    AxiosError<PasswordError, PasswordRequest>,
+    AxiosError<ErrorResponse, PasswordRequest>,
     PasswordRequest
   >({
     mutationFn: (userInfo: PasswordRequest) => sendPasswordChange(userInfo),

--- a/src/views/PasswordPage/index.tsx
+++ b/src/views/PasswordPage/index.tsx
@@ -1,70 +1,23 @@
-import { FieldValues, useForm } from 'react-hook-form';
-
-import Button from '@components/Button';
-import { TextBox비밀번호, TextBox이름, TextBox이메일 } from '@components/Input/InputTheme';
 import Title from '@components/Title';
-import { VALIDATION_CHECK } from '@constants/validationCheck';
 import useDate from '@hooks/useDate';
-import useVerificationStatus from '@hooks/useVerificationStatus';
 import NoMore from 'views/ErrorPage/components/NoMore';
 import BigLoading from 'views/loadings/BigLoding';
 
-import useMutateChangePassword from './hooks/useMutateChangePassword';
+import PasswordForm from './components/PasswordForm';
 import { container } from './style.css';
 
 const PasswordPage = () => {
-  const { isVerified, handleVerified } = useVerificationStatus();
-  const { handleSubmit, ...formObject } = useForm({ mode: 'onBlur' });
   const { season, group, NoMoreRecruit, isLoading } = useDate();
-
-  const { setError } = formObject;
-
-  const { changePasswordMutate, changePasswordIsPending } = useMutateChangePassword();
-
-  const handleChangePassword = ({ email, newPassword: password, passwordCheck }: FieldValues) => {
-    if (!isVerified) {
-      setError('code', {
-        type: 'not-match',
-        message: VALIDATION_CHECK.verificationCode.errorText,
-      });
-
-      return;
-    }
-
-    if (!season || !group) return;
-
-    changePasswordMutate({
-      email,
-      password,
-      passwordCheck,
-      season,
-      group,
-    });
-  };
 
   if (isLoading) return <BigLoading />;
 
   if (NoMoreRecruit) return <NoMore content="모집 기간이 아니에요" />;
 
   return (
-    <form noValidate onSubmit={handleSubmit(handleChangePassword)} className={container}>
+    <div className={container}>
       <Title>비밀번호 재설정하기</Title>
-      <TextBox이름 formObject={formObject} />
-      <TextBox이메일
-        recruitingInfo={{ season, group }}
-        isVerified={isVerified}
-        onChangeVerification={handleVerified}
-        formObject={formObject}
-      />
-      {isVerified && (
-        <>
-          <TextBox비밀번호 formObject={formObject} />
-          <Button isLoading={changePasswordIsPending} type="submit" style={{ marginTop: 30 }}>
-            저장하기
-          </Button>
-        </>
-      )}
-    </form>
+      <PasswordForm season={season} group={group} />
+    </div>
   );
 };
 

--- a/src/views/ResultPage/hooks/useGetFinalResult.tsx
+++ b/src/views/ResultPage/hooks/useGetFinalResult.tsx
@@ -2,13 +2,14 @@ import { useQuery } from '@tanstack/react-query';
 
 import { getFinalResult } from '../apis';
 
-import type { FinalResultResponse, MyError } from '../../MyPage/types';
+import type { FinalResultResponse } from '../../MyPage/types';
+import type { ErrorResponse } from '@type/errorResponse';
 import type { AxiosError, AxiosResponse } from 'axios';
 
 const useGetFinalResult = () => {
   const { data: finalResult, isLoading: finalResultIsLoading } = useQuery<
     AxiosResponse<FinalResultResponse, null>,
-    AxiosError<MyError, null>,
+    AxiosError<ErrorResponse, null>,
     AxiosResponse<FinalResultResponse, null>,
     string[]
   >({

--- a/src/views/ResultPage/hooks/useGetScreeningResult.tsx
+++ b/src/views/ResultPage/hooks/useGetScreeningResult.tsx
@@ -2,13 +2,14 @@ import { useQuery } from '@tanstack/react-query';
 
 import { getScreeningResult } from '../apis';
 
-import type { MyError, ScreeningResultResponse } from '../../MyPage/types';
+import type { ScreeningResultResponse } from '../../MyPage/types';
+import type { ErrorResponse } from '@type/errorResponse';
 import type { AxiosError, AxiosResponse } from 'axios';
 
 const useGetScreeningResult = () => {
   const { data: screeningResult, isLoading: screeningResultIsLoading } = useQuery<
     AxiosResponse<ScreeningResultResponse, null>,
-    AxiosError<MyError, null>,
+    AxiosError<ErrorResponse, null>,
     AxiosResponse<ScreeningResultResponse, null>,
     string[]
   >({

--- a/src/views/SignInPage/components/SignInForm/index.tsx
+++ b/src/views/SignInPage/components/SignInForm/index.tsx
@@ -8,12 +8,9 @@ import useMutateSignIn from 'views/SignInPage/hooks/useMutateSignIn';
 
 import { inputWrapper, newPasswordButton } from './style.css';
 
-interface SignInFormProps {
-  season?: number;
-  group?: string;
-}
+import type { SeasonGroupType } from '@type/seasonAndGroup';
 
-const SignInForm = ({ season, group }: SignInFormProps) => {
+const SignInForm = ({ season, group }: SeasonGroupType) => {
   const { handleSubmit, ...formObject } = useForm({ mode: 'onBlur' });
   const { setError } = formObject;
   const { signInMutate, signInIsPending } = useMutateSignIn({

--- a/src/views/SignInPage/components/SignInForm/index.tsx
+++ b/src/views/SignInPage/components/SignInForm/index.tsx
@@ -1,4 +1,4 @@
-import { type FieldValues, useForm } from 'react-hook-form';
+import { type FieldValues, FormProvider, useForm } from 'react-hook-form';
 import { Link } from 'react-router-dom';
 
 import Button from '@components/Button';
@@ -11,8 +11,8 @@ import { inputWrapper, newPasswordButton } from './style.css';
 import type { SeasonGroupType } from '@type/seasonAndGroup';
 
 const SignInForm = ({ season, group }: SeasonGroupType) => {
-  const { handleSubmit, ...formObject } = useForm({ mode: 'onBlur' });
-  const { setError } = formObject;
+  const methods = useForm({ mode: 'onBlur' });
+  const { handleSubmit, setError } = methods;
   const { signInMutate, signInIsPending } = useMutateSignIn({
     onSetError: (name, type, message) => setError(name, { type, message }),
   });
@@ -29,37 +29,39 @@ const SignInForm = ({ season, group }: SeasonGroupType) => {
   };
 
   return (
-    <form noValidate onSubmit={handleSubmit(handleSignIn)} className={inputWrapper}>
-      <TextBox label="이메일" name="email" formObject={formObject} required>
-        <InputLine
-          name="email"
-          placeholder="이메일을 입력해주세요"
-          type="email"
-          pattern={VALIDATION_CHECK.email.pattern}
-          maxLength={VALIDATION_CHECK.email.maxLength}
-          errorText={VALIDATION_CHECK.email.errorText}
-        />
-      </TextBox>
-      <TextBox label="비밀번호" name="password" formObject={formObject} required>
-        <InputLine
-          name="password"
-          placeholder="비밀번호를 입력해주세요"
-          type="password"
-          pattern={VALIDATION_CHECK.password.pattern}
-          maxLength={VALIDATION_CHECK.password.maxLength}
-          errorText={VALIDATION_CHECK.password.errorText}
-        />
-        <Description>
-          <p>비밀번호를 잃어버리셨나요?</p>
-          <Link className={newPasswordButton} to="/password">
-            비밀번호 재설정하기
-          </Link>
-        </Description>
-      </TextBox>
-      <Button isLoading={signInIsPending} type="submit">
-        로그인
-      </Button>
-    </form>
+    <FormProvider {...methods}>
+      <form noValidate onSubmit={handleSubmit(handleSignIn)} className={inputWrapper}>
+        <TextBox label="이메일" name="email" required>
+          <InputLine
+            name="email"
+            placeholder="이메일을 입력해주세요"
+            type="email"
+            pattern={VALIDATION_CHECK.email.pattern}
+            maxLength={VALIDATION_CHECK.email.maxLength}
+            errorText={VALIDATION_CHECK.email.errorText}
+          />
+        </TextBox>
+        <TextBox label="비밀번호" name="password" required>
+          <InputLine
+            name="password"
+            placeholder="비밀번호를 입력해주세요"
+            type="password"
+            pattern={VALIDATION_CHECK.password.pattern}
+            maxLength={VALIDATION_CHECK.password.maxLength}
+            errorText={VALIDATION_CHECK.password.errorText}
+          />
+          <Description>
+            <p>비밀번호를 잃어버리셨나요?</p>
+            <Link className={newPasswordButton} to="/password">
+              비밀번호 재설정하기
+            </Link>
+          </Description>
+        </TextBox>
+        <Button isLoading={signInIsPending} type="submit">
+          로그인
+        </Button>
+      </form>
+    </FormProvider>
   );
 };
 

--- a/src/views/SignInPage/components/SignInForm/index.tsx
+++ b/src/views/SignInPage/components/SignInForm/index.tsx
@@ -1,0 +1,69 @@
+import { type FieldValues, useForm } from 'react-hook-form';
+import { Link } from 'react-router-dom';
+
+import Button from '@components/Button';
+import { Description, InputLine, TextBox } from '@components/Input';
+import { VALIDATION_CHECK } from '@constants/validationCheck';
+import useMutateSignIn from 'views/SignInPage/hooks/useMutateSignIn';
+
+import { inputWrapper, newPasswordButton } from './style.css';
+
+interface SignInFormProps {
+  season?: number;
+  group?: string;
+}
+
+const SignInForm = ({ season, group }: SignInFormProps) => {
+  const { handleSubmit, ...formObject } = useForm({ mode: 'onBlur' });
+  const { setError } = formObject;
+  const { signInMutate, signInIsPending } = useMutateSignIn({
+    onSetError: (name, type, message) => setError(name, { type, message }),
+  });
+
+  const handleSignIn = ({ email, password }: FieldValues) => {
+    if (!season || !group) return;
+
+    signInMutate({
+      email,
+      password,
+      season,
+      group,
+    });
+  };
+
+  return (
+    <form noValidate onSubmit={handleSubmit(handleSignIn)} className={inputWrapper}>
+      <TextBox label="이메일" name="email" formObject={formObject} required>
+        <InputLine
+          name="email"
+          placeholder="이메일을 입력해주세요"
+          type="email"
+          pattern={VALIDATION_CHECK.email.pattern}
+          maxLength={VALIDATION_CHECK.email.maxLength}
+          errorText={VALIDATION_CHECK.email.errorText}
+        />
+      </TextBox>
+      <TextBox label="비밀번호" name="password" formObject={formObject} required>
+        <InputLine
+          name="password"
+          placeholder="비밀번호를 입력해주세요"
+          type="password"
+          pattern={VALIDATION_CHECK.password.pattern}
+          maxLength={VALIDATION_CHECK.password.maxLength}
+          errorText={VALIDATION_CHECK.password.errorText}
+        />
+        <Description>
+          <p>비밀번호를 잃어버리셨나요?</p>
+          <Link className={newPasswordButton} to="/password">
+            비밀번호 재설정하기
+          </Link>
+        </Description>
+      </TextBox>
+      <Button isLoading={signInIsPending} type="submit">
+        로그인
+      </Button>
+    </form>
+  );
+};
+
+export default SignInForm;

--- a/src/views/SignInPage/components/SignInForm/style.css.ts
+++ b/src/views/SignInPage/components/SignInForm/style.css.ts
@@ -1,0 +1,11 @@
+import { style } from '@vanilla-extract/css';
+
+export const inputWrapper = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 50,
+});
+
+export const newPasswordButton = style({
+  borderBottom: '1px solid currentColor',
+});

--- a/src/views/SignInPage/components/SignInInfo/index.tsx
+++ b/src/views/SignInPage/components/SignInInfo/index.tsx
@@ -5,11 +5,9 @@ import Title from '@components/Title';
 
 import { calloutButton, strongText } from './style.css';
 
-interface SignInInfoProps {
-  season?: number;
-}
+import type { SeasonGroupType } from '@type/seasonAndGroup';
 
-const SignInInfo = ({ season }: SignInInfoProps) => {
+const SignInInfo = ({ season }: SeasonGroupType) => {
   return (
     <>
       <Title>{season}기 Makers 지원하기</Title>

--- a/src/views/SignInPage/components/SignInInfo/index.tsx
+++ b/src/views/SignInPage/components/SignInInfo/index.tsx
@@ -1,0 +1,32 @@
+import { Link } from 'react-router-dom';
+
+import Callout from '@components/Callout';
+import Title from '@components/Title';
+
+import { calloutButton, strongText } from './style.css';
+
+interface SignInInfoProps {
+  season?: number;
+}
+
+const SignInInfo = ({ season }: SignInInfoProps) => {
+  return (
+    <>
+      <Title>{season}기 Makers 지원하기</Title>
+      <Callout
+        Button={
+          <Link to="/sign-up" className={calloutButton}>
+            새 지원서 작성하기
+          </Link>
+        }>
+        <p>
+          {season}기 Makers 지원서 작성이 처음이라면 ‘새 지원서 작성하기’를 진행해주세요.{' '}
+          <strong className={strongText}>이전에 지원서 </strong>를 제출한 적이 있더라도{' '}
+          <strong className={strongText}>반드시</strong> 새 지원서를 작성해야 해요.
+        </p>
+      </Callout>
+    </>
+  );
+};
+
+export default SignInInfo;

--- a/src/views/SignInPage/components/SignInInfo/style.css.ts
+++ b/src/views/SignInPage/components/SignInInfo/style.css.ts
@@ -1,0 +1,14 @@
+import { style } from '@vanilla-extract/css';
+
+import { theme } from 'styles/theme.css';
+
+export const calloutButton = style({
+  marginRight: 18,
+  borderBottom: '1px solid currentColor',
+  color: theme.color.lighterText,
+  ...theme.font.TITLE_5_18_SB,
+});
+
+export const strongText = style({
+  fontStyle: 'italic',
+});

--- a/src/views/SignInPage/hooks/useMutateSignIn.tsx
+++ b/src/views/SignInPage/hooks/useMutateSignIn.tsx
@@ -5,7 +5,8 @@ import { VALIDATION_CHECK } from '@constants/validationCheck';
 
 import { sendSignIn } from '../apis';
 
-import type { SignInError, SignInRequest, SignInResponse } from '../types';
+import type { SignInRequest, SignInResponse } from '../types';
+import type { ErrorResponse } from '@type/errorResponse';
 import type { AxiosError, AxiosResponse } from 'axios';
 
 const useMutateSignIn = ({ onSetError }: { onSetError: (name: string, type: string, message: string) => void }) => {
@@ -13,7 +14,7 @@ const useMutateSignIn = ({ onSetError }: { onSetError: (name: string, type: stri
 
   const { mutate: signInMutate, isPending: signInIsPending } = useMutation<
     AxiosResponse<SignInResponse, SignInRequest>,
-    AxiosError<SignInError, SignInRequest>,
+    AxiosError<ErrorResponse, SignInRequest>,
     SignInRequest
   >({
     mutationFn: (userInfo: SignInRequest) => sendSignIn(userInfo),

--- a/src/views/SignInPage/index.tsx
+++ b/src/views/SignInPage/index.tsx
@@ -1,84 +1,21 @@
 import { useContext } from 'react';
-import { FieldValues, useForm } from 'react-hook-form';
-import { Link } from 'react-router-dom';
 
-import Button from '@components/Button';
-import Callout from '@components/Callout';
-import { Description, InputLine, TextBox } from '@components/Input';
-import Title from '@components/Title';
-import { VALIDATION_CHECK } from '@constants/validationCheck';
 import { RecruitingInfoContext } from '@store/recruitingInfoContext';
 
-import useMutateSignIn from './hooks/useMutateSignIn';
-import { calloutButton, container, newPasswordButton, strongText } from './style.css';
+import SignInForm from './components/SignInForm';
+import SignInInfo from './components/SignInInfo';
+import { container } from './style.css';
 
 const SignInPage = () => {
-  const { handleSubmit, ...formObject } = useForm({ mode: 'onBlur' });
-  const { setError } = formObject;
   const {
     recruitingInfo: { season, group },
   } = useContext(RecruitingInfoContext);
 
-  const { signInMutate, signInIsPending } = useMutateSignIn({
-    onSetError: (name, type, message) => setError(name, { type, message }),
-  });
-
-  const handleSignIn = ({ email, password }: FieldValues) => {
-    if (!season || !group) return;
-
-    signInMutate({
-      email,
-      password,
-      season,
-      group,
-    });
-  };
-
   return (
-    <form noValidate onSubmit={handleSubmit(handleSignIn)} className={container}>
-      <Title>{season}기 Makers 지원하기</Title>
-      <Callout
-        Button={
-          <Link to="/sign-up" className={calloutButton}>
-            새 지원서 작성하기
-          </Link>
-        }>
-        <p>
-          {season}기 Makers 지원서 작성이 처음이라면 ‘새 지원서 작성하기’를 진행해주세요.{' '}
-          <strong className={strongText}>이전에 지원서 </strong>를 제출한 적이 있더라도{' '}
-          <strong className={strongText}>반드시</strong> 새 지원서를 작성해야 해요.
-        </p>
-      </Callout>
-      <TextBox label="이메일" name="email" formObject={formObject} required>
-        <InputLine
-          name="email"
-          placeholder="이메일을 입력해주세요"
-          type="email"
-          pattern={VALIDATION_CHECK.email.pattern}
-          maxLength={VALIDATION_CHECK.email.maxLength}
-          errorText={VALIDATION_CHECK.email.errorText}
-        />
-      </TextBox>
-      <TextBox label="비밀번호" name="password" formObject={formObject} required>
-        <InputLine
-          name="password"
-          placeholder="비밀번호를 입력해주세요"
-          type="password"
-          pattern={VALIDATION_CHECK.password.pattern}
-          maxLength={VALIDATION_CHECK.password.maxLength}
-          errorText={VALIDATION_CHECK.password.errorText}
-        />
-        <Description>
-          <p>비밀번호를 잃어버리셨나요?</p>
-          <Link className={newPasswordButton} to="/password">
-            비밀번호 재설정하기
-          </Link>
-        </Description>
-      </TextBox>
-      <Button isLoading={signInIsPending} type="submit">
-        로그인
-      </Button>
-    </form>
+    <div className={container}>
+      <SignInInfo season={season} />
+      <SignInForm season={season} group={group} />
+    </div>
   );
 };
 

--- a/src/views/SignInPage/style.css.ts
+++ b/src/views/SignInPage/style.css.ts
@@ -1,7 +1,5 @@
 import { style } from '@vanilla-extract/css';
 
-import { theme } from 'styles/theme.css';
-
 export const container = style({
   display: 'flex',
   flexDirection: 'column',
@@ -9,19 +7,4 @@ export const container = style({
 
   margin: '90px 0 168px 0',
   width: 466,
-});
-
-export const calloutButton = style({
-  marginRight: 18,
-  borderBottom: '1px solid currentColor',
-  color: theme.color.lighterText,
-  ...theme.font.TITLE_5_18_SB,
-});
-
-export const strongText = style({
-  fontStyle: 'italic',
-});
-
-export const newPasswordButton = style({
-  borderBottom: '1px solid currentColor',
 });

--- a/src/views/SignedInPage/hooks/useGetDraft.tsx
+++ b/src/views/SignedInPage/hooks/useGetDraft.tsx
@@ -2,13 +2,14 @@ import { useQuery } from '@tanstack/react-query';
 
 import { getDraft } from '../apis';
 
-import type { ApplyError, ApplyResponse } from '../../ApplyPage/types';
+import type { ApplyResponse } from '../../ApplyPage/types';
+import type { ErrorResponse } from '@type/errorResponse';
 import type { AxiosError, AxiosResponse } from 'axios';
 
 const useGetDraft = () => {
   const { data: draftData, isLoading: draftIsLoading } = useQuery<
     AxiosResponse<ApplyResponse, null>,
-    AxiosError<ApplyError, null>,
+    AxiosError<ErrorResponse, null>,
     AxiosResponse<ApplyResponse, null>,
     string[]
   >({

--- a/src/views/SignupPage/components/SignupForm/index.tsx
+++ b/src/views/SignupPage/components/SignupForm/index.tsx
@@ -13,12 +13,9 @@ import useMutateSignUp from 'views/SignupPage/hooks/useMutateSignUp';
 
 import { formWrapper } from './style.css';
 
-interface SignupFormProps {
-  season?: number;
-  group?: string;
-}
+import type { SeasonGroupType } from '@type/seasonAndGroup';
 
-const SignupForm = ({ season, group }: SignupFormProps) => {
+const SignupForm = ({ season, group }: SeasonGroupType) => {
   const { isVerified, handleVerified } = useVerificationStatus();
   const { handleSubmit, ...formObject } = useForm({ mode: 'onBlur' }); // 임시
   const {

--- a/src/views/SignupPage/components/SignupForm/index.tsx
+++ b/src/views/SignupPage/components/SignupForm/index.tsx
@@ -1,0 +1,96 @@
+import { useEffect } from 'react';
+import { type FieldValues, useForm } from 'react-hook-form';
+
+import Button from '@components/Button';
+import Checkbox from '@components/Checkbox';
+import Contentbox from '@components/Checkbox/Contentbox';
+import { InputLine, TextBox } from '@components/Input';
+import { TextBox비밀번호, TextBox이름, TextBox이메일 } from '@components/Input/InputTheme';
+import { PRIVACY_POLICY } from '@constants/policy';
+import { VALIDATION_CHECK } from '@constants/validationCheck';
+import useVerificationStatus from '@hooks/useVerificationStatus';
+import useMutateSignUp from 'views/SignupPage/hooks/useMutateSignUp';
+
+import { formWrapper } from './style.css';
+
+interface SignupFormProps {
+  season?: number;
+  group?: string;
+}
+
+const SignupForm = ({ season, group }: SignupFormProps) => {
+  const { isVerified, handleVerified } = useVerificationStatus();
+  const { handleSubmit, ...formObject } = useForm({ mode: 'onBlur' }); // 임시
+  const {
+    setError,
+    setFocus,
+    formState: { errors },
+  } = formObject;
+  const { signUpMutate, signUpIsPending } = useMutateSignUp({
+    onSetError: (name, type, message) => setError(name, { type, message }),
+  });
+
+  const handleSubmitSignUp = ({ email, password, passwordCheck, name, phone }: FieldValues) => {
+    if (!isVerified) {
+      setError('code', {
+        type: 'not-match',
+        message: VALIDATION_CHECK.verificationCode.errorText,
+      });
+
+      return;
+    }
+
+    if (!season || !group) return;
+
+    signUpMutate({
+      email,
+      password,
+      passwordCheck,
+      name,
+      phone,
+      season,
+      group,
+    });
+  };
+
+  useEffect(() => {
+    if (errors.email?.message === VALIDATION_CHECK.email.errorTextExistence) {
+      setFocus('email');
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [errors.email?.message, setFocus]);
+
+  return (
+    <form noValidate onSubmit={handleSubmit(handleSubmitSignUp)} className={formWrapper}>
+      <TextBox이름 formObject={formObject} />
+      <TextBox label="연락처" name="phone" formObject={formObject} required>
+        <InputLine
+          name="phone"
+          placeholder="010-0000-0000"
+          type="tel"
+          pattern={VALIDATION_CHECK.phoneNumber.pattern}
+          maxLength={VALIDATION_CHECK.phoneNumber.maxLength}
+          errorText={VALIDATION_CHECK.phoneNumber.errorText}
+        />
+      </TextBox>
+      <TextBox이메일
+        recruitingInfo={{ season, group }}
+        isVerified={isVerified}
+        onChangeVerification={handleVerified}
+        formObject={formObject}
+      />
+      <TextBox비밀번호 formObject={formObject} />
+      <div>
+        <Checkbox required name="personalInformation" formObject={formObject}>
+          개인정보 수집 ‧ 이용에 동의합니다.
+        </Checkbox>
+        <Contentbox>{PRIVACY_POLICY}</Contentbox>
+      </div>
+      <Button isLoading={signUpIsPending} type="submit" style={{ marginTop: 30 }}>
+        지원서 작성하기
+      </Button>
+    </form>
+  );
+};
+
+export default SignupForm;

--- a/src/views/SignupPage/components/SignupForm/index.tsx
+++ b/src/views/SignupPage/components/SignupForm/index.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { type FieldValues, useForm } from 'react-hook-form';
+import { type FieldValues, FormProvider, useForm } from 'react-hook-form';
 
 import Button from '@components/Button';
 import Checkbox from '@components/Checkbox';
@@ -17,12 +17,13 @@ import type { SeasonGroupType } from '@type/seasonAndGroup';
 
 const SignupForm = ({ season, group }: SeasonGroupType) => {
   const { isVerified, handleVerified } = useVerificationStatus();
-  const { handleSubmit, ...formObject } = useForm({ mode: 'onBlur' }); // 임시
+  const methods = useForm({ mode: 'onBlur' });
   const {
+    handleSubmit,
     setError,
     setFocus,
     formState: { errors },
-  } = formObject;
+  } = methods;
   const { signUpMutate, signUpIsPending } = useMutateSignUp({
     onSetError: (name, type, message) => setError(name, { type, message }),
   });
@@ -58,35 +59,36 @@ const SignupForm = ({ season, group }: SeasonGroupType) => {
   }, [errors.email?.message, setFocus]);
 
   return (
-    <form noValidate onSubmit={handleSubmit(handleSubmitSignUp)} className={formWrapper}>
-      <TextBox이름 formObject={formObject} />
-      <TextBox label="연락처" name="phone" formObject={formObject} required>
-        <InputLine
-          name="phone"
-          placeholder="010-0000-0000"
-          type="tel"
-          pattern={VALIDATION_CHECK.phoneNumber.pattern}
-          maxLength={VALIDATION_CHECK.phoneNumber.maxLength}
-          errorText={VALIDATION_CHECK.phoneNumber.errorText}
+    <FormProvider {...methods}>
+      <form noValidate onSubmit={handleSubmit(handleSubmitSignUp)} className={formWrapper}>
+        <TextBox이름 />
+        <TextBox label="연락처" name="phone" required>
+          <InputLine
+            name="phone"
+            placeholder="010-0000-0000"
+            type="tel"
+            pattern={VALIDATION_CHECK.phoneNumber.pattern}
+            maxLength={VALIDATION_CHECK.phoneNumber.maxLength}
+            errorText={VALIDATION_CHECK.phoneNumber.errorText}
+          />
+        </TextBox>
+        <TextBox이메일
+          recruitingInfo={{ season, group }}
+          isVerified={isVerified}
+          onChangeVerification={handleVerified}
         />
-      </TextBox>
-      <TextBox이메일
-        recruitingInfo={{ season, group }}
-        isVerified={isVerified}
-        onChangeVerification={handleVerified}
-        formObject={formObject}
-      />
-      <TextBox비밀번호 formObject={formObject} />
-      <div>
-        <Checkbox required name="personalInformation" formObject={formObject}>
-          개인정보 수집 ‧ 이용에 동의합니다.
-        </Checkbox>
-        <Contentbox>{PRIVACY_POLICY}</Contentbox>
-      </div>
-      <Button isLoading={signUpIsPending} type="submit" style={{ marginTop: 30 }}>
-        지원서 작성하기
-      </Button>
-    </form>
+        <TextBox비밀번호 />
+        <div>
+          <Checkbox required name="personalInformation">
+            개인정보 수집 ‧ 이용에 동의합니다.
+          </Checkbox>
+          <Contentbox>{PRIVACY_POLICY}</Contentbox>
+        </div>
+        <Button isLoading={signUpIsPending} type="submit" style={{ marginTop: 30 }}>
+          지원서 작성하기
+        </Button>
+      </form>
+    </FormProvider>
   );
 };
 

--- a/src/views/SignupPage/components/SignupForm/style.css.ts
+++ b/src/views/SignupPage/components/SignupForm/style.css.ts
@@ -1,0 +1,7 @@
+import { style } from '@vanilla-extract/css';
+
+export const formWrapper = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 50,
+});

--- a/src/views/SignupPage/hooks/useMutateSignUp.tsx
+++ b/src/views/SignupPage/hooks/useMutateSignUp.tsx
@@ -5,7 +5,8 @@ import { VALIDATION_CHECK } from '@constants/validationCheck';
 
 import { sendSignUp } from '../apis';
 
-import type { SignUpError, SignUpRequest, SignUpResponse } from '../types';
+import type { SignUpRequest, SignUpResponse } from '../types';
+import type { ErrorResponse } from '@type/errorResponse';
 import type { AxiosError, AxiosResponse } from 'axios';
 
 const useMutateSignUp = ({ onSetError }: { onSetError: (name: string, type: string, message: string) => void }) => {
@@ -13,7 +14,7 @@ const useMutateSignUp = ({ onSetError }: { onSetError: (name: string, type: stri
 
   const { mutate: signUpMutate, isPending: signUpIsPending } = useMutation<
     AxiosResponse<SignUpResponse, SignUpRequest>,
-    AxiosError<SignUpError, SignUpRequest>,
+    AxiosError<ErrorResponse, SignUpRequest>,
     SignUpRequest
   >({
     mutationFn: (userInfo: SignUpRequest) => sendSignUp(userInfo),

--- a/src/views/SignupPage/index.tsx
+++ b/src/views/SignupPage/index.tsx
@@ -1,102 +1,23 @@
-import { useEffect } from 'react';
-import { FieldValues, useForm } from 'react-hook-form';
-
-import Button from '@components/Button';
-import Checkbox from '@components/Checkbox';
-import Contentbox from '@components/Checkbox/Contentbox';
-import { InputLine, TextBox } from '@components/Input';
-import { TextBox비밀번호, TextBox이름, TextBox이메일 } from '@components/Input/InputTheme';
 import Title from '@components/Title';
-import { PRIVACY_POLICY } from '@constants/policy';
-import { VALIDATION_CHECK } from '@constants/validationCheck';
 import useDate from '@hooks/useDate';
-import useVerificationStatus from '@hooks/useVerificationStatus';
 import NoMore from 'views/ErrorPage/components/NoMore';
 import BigLoading from 'views/loadings/BigLoding';
 
-import useMutateSignUp from './hooks/useMutateSignUp';
+import SignupForm from './components/SignupForm';
 import { container } from './style.css';
 
 const SignupPage = () => {
-  const { isVerified, handleVerified } = useVerificationStatus();
-  const { handleSubmit, ...formObject } = useForm({ mode: 'onBlur' }); // 임시
-  const {
-    setError,
-    setFocus,
-    formState: { errors },
-  } = formObject;
-
   const { season, group, NoMoreRecruit, NoMoreApply, isLoading } = useDate();
-
-  const { signUpMutate, signUpIsPending } = useMutateSignUp({
-    onSetError: (name, type, message) => setError(name, { type, message }),
-  });
-
-  const handleSubmitSignUp = ({ email, password, passwordCheck, name, phone }: FieldValues) => {
-    if (!isVerified) {
-      setError('code', {
-        type: 'not-match',
-        message: VALIDATION_CHECK.verificationCode.errorText,
-      });
-
-      return;
-    }
-
-    if (!season || !group) return;
-
-    signUpMutate({
-      email,
-      password,
-      passwordCheck,
-      name,
-      phone,
-      season,
-      group,
-    });
-  };
-
-  useEffect(() => {
-    if (errors.email?.message === VALIDATION_CHECK.email.errorTextExistence) {
-      setFocus('email');
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [errors.email?.message, setFocus]);
 
   if (isLoading) return <BigLoading />;
 
   if (NoMoreRecruit || NoMoreApply) return <NoMore content="모집 기간이 아니에요" />;
 
   return (
-    <form noValidate onSubmit={handleSubmit(handleSubmitSignUp)} className={container}>
+    <div className={container}>
       <Title>새 지원서 작성하기</Title>
-      <TextBox이름 formObject={formObject} />
-      <TextBox label="연락처" name="phone" formObject={formObject} required>
-        <InputLine
-          name="phone"
-          placeholder="010-0000-0000"
-          type="tel"
-          pattern={VALIDATION_CHECK.phoneNumber.pattern}
-          maxLength={VALIDATION_CHECK.phoneNumber.maxLength}
-          errorText={VALIDATION_CHECK.phoneNumber.errorText}
-        />
-      </TextBox>
-      <TextBox이메일
-        recruitingInfo={{ season, group }}
-        isVerified={isVerified}
-        onChangeVerification={handleVerified}
-        formObject={formObject}
-      />
-      <TextBox비밀번호 formObject={formObject} />
-      <div>
-        <Checkbox required name="personalInformation" formObject={formObject}>
-          개인정보 수집 ‧ 이용에 동의합니다.
-        </Checkbox>
-        <Contentbox>{PRIVACY_POLICY}</Contentbox>
-      </div>
-      <Button isLoading={signUpIsPending} type="submit" style={{ marginTop: 30 }}>
-        지원서 작성하기
-      </Button>
-    </form>
+      <SignupForm season={season} group={group} />
+    </div>
   );
 };
 


### PR DESCRIPTION
**Related Issue :** Closes #178 

---

## 🧑‍🎤 Summary
- [x] 렌더링 개선
- [x] useFormContext 사용

## 🧑‍🎤 Comment
### 렌더링 개선

https://github.com/user-attachments/assets/416aa1e5-4c43-4e0e-9dcf-3b4417e7940c

위와 같이 입력값 입력할 때 마다 모든 게 재렌더링이 일어났는데

https://github.com/user-attachments/assets/69c50d4f-86f3-40cd-8811-e4a4b575294c

컴포넌트를 분리해줌으로써 form 부분만 재렌더링 일어나게 만들었습니다

--- 

apply 페이지는 컴포넌트 분리하기가 어려웠어요
왜냐면 header에도 제출하기 버튼이 있어 여기서도 form handler를 사용할 수 있어야 했거든요
그래서 header와 form 부분을 제외한 info와 category 부분에 memo를 씌워 재렌더링을 막았습니다

https://github.com/user-attachments/assets/cd5b091e-c7c0-4be5-a23a-611a27e7a8dd

### formObject 전달
현재는 formObject를 prop으로 전달하고 있었는데
react-hook-form의 useFormContext 기능이 있어 그럴 필요가 없더라고요
다 수정해줬습니다