### PR TITLE
[Feat] amplitude로 사용자 트래킹 하기

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 <img src="https://img.shields.io/badge/Date--fns-3D7DCA?style=flat-square&logo=date-fns&logoColor=white" alt="Date-fns Badge"/></a>
 <img src="https://img.shields.io/badge/Firebase-FFCA28?style=flat-square&logo=firebase&logoColor=white" alt="Firebase Badge"/></a>
 <img src="https://img.shields.io/badge/Lottie--react-8DD6F9?style=flat-square&logo=react&logoColor=white" alt="Lottie-react Badge"/></a>
+<img src="https://img.shields.io/badge/Amplitude-FF9D00?style=flat-square&logo=amplitude&logoColor=white" alt="Amplitude Badge"/></a>
 
 ## 만든 사람들
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@amplitude/analytics-browser": "^2.9.3",
     "@sopt-makers/colors": "^3.0.1",
     "@sopt-makers/fonts": "^2.0.1",
     "@sopt-makers/icons": "^1.0.4",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,9 @@
+import * as amplitude from '@amplitude/analytics-browser';
 import { colors } from '@sopt-makers/colors';
 import { MutationCache, QueryCache, QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { AxiosError } from 'axios';
-import { useCallback, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { RouterProvider, createBrowserRouter } from 'react-router-dom';
 
 import Layout from '@components/Layout';
@@ -43,6 +44,7 @@ const App = () => {
 
   const [isLight, setIsLight] = useState(true);
   const [recruitingInfo, setRecruitingInfo] = useState<RecruitingInfoType>({});
+  const [isAmplitudeInitialized, setIsAmplitudeInitialized] = useState(false);
 
   const queryClient = new QueryClient({
     defaultOptions: {
@@ -94,6 +96,13 @@ const App = () => {
       setRecruitingInfo((prev) => ({ ...prev, ...obj }));
     }, []),
   };
+
+  useEffect(() => {
+    if (!isAmplitudeInitialized) {
+      amplitude.init(import.meta.env.VITE_AMPLITUDE_API_KEY);
+      setIsAmplitudeInitialized(true);
+    }
+  }, [isAmplitudeInitialized]);
 
   return (
     <>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import * as amplitude from '@amplitude/analytics-browser';
+import { init } from '@amplitude/analytics-browser';
 import { colors } from '@sopt-makers/colors';
 import { MutationCache, QueryCache, QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
@@ -99,7 +99,7 @@ const App = () => {
 
   useEffect(() => {
     if (!isAmplitudeInitialized) {
-      amplitude.init(import.meta.env.VITE_AMPLITUDE_API_KEY);
+      init(import.meta.env.VITE_AMPLITUDE_API_KEY);
       setIsAmplitudeInitialized(true);
     }
   }, [isAmplitudeInitialized]);

--- a/src/common/components/Input/components/InputTheme/index.tsx
+++ b/src/common/components/Input/components/InputTheme/index.tsx
@@ -1,3 +1,4 @@
+import { track } from '@amplitude/analytics-browser';
 import { useCallback, useEffect, useState } from 'react';
 import { useFormContext } from 'react-hook-form';
 import { useLocation, useNavigate } from 'react-router-dom';
@@ -102,6 +103,7 @@ export const TextBox이메일 = ({
 
       // 오류가 없을 때 이메일 확인 요청
       if (!emailError && isDone) {
+        track('click-password-email');
         checkUserMutate({ email, name, season, group });
         setValue('code', '');
         clearErrors('email');
@@ -111,6 +113,7 @@ export const TextBox이메일 = ({
 
     if (location.pathname === '/sign-up' && !errors.email && isDone) {
       if (!season || !group) return;
+      track('click-signup-email');
       setValue('code', '');
       clearErrors('email');
       sendVerificationCodeMutate({ email, season, group, isSignup: true });

--- a/src/common/components/Layout/components/Header/index.tsx
+++ b/src/common/components/Layout/components/Header/index.tsx
@@ -1,3 +1,4 @@
+import * as amplitude from '@amplitude/analytics-browser';
 import { useContext } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 
@@ -23,6 +24,7 @@ const Header = () => {
   };
 
   const handleLogout = () => {
+    amplitude.reset();
     localStorage.removeItem('soptApplyAccessToken');
     if (pathname === '/') navigate(0);
     else navigate('/');

--- a/src/common/components/Layout/components/Header/index.tsx
+++ b/src/common/components/Layout/components/Header/index.tsx
@@ -1,4 +1,4 @@
-import * as amplitude from '@amplitude/analytics-browser';
+import { reset } from '@amplitude/analytics-browser';
 import { useContext } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 
@@ -24,7 +24,7 @@ const Header = () => {
   };
 
   const handleLogout = () => {
-    amplitude.reset();
+    reset();
     localStorage.removeItem('soptApplyAccessToken');
     if (pathname === '/') navigate(0);
     else navigate('/');

--- a/src/views/ApplyPage/index.tsx
+++ b/src/views/ApplyPage/index.tsx
@@ -279,7 +279,7 @@ const ApplyPage = ({ isReview, onSetComplete, draftData }: ApplyPageProps) => {
         />
         <ApplyInfo isReview={isReview} />
         <ApplyCategory minIndex={minIndex} />
-        <form onSubmit={handleSubmit(handleApplySubmit)} className={formContainer}>
+        <form id="apply-form" name="apply-form" onSubmit={handleSubmit(handleApplySubmit)} className={formContainer}>
           <DefaultSection isReview={isReview} refCallback={refCallback} applicantDraft={applicantDraft} />
           <CommonSection
             isReview={isReview}

--- a/src/views/ApplyPage/index.tsx
+++ b/src/views/ApplyPage/index.tsx
@@ -1,3 +1,4 @@
+import { track } from '@amplitude/analytics-browser';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import { useNavigate } from 'react-router-dom';
@@ -246,10 +247,12 @@ const ApplyPage = ({ isReview, onSetComplete, draftData }: ApplyPageProps) => {
       willAppjam: false,
     };
 
+    type === 'draft' ? track('click-apply-draft') : track('click-apply-confirm_submit');
     type === 'draft' ? draftMutate(formValues) : submitMutate(formValues);
   };
 
   const handleApplySubmit = () => {
+    track('click-apply-submit');
     submitDialog.current?.showModal();
   };
 

--- a/src/views/ErrorPage/components/NoMore/index.tsx
+++ b/src/views/ErrorPage/components/NoMore/index.tsx
@@ -1,3 +1,5 @@
+import { track } from '@amplitude/analytics-browser';
+
 import { article, contactButton, container, errorButton, errorText, instruction } from '../../style.css';
 
 const NoMore = ({ content }: { content: string }) => {
@@ -5,12 +7,21 @@ const NoMore = ({ content }: { content: string }) => {
     <section className={container}>
       <article className={article}>
         <p className={errorText}>{content}</p>
-        <a href="https://makers.sopt.org/" className={errorButton} target="_blank" rel="noreferrer">
+        <a
+          href="https://makers.sopt.org/"
+          className={errorButton}
+          target="_blank"
+          rel="noreferrer"
+          onClick={() => track('click-nomore-official')}>
           공식 홈페이지 가기
         </a>
       </article>
       <p className={instruction}>{`문의사항이 있다면\n아래 ‘문의하기’를 이용해 주세요`}</p>
-      <a id="chat-channel-button" href="http://pf.kakao.com/_sxaIWG" className={contactButton}>
+      <a
+        id="chat-channel-button"
+        href="http://pf.kakao.com/_sxaIWG"
+        className={contactButton}
+        onClick={() => track('click-nomore-ask')}>
         문의하기
       </a>
     </section>

--- a/src/views/ErrorPage/index.tsx
+++ b/src/views/ErrorPage/index.tsx
@@ -1,3 +1,4 @@
+import { track } from '@amplitude/analytics-browser';
 import { useNavigate } from 'react-router-dom';
 
 import ErrorCode from './components/ErrorCode';
@@ -17,6 +18,11 @@ const ErrorPage = ({ code }: { code: 404 | 500 }) => {
     }
   };
 
+  const handleClickErrorButton = () => {
+    code === 404 ? track('click-error-home') : track('click-error-back');
+    handleGoBack(code);
+  };
+
   const CODE_KEY: 'CODE404' | 'CODE500' = `CODE${code}`;
 
   return (
@@ -24,12 +30,16 @@ const ErrorPage = ({ code }: { code: 404 | 500 }) => {
       <article className={article}>
         <ErrorCode code={code} />
         <p className={errorText}>{ERROR_MESSAGE[CODE_KEY]?.text}</p>
-        <button className={errorButton} onClick={() => handleGoBack(code)}>
+        <button className={errorButton} onClick={handleClickErrorButton}>
           {ERROR_MESSAGE[CODE_KEY]?.button}
         </button>
       </article>
       <p className={instruction}>{`문제가 지속적으로 발생하거나 문의사항이 있다면\n아래 ‘문의하기’를 이용해 주세요`}</p>
-      <a id="chat-channel-button" href="http://pf.kakao.com/_sxaIWG" className={contactButton}>
+      <a
+        id="chat-channel-button"
+        href="http://pf.kakao.com/_sxaIWG"
+        className={contactButton}
+        onClick={() => track('click-error-ask')}>
         문의하기
       </a>
     </section>

--- a/src/views/MyPage/index.tsx
+++ b/src/views/MyPage/index.tsx
@@ -1,3 +1,5 @@
+import { track } from '@amplitude/analytics-browser';
+
 import Button from '@components/Button';
 import Callout from '@components/Callout';
 import Title from '@components/Title';
@@ -36,7 +38,12 @@ const MyPage = ({ onShowReview }: { onShowReview: () => void }) => {
         {(!NoMoreScreeningResult || !NoMoreFinalResult) && (
           <li className={buttonValue}>
             <span className={infoLabel}>지원상태</span>
-            <Button isLink to="/result" className={buttonWidth} padding="15x25">
+            <Button
+              isLink
+              to="/result"
+              className={buttonWidth}
+              onClick={() => track('click-my-result')}
+              padding="15x25">
               결과 확인
             </Button>
           </li>

--- a/src/views/PasswordPage/components/PasswordForm/index.tsx
+++ b/src/views/PasswordPage/components/PasswordForm/index.tsx
@@ -51,7 +51,12 @@ const PasswordForm = ({ season, group }: SeasonGroupType) => {
     <>
       <CompleteDialog ref={completeDialog} />
       <FormProvider {...methods}>
-        <form noValidate onSubmit={handleSubmit(handleChangePassword)} className={formWrapper}>
+        <form
+          id="password-form"
+          name="password-form"
+          noValidate
+          onSubmit={handleSubmit(handleChangePassword)}
+          className={formWrapper}>
           <TextBox이름 />
           <TextBox이메일
             recruitingInfo={{ season, group }}

--- a/src/views/PasswordPage/components/PasswordForm/index.tsx
+++ b/src/views/PasswordPage/components/PasswordForm/index.tsx
@@ -1,3 +1,4 @@
+import { track } from '@amplitude/analytics-browser';
 import { useRef } from 'react';
 import { FormProvider, useForm, type FieldValues } from 'react-hook-form';
 
@@ -66,7 +67,11 @@ const PasswordForm = ({ season, group }: SeasonGroupType) => {
           {isVerified && (
             <>
               <TextBox비밀번호 />
-              <Button isLoading={changePasswordIsPending} type="submit" style={{ marginTop: 30 }}>
+              <Button
+                isLoading={changePasswordIsPending}
+                type="submit"
+                style={{ marginTop: 30 }}
+                onClick={() => track('click-password-password')}>
                 저장하기
               </Button>
             </>

--- a/src/views/SignInPage/components/SignInForm/index.tsx
+++ b/src/views/SignInPage/components/SignInForm/index.tsx
@@ -13,9 +13,8 @@ import type { SeasonGroupType } from '@type/seasonAndGroup';
 
 const SignInForm = ({ season, group }: SeasonGroupType) => {
   const methods = useForm({ mode: 'onBlur' });
-  const { getValues, handleSubmit, setError } = methods;
+  const { handleSubmit, setError } = methods;
   const { signInMutate, signInIsPending } = useMutateSignIn({
-    email: getValues('email'),
     onSetError: (name, type, message) => setError(name, { type, message }),
   });
 

--- a/src/views/SignInPage/components/SignInForm/index.tsx
+++ b/src/views/SignInPage/components/SignInForm/index.tsx
@@ -1,3 +1,4 @@
+import { track } from '@amplitude/analytics-browser';
 import { type FieldValues, FormProvider, useForm } from 'react-hook-form';
 import { Link } from 'react-router-dom';
 
@@ -58,12 +59,12 @@ const SignInForm = ({ season, group }: SeasonGroupType) => {
           />
           <Description>
             <p>비밀번호를 잃어버리셨나요?</p>
-            <Link className={newPasswordButton} to="/password">
+            <Link className={newPasswordButton} to="/password" onClick={() => track('click-signin-password')}>
               비밀번호 재설정하기
             </Link>
           </Description>
         </TextBox>
-        <Button isLoading={signInIsPending} type="submit">
+        <Button isLoading={signInIsPending} type="submit" onClick={() => track('click-signin-signin')}>
           로그인
         </Button>
       </form>

--- a/src/views/SignInPage/components/SignInForm/index.tsx
+++ b/src/views/SignInPage/components/SignInForm/index.tsx
@@ -30,7 +30,12 @@ const SignInForm = ({ season, group }: SeasonGroupType) => {
 
   return (
     <FormProvider {...methods}>
-      <form noValidate onSubmit={handleSubmit(handleSignIn)} className={inputWrapper}>
+      <form
+        id="sign-in-form"
+        name="sign-in-form"
+        noValidate
+        onSubmit={handleSubmit(handleSignIn)}
+        className={inputWrapper}>
         <TextBox label="이메일" name="email" required>
           <InputLine
             name="email"

--- a/src/views/SignInPage/components/SignInForm/index.tsx
+++ b/src/views/SignInPage/components/SignInForm/index.tsx
@@ -12,8 +12,9 @@ import type { SeasonGroupType } from '@type/seasonAndGroup';
 
 const SignInForm = ({ season, group }: SeasonGroupType) => {
   const methods = useForm({ mode: 'onBlur' });
-  const { handleSubmit, setError } = methods;
+  const { getValues, handleSubmit, setError } = methods;
   const { signInMutate, signInIsPending } = useMutateSignIn({
+    email: getValues('email'),
     onSetError: (name, type, message) => setError(name, { type, message }),
   });
 

--- a/src/views/SignInPage/components/SignInInfo/index.tsx
+++ b/src/views/SignInPage/components/SignInInfo/index.tsx
@@ -1,3 +1,4 @@
+import { track } from '@amplitude/analytics-browser';
 import { Link } from 'react-router-dom';
 
 import Callout from '@components/Callout';
@@ -13,7 +14,7 @@ const SignInInfo = ({ season }: SeasonGroupType) => {
       <Title>{season}기 Makers 지원하기</Title>
       <Callout
         Button={
-          <Link to="/sign-up" className={calloutButton}>
+          <Link to="/sign-up" className={calloutButton} onClick={() => track('click-signin-signup')}>
             새 지원서 작성하기
           </Link>
         }>

--- a/src/views/SignInPage/hooks/useMutateSignIn.tsx
+++ b/src/views/SignInPage/hooks/useMutateSignIn.tsx
@@ -1,3 +1,4 @@
+import * as amplitude from '@amplitude/analytics-browser';
 import { useMutation } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
 
@@ -9,7 +10,12 @@ import type { SignInRequest, SignInResponse } from '../types';
 import type { ErrorResponse } from '@type/errorResponse';
 import type { AxiosError, AxiosResponse } from 'axios';
 
-const useMutateSignIn = ({ onSetError }: { onSetError: (name: string, type: string, message: string) => void }) => {
+interface MutateSignInProps {
+  email: string;
+  onSetError: (name: string, type: string, message: string) => void;
+}
+
+const useMutateSignIn = ({ email, onSetError }: MutateSignInProps) => {
   const navigate = useNavigate();
 
   const { mutate: signInMutate, isPending: signInIsPending } = useMutation<
@@ -19,6 +25,7 @@ const useMutateSignIn = ({ onSetError }: { onSetError: (name: string, type: stri
   >({
     mutationFn: (userInfo: SignInRequest) => sendSignIn(userInfo),
     onSuccess: ({ data: { token } }) => {
+      amplitude.setUserId(email);
       localStorage.setItem('soptApplyAccessToken', token);
       navigate(0);
     },

--- a/src/views/SignInPage/hooks/useMutateSignIn.tsx
+++ b/src/views/SignInPage/hooks/useMutateSignIn.tsx
@@ -1,4 +1,4 @@
-import * as amplitude from '@amplitude/analytics-browser';
+import { setUserId } from '@amplitude/analytics-browser';
 import { useMutation } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
 
@@ -25,7 +25,7 @@ const useMutateSignIn = ({ email, onSetError }: MutateSignInProps) => {
   >({
     mutationFn: (userInfo: SignInRequest) => sendSignIn(userInfo),
     onSuccess: ({ data: { token } }) => {
-      amplitude.setUserId(email);
+      setUserId(email);
       localStorage.setItem('soptApplyAccessToken', token);
       navigate(0);
     },

--- a/src/views/SignInPage/hooks/useMutateSignIn.tsx
+++ b/src/views/SignInPage/hooks/useMutateSignIn.tsx
@@ -11,11 +11,10 @@ import type { ErrorResponse } from '@type/errorResponse';
 import type { AxiosError, AxiosResponse } from 'axios';
 
 interface MutateSignInProps {
-  email: string;
   onSetError: (name: string, type: string, message: string) => void;
 }
 
-const useMutateSignIn = ({ email, onSetError }: MutateSignInProps) => {
+const useMutateSignIn = ({ onSetError }: MutateSignInProps) => {
   const navigate = useNavigate();
 
   const { mutate: signInMutate, isPending: signInIsPending } = useMutation<
@@ -24,7 +23,7 @@ const useMutateSignIn = ({ email, onSetError }: MutateSignInProps) => {
     SignInRequest
   >({
     mutationFn: (userInfo: SignInRequest) => sendSignIn(userInfo),
-    onSuccess: ({ data: { token } }) => {
+    onSuccess: ({ data: { email, token } }) => {
       setUserId(email);
       localStorage.setItem('soptApplyAccessToken', token);
       navigate(0);

--- a/src/views/SignInPage/types.ts
+++ b/src/views/SignInPage/types.ts
@@ -13,4 +13,5 @@ export interface SignInError {
 export interface SignInResponse {
   err: boolean;
   token: string;
+  email: string;
 }

--- a/src/views/SignedInPage/index.tsx
+++ b/src/views/SignedInPage/index.tsx
@@ -1,3 +1,4 @@
+import { track } from '@amplitude/analytics-browser';
 import { useContext, useEffect, useState } from 'react';
 
 import { RecruitingInfoContext } from '@store/recruitingInfoContext';
@@ -17,6 +18,15 @@ const SignedInPage = () => {
 
   const { handleSaveRecruitingInfo } = useContext(RecruitingInfoContext);
 
+  const handleShowReview = () => {
+    track('click-my-review');
+    setIsReview(true);
+  };
+
+  const handleSetComplete = () => {
+    setIsComplete(true);
+  };
+
   useEffect(() => {
     handleSaveRecruitingInfo({
       name: applicant?.name,
@@ -28,9 +38,9 @@ const SignedInPage = () => {
   return (
     <>
       {!isReview && isComplete && <CompletePage />}
-      {!isReview && !isComplete && isSubmit && <MyPage onShowReview={() => setIsReview(true)} />}
+      {!isReview && !isComplete && isSubmit && <MyPage onShowReview={handleShowReview} />}
       {(isReview || (!isComplete && !isSubmit)) && (
-        <ApplyPage isReview={isReview} onSetComplete={() => setIsComplete(true)} draftData={draftData} />
+        <ApplyPage isReview={isReview} onSetComplete={handleSetComplete} draftData={draftData} />
       )}
     </>
   );

--- a/src/views/SignupPage/components/SignupForm/index.tsx
+++ b/src/views/SignupPage/components/SignupForm/index.tsx
@@ -1,3 +1,4 @@
+import { track } from '@amplitude/analytics-browser';
 import { useEffect } from 'react';
 import { type FieldValues, FormProvider, useForm } from 'react-hook-form';
 
@@ -89,7 +90,11 @@ const SignupForm = ({ season, group }: SeasonGroupType) => {
           </Checkbox>
           <Contentbox>{PRIVACY_POLICY}</Contentbox>
         </div>
-        <Button isLoading={signUpIsPending} type="submit" style={{ marginTop: 30 }}>
+        <Button
+          isLoading={signUpIsPending}
+          type="submit"
+          style={{ marginTop: 30 }}
+          onClick={() => track('click-signup-apply')}>
           지원서 작성하기
         </Button>
       </form>

--- a/src/views/SignupPage/components/SignupForm/index.tsx
+++ b/src/views/SignupPage/components/SignupForm/index.tsx
@@ -60,7 +60,12 @@ const SignupForm = ({ season, group }: SeasonGroupType) => {
 
   return (
     <FormProvider {...methods}>
-      <form noValidate onSubmit={handleSubmit(handleSubmitSignUp)} className={formWrapper}>
+      <form
+        id="sign-up-form"
+        name="sign-up-form"
+        noValidate
+        onSubmit={handleSubmit(handleSubmitSignUp)}
+        className={formWrapper}>
         <TextBox이름 />
         <TextBox label="연락처" name="phone" required>
           <InputLine

--- a/src/views/dialogs/SessionExpiredDialog/index.tsx
+++ b/src/views/dialogs/SessionExpiredDialog/index.tsx
@@ -1,3 +1,4 @@
+import { track } from '@amplitude/analytics-browser';
 import { forwardRef, type KeyboardEvent } from 'react';
 
 import Dialog from '@components/Dialog';
@@ -10,6 +11,7 @@ const SessionExpiredDialog = forwardRef<HTMLDialogElement>((_, ref) => {
   };
 
   const handleLogout = () => {
+    track('click-session-okay');
     localStorage.removeItem('soptApplyAccessToken');
     if (window.location.pathname === '/') {
       location.reload();

--- a/src/views/dialogs/SubmitDialog/index.tsx
+++ b/src/views/dialogs/SubmitDialog/index.tsx
@@ -1,3 +1,4 @@
+import { track } from '@amplitude/analytics-browser';
 import { type ChangeEvent, forwardRef, useState } from 'react';
 
 import Dialog from '@components/Dialog';
@@ -65,7 +66,7 @@ const SubmitDialog = forwardRef<HTMLDialogElement, SubmitDialogProps>(
             method="dialog"
             className={dataIsPending ? buttonOutside.disabled : buttonOutside.line}
             onSubmit={() => setIsChecked(false)}>
-            <button className={buttonInside.line} disabled={dataIsPending}>
+            <button className={buttonInside.line} disabled={dataIsPending} onClick={() => track('click-apply-cancel')}>
               {dataIsPending ? <ButtonLoading width={48} height={18} /> : '검토하기'}
             </button>
           </form>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,54 @@
 # yarn lockfile v1
 
 
+"@amplitude/analytics-browser@^2.9.3":
+  version "2.9.3"
+  resolved "https://registry.yarnpkg.com/@amplitude/analytics-browser/-/analytics-browser-2.9.3.tgz#6139d2c5482cde5df0b42b65866c0dcbdf583257"
+  integrity sha512-PnkJrJGRUfdE9nFgQZbWvUjNGnbcFojQROfj7KQeKGJTzQZXMt+xafmfXWDnhsf0JRgbk273Wh7Z6WNXxS1seA==
+  dependencies:
+    "@amplitude/analytics-client-common" "^2.2.4"
+    "@amplitude/analytics-core" "^2.3.0"
+    "@amplitude/analytics-types" "^2.6.0"
+    "@amplitude/plugin-page-view-tracking-browser" "^2.2.17"
+    tslib "^2.4.1"
+
+"@amplitude/analytics-client-common@^2.2.4":
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/@amplitude/analytics-client-common/-/analytics-client-common-2.2.4.tgz#8c64304b26bbbd9788a09d0d7fd7a30807314971"
+  integrity sha512-+zOW3/Yb4LzK1DfhFCnSOcb8vgeZgIQffLM6yrgzKGedtQOnwDQeKTDI3aaMzckXQPVcJs1M6bJcT/l5TmAkDw==
+  dependencies:
+    "@amplitude/analytics-connector" "^1.4.8"
+    "@amplitude/analytics-core" "^2.3.0"
+    "@amplitude/analytics-types" "^2.6.0"
+    tslib "^2.4.1"
+
+"@amplitude/analytics-connector@^1.4.8":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@amplitude/analytics-connector/-/analytics-connector-1.5.0.tgz#89a78b8c6463abe4de1d621db4af6c62f0d62b0a"
+  integrity sha512-T8mOYzB9RRxckzhL0NTHwdge9xuFxXEOplC8B1Y3UX3NHa3BLh7DlBUZlCOwQgMc2nxDfnSweDL5S3bhC+W90g==
+
+"@amplitude/analytics-core@^2.3.0":
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/@amplitude/analytics-core/-/analytics-core-2.3.0.tgz#bab54d8acbb825496b51c1f1b4b9482f0533891f"
+  integrity sha512-Knafvocs29cPOHM3GHyBkP4nXUrh/oXnj2fULoSyh/03Bt63UPoyQCNS/EtQB/dOUhapTP35ZU9yZnrY+jvndQ==
+  dependencies:
+    "@amplitude/analytics-types" "^2.6.0"
+    tslib "^2.4.1"
+
+"@amplitude/analytics-types@^2.6.0":
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/@amplitude/analytics-types/-/analytics-types-2.6.0.tgz#00d1957d3f5eecb85e00ef4a1b2f65c497967d46"
+  integrity sha512-7MSENvLCTGjec7K45JT+RcOuoPTCvq1MMq/HRLiQK/BMR4taX7f/uXldEc8b//o+ZZP45IBqFroR7Bl8LwJQrQ==
+
+"@amplitude/plugin-page-view-tracking-browser@^2.2.17":
+  version "2.2.17"
+  resolved "https://registry.yarnpkg.com/@amplitude/plugin-page-view-tracking-browser/-/plugin-page-view-tracking-browser-2.2.17.tgz#cde72080efa386752ca4460e9eff3471d30128aa"
+  integrity sha512-s19LUuPMvOhvM/36XOUeVSMGOhtSOPA6bhhrR4x/lEsyylsS+rfi6/fILd2B5gojplXKMvVlJXEP+t1fjIr1HA==
+  dependencies:
+    "@amplitude/analytics-client-common" "^2.2.4"
+    "@amplitude/analytics-types" "^2.6.0"
+    tslib "^2.4.1"
+
 "@ampproject/remapping@^2.2.0":
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/@ampproject/remapping/-/remapping-2.3.0.tgz#ed441b6fa600072520ce18b43d2c8cc8caecc7f4"
@@ -3716,7 +3764,7 @@ tsconfig-paths@^3.15.0:
     minimist "^1.2.6"
     strip-bom "^3.0.0"
 
-tslib@^2.1.0:
+tslib@^2.1.0, tslib@^2.4.1:
   version "2.6.3"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.3.tgz#0438f810ad7a9edcde7a241c3d80db693c8cbfe0"
   integrity sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==


### PR DESCRIPTION
**Related Issue :** Closes #193 

---

## 🧑‍🎤 Summary
- [x] amplitude 연동
- [x] user id 설정
- [x] 버튼 tracking

## 🧑‍🎤 Screenshot


## 🧑‍🎤 Comment
amplitude 공식문서 보면서 적용해 줬습니다
[참고자료](https://amplitude.com/docs/sdks/analytics/browser/browser-sdk-2) 

현재 추적중인 버튼들은 아래와 같아요

event page | 역할 | 설명 | event name 
-- | -- | -- | --
sign-in | go-to-sign-up | 새지원서작성하기 버튼 클릭 | click-signin-signup
  | go-to-password | 비밀번호재설정하기 버튼 클릭 | click-signin-password
  | login | 로그인 버튼 클릭 | click-signin-signin
  |   |   |  
sign-up | send-email | 이메일인증 버튼 클릭 | click-signup-email
  | go-to-apply | 지원서작성하기 버튼 클릭 | click-signup-apply
  |   |   |  
password | send-email | 이메일인증 버튼 클릭 | click-password-email
  | change-password | 비밀번호변경하기 버튼 클릭 | click-password-password
  |   |   |  
apply | draft | 임시저장 버튼 클릭 | click-apply-draft
  | submit | 제출하기 버튼 클릭 | click-apply-submit
  | cancel-submit | 검토하기 버튼 클릭 | click-apply-cancel
  | confirm-submit | 두 번째 제출하기 버튼 클릭 | click-apply-confirm_submit
  |   |   |  
my | check-apply | 지원서확인 버튼 클릭 | click-my-review
  | see-result | 결과확인 버튼 클릭 | click-my-result
  |   |   |  
session dialog | session-dialog | 세션 만료 모달 확인 버튼 클릭 | click-session-okay
  |   |   |  
500 | go-back | 이전페이지로가기 버튼 클릭 | click-error-back
  | ask | 문의하기 버튼 클릭 | click-error-ask
404 | go-home | 홈으로가기 버튼 클릭 | click-error-home
  |   |   |  
모집 기간 아님 | go-to-hompage | 공식홈페이지 버튼 클릭 | click-nomore-official
  |   | 문의하기 버튼 클릭 | click-nomore-ask

이외에 페이지 이동과 페이지 머문 시간 등은 defualt로 tracking 해준다고 합니다