### PR TITLE
[Refactor] 하드코딩 지우기

### DIFF
--- a/src/common/components/Layout/components/Header/index.tsx
+++ b/src/common/components/Layout/components/Header/index.tsx
@@ -3,7 +3,7 @@ import { useContext } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 
 import MakersLogo from '@assets/MakersLogo';
-// import NowsoptLogo from '@assets/NowsoptLogo';
+import NowsoptLogo from '@assets/NowsoptLogo';
 import { RecruitingInfoContext } from '@store/recruitingInfoContext';
 
 import { MENU_ITEMS } from './contants';
@@ -15,8 +15,10 @@ const Header = () => {
   const { pathname } = useLocation();
   const isSignedIn = localStorage.getItem('soptApplyAccessToken');
   const {
-    recruitingInfo: { name },
+    recruitingInfo: { name, soptName },
   } = useContext(RecruitingInfoContext);
+
+  const isMakers = soptName?.toLowerCase().includes('makers');
 
   const handleClickLogo = () => {
     if (pathname === '/') navigate(0);
@@ -34,7 +36,7 @@ const Header = () => {
   return (
     <header className={container}>
       <button onClick={handleClickLogo} className={logo}>
-        <MakersLogo />
+        {isMakers ? <MakersLogo /> : <NowsoptLogo />}
       </button>
       <nav>
         <ul className={menuList}>

--- a/src/common/hooks/useDate.tsx
+++ b/src/common/hooks/useDate.tsx
@@ -6,7 +6,6 @@ const useDate = () => {
   const { data, isLoading } = useGetRecruitingInfo();
 
   const {
-    season,
     group,
     ybApplicationStart,
     obApplicationStart,
@@ -57,8 +56,7 @@ const useDate = () => {
   const NoMoreFinalResult = beforeFinalResult || afterRecruiting; // 최종 합불 확인 기간 아님
 
   return {
-    season,
-    group,
+    ...data?.data.season,
     NoMoreRecruit,
     NoMoreApply,
     NoMoreScreeningResult,

--- a/src/common/store/recruitingInfoContext.ts
+++ b/src/common/store/recruitingInfoContext.ts
@@ -2,6 +2,7 @@ import { createContext } from 'react';
 
 export type RecruitingInfoType = {
   name?: string;
+  soptName?: string;
   season?: number;
   group?: string;
   applicationStart?: string;

--- a/src/views/MainPage/index.tsx
+++ b/src/views/MainPage/index.tsx
@@ -21,6 +21,7 @@ const MainPage = () => {
     if (!data) return;
 
     const {
+      name,
       season,
       group,
       ybApplicationStart,
@@ -57,6 +58,7 @@ const MainPage = () => {
     const interviewEnd = group === 'YB' ? ybInterviewEnd : obInterviewEnd;
 
     handleSaveRecruitingInfo({
+      name,
       season,
       group,
       applicationStart, // 서류 지원 시작

--- a/src/views/MainPage/index.tsx
+++ b/src/views/MainPage/index.tsx
@@ -58,7 +58,7 @@ const MainPage = () => {
     const interviewEnd = group === 'YB' ? ybInterviewEnd : obInterviewEnd;
 
     handleSaveRecruitingInfo({
-      name,
+      soptName: name,
       season,
       group,
       applicationStart, // 서류 지원 시작

--- a/src/views/ResultPage/components/FinalResult.tsx
+++ b/src/views/ResultPage/components/FinalResult.tsx
@@ -14,12 +14,14 @@ import useGetFinalResult from '../hooks/useGetFinalResult';
 
 const Content = ({ pass }: { pass?: boolean }) => {
   const { data, isLoading } = useGetRecruitingInfo();
-  const { name: soptName, season } = data?.data.season || {};
+  const { name: soptName, season, group } = data?.data.season || {};
   const {
     recruitingInfo: { name },
   } = useContext(RecruitingInfoContext);
 
   if (isLoading) return <BigLoading />;
+
+  const isMakers = soptName?.toLowerCase().includes('makers');
 
   return (
     <>
@@ -29,10 +31,10 @@ const Content = ({ pass }: { pass?: boolean }) => {
           <strong className={strongText}>{`축하드립니다!`}</strong>
           <span>
             {`
-              ${name}님은 ${season}기 ${soptName} 신입회원 모집에 최종 합격하셨습니다.
+              ${name}님은 ${season}기 ${soptName} ${!isMakers ? group : ''} 신입회원 모집에 최종 합격하셨습니다.
   
               ${name}님과 함께하게 되어 진심으로 기쁩니다.
-              향후 활동은 ${name} 공식 노션과 카카오톡 단체 대화방, SOPT 공식 디스코드를 통해
+              향후 활동은 ${soptName} 공식 노션과 카카오톡 단체 대화방, SOPT 공식 디스코드를 통해
               운영 및 진행됩니다.
           
               오늘 중으로 카카오톡 단체 대화방에 초대해드릴 예정이니 참고 부탁드립니다.\n
@@ -42,9 +44,9 @@ const Content = ({ pass }: { pass?: boolean }) => {
         </p>
       ) : (
         <p className={content}>
-          {`안녕하세요. ${soptName}입니다.
+          {`안녕하세요. ${soptName} 입니다.
               
-            ${name}님은 ${season}기 ${soptName} 신입회원 모집에 불합격하셨습니다.
+            ${name}님은 ${season}기 ${soptName} ${!isMakers ? group : ''} 신입회원 모집에 불합격하셨습니다.
 
             지원자님의 뛰어난 역량과 잠재력에도 불구하고 안타깝게도 귀하의 최종 합격 소식을
             전해드리지 못하게 되었습니다.

--- a/src/views/ResultPage/components/FinalResult.tsx
+++ b/src/views/ResultPage/components/FinalResult.tsx
@@ -6,22 +6,16 @@ import { RecruitingInfoContext } from '@store/recruitingInfoContext';
 import BigLoading from 'views/loadings/BigLoding';
 
 import { bottomAnimation, bottomImg, container, content, contentWrapper, strongText } from './style.css';
-// import imgSoptLogo from '../assets/imgSoptLogo.png';
-// import imgSoptLogoWebp from '../assets/imgSoptLogo.webp';
 import imgMakersLogo from '../assets/imgMakersLogo.png';
 import imgMakersLogoWebp from '../assets/imgMakersLogo.webp';
+import imgSoptLogo from '../assets/imgSoptLogo.png';
+import imgSoptLogoWebp from '../assets/imgSoptLogo.webp';
 import useGetFinalResult from '../hooks/useGetFinalResult';
 
-const Content = ({ pass }: { pass?: boolean }) => {
-  const { data, isLoading } = useGetRecruitingInfo();
-  const { name: soptName, season, group } = data?.data.season || {};
+const Content = ({ isMakers, pass }: { isMakers?: boolean; pass?: boolean }) => {
   const {
-    recruitingInfo: { name },
+    recruitingInfo: { name, soptName, season, group },
   } = useContext(RecruitingInfoContext);
-
-  if (isLoading) return <BigLoading />;
-
-  const isMakers = soptName?.toLowerCase().includes('makers');
 
   return (
     <>
@@ -61,35 +55,41 @@ const Content = ({ pass }: { pass?: boolean }) => {
 };
 
 const FinalResult = () => {
-  const { handleSaveRecruitingInfo } = useContext(RecruitingInfoContext);
+  const { data, isLoading } = useGetRecruitingInfo();
   const { finalResult, finalResultIsLoading } = useGetFinalResult();
+  const { handleSaveRecruitingInfo } = useContext(RecruitingInfoContext);
 
-  const { name, season, group } = finalResult?.data || {};
+  const { name: soptName, season, group } = data?.data.season || {};
+  const { name, pass } = finalResult?.data || {};
+
+  const isMakers = soptName?.toLowerCase().includes('makers');
+
+  const imgLogo = isMakers ? imgMakersLogo : imgSoptLogo;
+  const imgLogoWebp = isMakers ? imgMakersLogoWebp : imgSoptLogoWebp;
 
   useEffect(() => {
     handleSaveRecruitingInfo({
       name,
+      soptName,
       season,
       group,
     });
-  }, [name, season, group, handleSaveRecruitingInfo]);
+  }, [name, soptName, season, group, handleSaveRecruitingInfo]);
 
-  if (finalResultIsLoading) return <BigLoading />;
-
-  const { pass } = finalResult?.data || {};
+  if (isLoading || finalResultIsLoading) return <BigLoading />;
 
   return (
     <section className={container}>
       <div className={contentWrapper}>
         <Title>결과 확인</Title>
-        <Content pass={pass} />
+        <Content isMakers={isMakers} pass={pass} />
       </div>
       {pass && (
         <>
           <div className={bottomAnimation} />
           <picture className={bottomImg}>
-            <source srcSet={imgMakersLogoWebp} type="image/webp" />
-            <img src={imgMakersLogo} alt="sopt-logo" />
+            <source srcSet={imgLogoWebp} type="image/webp" />
+            <img src={imgLogo} alt="sopt-logo" />
           </picture>
         </>
       )}

--- a/src/views/ResultPage/components/FinalResult.tsx
+++ b/src/views/ResultPage/components/FinalResult.tsx
@@ -1,7 +1,6 @@
 import { useContext, useEffect } from 'react';
 
 import Title from '@components/Title';
-import useGetRecruitingInfo from '@hooks/useGetRecruitingInfo';
 import { RecruitingInfoContext } from '@store/recruitingInfoContext';
 import BigLoading from 'views/loadings/BigLoding';
 
@@ -55,11 +54,12 @@ const Content = ({ isMakers, pass }: { isMakers?: boolean; pass?: boolean }) => 
 };
 
 const FinalResult = () => {
-  const { data, isLoading } = useGetRecruitingInfo();
   const { finalResult, finalResultIsLoading } = useGetFinalResult();
-  const { handleSaveRecruitingInfo } = useContext(RecruitingInfoContext);
+  const {
+    recruitingInfo: { soptName },
+    handleSaveRecruitingInfo,
+  } = useContext(RecruitingInfoContext);
 
-  const { name: soptName, season, group } = data?.data.season || {};
   const { name, pass } = finalResult?.data || {};
 
   const isMakers = soptName?.toLowerCase().includes('makers');
@@ -70,13 +70,10 @@ const FinalResult = () => {
   useEffect(() => {
     handleSaveRecruitingInfo({
       name,
-      soptName,
-      season,
-      group,
     });
-  }, [name, soptName, season, group, handleSaveRecruitingInfo]);
+  }, [name, handleSaveRecruitingInfo]);
 
-  if (isLoading || finalResultIsLoading) return <BigLoading />;
+  if (finalResultIsLoading) return <BigLoading />;
 
   return (
     <section className={container}>

--- a/src/views/ResultPage/components/ScreeningResult.tsx
+++ b/src/views/ResultPage/components/ScreeningResult.tsx
@@ -8,43 +8,23 @@ import { RecruitingInfoContext } from '@store/recruitingInfoContext';
 import BigLoading from 'views/loadings/BigLoding';
 
 import { bottomAnimation, bottomImg, container, content, contentWrapper, link, strongText } from './style.css';
-// import imgSoptLogo from '../assets/imgSoptLogo.png';
-// import imgSoptLogoWebp from '../assets/imgSoptLogo.webp';
 import imgMakersLogo from '../assets/imgMakersLogo.png';
 import imgMakersLogoWebp from '../assets/imgMakersLogo.webp';
+import imgSoptLogo from '../assets/imgSoptLogo.png';
+import imgSoptLogoWebp from '../assets/imgSoptLogo.webp';
 import useGetScreeningResult from '../hooks/useGetScreeningResult';
 
-const Content = ({ pass }: { pass?: boolean }) => {
+const Content = ({ isMakers, pass }: { isMakers?: boolean; pass?: boolean }) => {
   const {
-    recruitingInfo: { name },
+    recruitingInfo: { name, soptName, season, group, interviewStart, interviewEnd, applicationPassConfirmStart },
   } = useContext(RecruitingInfoContext);
-  const { data, isLoading } = useGetRecruitingInfo();
-  const {
-    name: soptName,
-    season,
-    group,
-    ybApplicationPassConfirmStart,
-    obApplicationPassConfirmStart,
-    ybInterviewStart,
-    ybInterviewEnd,
-    obInterviewStart,
-    obInterviewEnd,
-  } = data?.data.season || {};
 
-  if (isLoading) return <BigLoading />;
-
-  const isMakers = soptName?.toLowerCase().includes('makers');
-
-  const interviewStartTime = group === 'OB' ? obInterviewStart : ybInterviewStart;
-  const interviewEndTime = group === 'OB' ? obInterviewEnd : ybInterviewEnd;
-  const applicationPassConfirmTime = group === 'OB' ? obApplicationPassConfirmStart : ybApplicationPassConfirmStart;
-
-  const applicationDate = new Date(applicationPassConfirmTime || '');
+  const applicationDate = new Date(applicationPassConfirmStart || '');
   const applicationPassConfirmNextDay = new Date(applicationDate);
   applicationPassConfirmNextDay.setDate(applicationDate.getDate() + 1);
 
-  const formattedInterviewStart = format(new Date(interviewStartTime || ''), 'M/dd(E)', { locale: ko });
-  const formattedInterviewEnd = format(new Date(interviewEndTime || ''), 'M/dd(E)', { locale: ko });
+  const formattedInterviewStart = format(new Date(interviewStart || ''), 'M/dd(E)', { locale: ko });
+  const formattedInterviewEnd = format(new Date(interviewEnd || ''), 'M/dd(E)', { locale: ko });
   const formattedApplicationPassConfirmStart = format(applicationDate, 'dd일 EEEE', {
     locale: ko,
   });
@@ -100,34 +80,55 @@ const Content = ({ pass }: { pass?: boolean }) => {
 
 const ScreeningResult = () => {
   const { handleSaveRecruitingInfo } = useContext(RecruitingInfoContext);
+
+  const { data, isLoading } = useGetRecruitingInfo();
   const { screeningResult, screeningResultIsLoading } = useGetScreeningResult();
 
-  const { name, season, group } = screeningResult?.data || {};
+  const { name: soptName, obApplicationPassConfirmStart, ybApplicationPassConfirmStart } = data?.data.season || {};
+  const { name, season, group, interviewStart, interviewEnd, pass } = screeningResult?.data || {};
+
+  const applicationPassConfirmStart = group === 'OB' ? obApplicationPassConfirmStart : ybApplicationPassConfirmStart;
 
   useEffect(() => {
     handleSaveRecruitingInfo({
       name,
+      soptName,
       season,
       group,
+      interviewStart,
+      interviewEnd,
+      applicationPassConfirmStart,
     });
-  }, [name, season, group, handleSaveRecruitingInfo]);
+  }, [
+    name,
+    soptName,
+    season,
+    group,
+    interviewStart,
+    interviewEnd,
+    applicationPassConfirmStart,
+    handleSaveRecruitingInfo,
+  ]);
 
-  if (screeningResultIsLoading) return <BigLoading />;
+  if (isLoading || screeningResultIsLoading) return <BigLoading />;
 
-  const { pass } = screeningResult?.data || {};
+  const isMakers = soptName?.toLowerCase().includes('makers');
+
+  const imgLogo = isMakers ? imgMakersLogo : imgSoptLogo;
+  const imgLogoWebp = isMakers ? imgMakersLogoWebp : imgSoptLogoWebp;
 
   return (
     <section className={container}>
       <div className={contentWrapper}>
         <Title>결과 확인</Title>
-        <Content pass={pass} />
+        <Content isMakers={isMakers} pass={pass} />
       </div>
       {pass && (
         <>
           <div className={bottomAnimation} />
           <picture className={bottomImg}>
-            <source srcSet={imgMakersLogoWebp} type="image/webp" />
-            <img src={imgMakersLogo} alt="sopt-logo" />
+            <source srcSet={imgLogoWebp} type="image/webp" />
+            <img src={imgLogo} alt="sopt-logo" />
           </picture>
         </>
       )}

--- a/src/views/ResultPage/components/ScreeningResult.tsx
+++ b/src/views/ResultPage/components/ScreeningResult.tsx
@@ -33,6 +33,8 @@ const Content = ({ pass }: { pass?: boolean }) => {
 
   if (isLoading) return <BigLoading />;
 
+  const isMakers = soptName?.toLowerCase().includes('makers');
+
   const interviewStartTime = group === 'OB' ? obInterviewStart : ybInterviewStart;
   const interviewEndTime = group === 'OB' ? obInterviewEnd : ybInterviewEnd;
   const applicationPassConfirmTime = group === 'OB' ? obApplicationPassConfirmStart : ybApplicationPassConfirmStart;
@@ -60,7 +62,7 @@ const Content = ({ pass }: { pass?: boolean }) => {
             {`
               서류 검토 결과, ${name}님은 면접 대상자로 선정되셨습니다.
   
-              ${season}기 ${group} 면접은 ${formattedInterviewStart} ~ ${formattedInterviewEnd} 양일 간 오프라인 으로 진행될 예정입니다.
+              ${season}기 ${soptName} ${!isMakers ? group : ''} 면접은 ${formattedInterviewStart} ~ ${formattedInterviewEnd} 양일 간 오프라인 으로 진행될 예정입니다.
               모든 면접 대상자 분들은 아래 구글폼을 제출해주세요.
             `}
           </span>
@@ -82,7 +84,7 @@ const Content = ({ pass }: { pass?: boolean }) => {
         <p className={content}>
           {`안녕하세요. ${soptName}입니다.
               
-            ${name}님은 ${season}기 ${soptName} 신입회원 서류 모집에 불합격하셨습니다.
+            ${name}님은 ${season}기 ${soptName} ${!isMakers ? group : ''} 신입회원 서류 모집에 불합격하셨습니다.
 
             지원자님의 뛰어난 역량과 잠재력에도 불구하고 안타깝게도 귀하의 합격 소식을
             전해드리지 못하게 되었습니다.

--- a/src/views/ResultPage/components/ScreeningResult.tsx
+++ b/src/views/ResultPage/components/ScreeningResult.tsx
@@ -3,7 +3,6 @@ import { ko } from 'date-fns/locale';
 import { useContext, useEffect } from 'react';
 
 import Title from '@components/Title';
-import useGetRecruitingInfo from '@hooks/useGetRecruitingInfo';
 import { RecruitingInfoContext } from '@store/recruitingInfoContext';
 import BigLoading from 'views/loadings/BigLoding';
 
@@ -79,38 +78,24 @@ const Content = ({ isMakers, pass }: { isMakers?: boolean; pass?: boolean }) => 
 };
 
 const ScreeningResult = () => {
-  const { handleSaveRecruitingInfo } = useContext(RecruitingInfoContext);
+  const {
+    recruitingInfo: { soptName },
+    handleSaveRecruitingInfo,
+  } = useContext(RecruitingInfoContext);
 
-  const { data, isLoading } = useGetRecruitingInfo();
   const { screeningResult, screeningResultIsLoading } = useGetScreeningResult();
 
-  const { name: soptName, obApplicationPassConfirmStart, ybApplicationPassConfirmStart } = data?.data.season || {};
-  const { name, season, group, interviewStart, interviewEnd, pass } = screeningResult?.data || {};
-
-  const applicationPassConfirmStart = group === 'OB' ? obApplicationPassConfirmStart : ybApplicationPassConfirmStart;
+  const { name, interviewStart, interviewEnd, pass } = screeningResult?.data || {};
 
   useEffect(() => {
     handleSaveRecruitingInfo({
       name,
-      soptName,
-      season,
-      group,
       interviewStart,
       interviewEnd,
-      applicationPassConfirmStart,
     });
-  }, [
-    name,
-    soptName,
-    season,
-    group,
-    interviewStart,
-    interviewEnd,
-    applicationPassConfirmStart,
-    handleSaveRecruitingInfo,
-  ]);
+  }, [name, interviewStart, interviewEnd, handleSaveRecruitingInfo]);
 
-  if (isLoading || screeningResultIsLoading) return <BigLoading />;
+  if (screeningResultIsLoading) return <BigLoading />;
 
   const isMakers = soptName?.toLowerCase().includes('makers');
 

--- a/src/views/ResultPage/index.tsx
+++ b/src/views/ResultPage/index.tsx
@@ -1,6 +1,7 @@
 import { useContext, useEffect } from 'react';
 
 import useDate from '@hooks/useDate';
+import { RecruitingInfoContext } from '@store/recruitingInfoContext';
 import { ThemeContext } from '@store/themeContext';
 import NoMore from 'views/ErrorPage/components/NoMore';
 import BigLoading from 'views/loadings/BigLoding';
@@ -9,8 +10,22 @@ import FinalResult from './components/FinalResult';
 import ScreeningResult from './components/ScreeningResult';
 
 const ResultPage = () => {
+  const { handleSaveRecruitingInfo } = useContext(RecruitingInfoContext);
   const { handleChangeMode } = useContext(ThemeContext);
-  const { NoMoreRecruit, NoMoreScreeningResult, NoMoreFinalResult, isLoading } = useDate();
+
+  const {
+    name: soptName,
+    season,
+    group,
+    obApplicationPassConfirmStart,
+    ybApplicationPassConfirmStart,
+    NoMoreRecruit,
+    NoMoreScreeningResult,
+    NoMoreFinalResult,
+    isLoading,
+  } = useDate();
+
+  const applicationPassConfirmStart = group === 'OB' ? obApplicationPassConfirmStart : ybApplicationPassConfirmStart;
 
   useEffect(() => {
     handleChangeMode('dark');
@@ -19,6 +34,15 @@ const ResultPage = () => {
       handleChangeMode('light');
     };
   }, [handleChangeMode]);
+
+  useEffect(() => {
+    handleSaveRecruitingInfo({
+      soptName,
+      season,
+      group,
+      applicationPassConfirmStart,
+    });
+  }, [soptName, season, group, applicationPassConfirmStart, handleSaveRecruitingInfo]);
 
   if (isLoading) return <BigLoading />;
 

--- a/src/views/SignInPage/components/SignInInfo/index.tsx
+++ b/src/views/SignInPage/components/SignInInfo/index.tsx
@@ -12,11 +12,11 @@ interface SignInInfoProps extends SeasonGroupType {
   name?: string;
 }
 
-const SignInInfo = ({ name, season, group }: SignInInfoProps) => {
+const SignInInfo = ({ name: soptName, season, group }: SignInInfoProps) => {
   return (
     <>
       <Title>
-        {season}기 {name} {name === 'Makers' ? '' : group} 지원하기
+        {season}기 {soptName} {soptName === 'Makers' ? '' : group} 지원하기
       </Title>
       <Callout
         Button={
@@ -25,7 +25,7 @@ const SignInInfo = ({ name, season, group }: SignInInfoProps) => {
           </Link>
         }>
         <p>
-          {season}기 {name} {name === 'Makers' ? '' : group} 지원서 작성이 처음이라면 ‘새 지원서 작성하기’를
+          {season}기 {soptName} {soptName === 'Makers' ? '' : group} 지원서 작성이 처음이라면 ‘새 지원서 작성하기’를
           진행해주세요. <strong className={strongText}>이전에 지원서 </strong>를 제출한 적이 있더라도{' '}
           <strong className={strongText}>반드시</strong> 새 지원서를 작성해야 해요.
         </p>

--- a/src/views/SignInPage/components/SignInInfo/index.tsx
+++ b/src/views/SignInPage/components/SignInInfo/index.tsx
@@ -16,7 +16,7 @@ const SignInInfo = ({ name, season, group }: SignInInfoProps) => {
   return (
     <>
       <Title>
-        {season}기 {name === 'Makers' ? '' : group} {name} 지원하기
+        {season}기 {name} {name === 'Makers' ? '' : group} 지원하기
       </Title>
       <Callout
         Button={
@@ -25,7 +25,7 @@ const SignInInfo = ({ name, season, group }: SignInInfoProps) => {
           </Link>
         }>
         <p>
-          {season}기 {name === 'Makers' ? '' : group} {name} 지원서 작성이 처음이라면 ‘새 지원서 작성하기’를
+          {season}기 {name} {name === 'Makers' ? '' : group} 지원서 작성이 처음이라면 ‘새 지원서 작성하기’를
           진행해주세요. <strong className={strongText}>이전에 지원서 </strong>를 제출한 적이 있더라도{' '}
           <strong className={strongText}>반드시</strong> 새 지원서를 작성해야 해요.
         </p>

--- a/src/views/SignInPage/components/SignInInfo/index.tsx
+++ b/src/views/SignInPage/components/SignInInfo/index.tsx
@@ -13,10 +13,12 @@ interface SignInInfoProps extends SeasonGroupType {
 }
 
 const SignInInfo = ({ soptName, season, group }: SignInInfoProps) => {
+  const isMakers = soptName?.toLowerCase().includes('makers');
+
   return (
     <>
       <Title>
-        {season}기 {soptName} {soptName === 'Makers' ? '' : group} 지원하기
+        {season}기 {soptName} {isMakers ? '' : group} 지원하기
       </Title>
       <Callout
         Button={
@@ -25,8 +27,8 @@ const SignInInfo = ({ soptName, season, group }: SignInInfoProps) => {
           </Link>
         }>
         <p>
-          {season}기 {soptName} {soptName === 'Makers' ? '' : group} 지원서 작성이 처음이라면 ‘새 지원서 작성하기’를
-          진행해주세요. <strong className={strongText}>이전에 지원서 </strong>를 제출한 적이 있더라도{' '}
+          {season}기 {soptName} {isMakers ? '' : group} 지원서 작성이 처음이라면 ‘새 지원서 작성하기’를 진행해주세요.{' '}
+          <strong className={strongText}>이전에 지원서 </strong>를 제출한 적이 있더라도{' '}
           <strong className={strongText}>반드시</strong> 새 지원서를 작성해야 해요.
         </p>
       </Callout>

--- a/src/views/SignInPage/components/SignInInfo/index.tsx
+++ b/src/views/SignInPage/components/SignInInfo/index.tsx
@@ -9,10 +9,10 @@ import { calloutButton, strongText } from './style.css';
 import type { SeasonGroupType } from '@type/seasonAndGroup';
 
 interface SignInInfoProps extends SeasonGroupType {
-  name?: string;
+  soptName?: string;
 }
 
-const SignInInfo = ({ name: soptName, season, group }: SignInInfoProps) => {
+const SignInInfo = ({ soptName, season, group }: SignInInfoProps) => {
   return (
     <>
       <Title>

--- a/src/views/SignInPage/components/SignInInfo/index.tsx
+++ b/src/views/SignInPage/components/SignInInfo/index.tsx
@@ -8,10 +8,16 @@ import { calloutButton, strongText } from './style.css';
 
 import type { SeasonGroupType } from '@type/seasonAndGroup';
 
-const SignInInfo = ({ season }: SeasonGroupType) => {
+interface SignInInfoProps extends SeasonGroupType {
+  name?: string;
+}
+
+const SignInInfo = ({ name, season, group }: SignInInfoProps) => {
   return (
     <>
-      <Title>{season}기 Makers 지원하기</Title>
+      <Title>
+        {season}기 {name === 'Makers' ? '' : group} {name} 지원하기
+      </Title>
       <Callout
         Button={
           <Link to="/sign-up" className={calloutButton} onClick={() => track('click-signin-signup')}>
@@ -19,8 +25,8 @@ const SignInInfo = ({ season }: SeasonGroupType) => {
           </Link>
         }>
         <p>
-          {season}기 Makers 지원서 작성이 처음이라면 ‘새 지원서 작성하기’를 진행해주세요.{' '}
-          <strong className={strongText}>이전에 지원서 </strong>를 제출한 적이 있더라도{' '}
+          {season}기 {name === 'Makers' ? '' : group} {name} 지원서 작성이 처음이라면 ‘새 지원서 작성하기’를
+          진행해주세요. <strong className={strongText}>이전에 지원서 </strong>를 제출한 적이 있더라도{' '}
           <strong className={strongText}>반드시</strong> 새 지원서를 작성해야 해요.
         </p>
       </Callout>

--- a/src/views/SignInPage/index.tsx
+++ b/src/views/SignInPage/index.tsx
@@ -8,12 +8,12 @@ import { container } from './style.css';
 
 const SignInPage = () => {
   const {
-    recruitingInfo: { name, season, group },
+    recruitingInfo: { soptName, season, group },
   } = useContext(RecruitingInfoContext);
 
   return (
     <div className={container}>
-      <SignInInfo name={name} season={season} group={group} />
+      <SignInInfo soptName={soptName} season={season} group={group} />
       <SignInForm season={season} group={group} />
     </div>
   );

--- a/src/views/SignInPage/index.tsx
+++ b/src/views/SignInPage/index.tsx
@@ -8,12 +8,12 @@ import { container } from './style.css';
 
 const SignInPage = () => {
   const {
-    recruitingInfo: { season, group },
+    recruitingInfo: { name, season, group },
   } = useContext(RecruitingInfoContext);
 
   return (
     <div className={container}>
-      <SignInInfo season={season} />
+      <SignInInfo name={name} season={season} group={group} />
       <SignInForm season={season} group={group} />
     </div>
   );


### PR DESCRIPTION
**Related Issue :** Closes #207 

---

## 🧑‍🎤 Summary
- [x] Makers 라고 하드 코딩 되어 있는 거 서버에서 동적으로 받아오게 하기
- [x] Makers 여부에 따라 group 및 image 조건부 렌더링
- [x] result page, 데이터 받아오는 방식 수정

## 🧑‍🎤 Comment
### isMakers?
soptName을 서버로 부터 받아와서 해당 name에 makers가 포함 되었는지 여부에 따라
makers 모집인지 sopt 모집인지 구분해 줬어요
이를 이용해서 공고 문구, 로고 등을 조건부 렌더링 처리했어요
makers 모집이라면 group 데이터는 렌더링하지 않도록 처리해줬습니다!

### 불필요한 api 요청 제거
useDate()에서는 useGetRecruitingInfo()를 이용해서 데이터를 받아오고 있었어요
근데 useDate를 사용하는 곳에서 한 번 더 useGetRecruitingInfo를 이용해 데이터를 받아오고 있더라고요
그래서 useDate에서 useGetRecruitingInfo data를 사용할 수 있도록 해당 데이터를 넘겨줬습니다

```tsx
const useDate = () => {
  const { data, isLoading } = useGetRecruitingInfo();
  // ...

  return {
    ...data?.data.season,
  };
};
```