### PR TITLE
[Fix] 두 번 api 요청 가는 이슈 해결

### DIFF
--- a/src/common/components/Layout/components/Header/index.tsx
+++ b/src/common/components/Layout/components/Header/index.tsx
@@ -18,8 +18,6 @@ const Header = () => {
     recruitingInfo: { name, isMakers },
   } = useContext(RecruitingInfoContext);
 
-  console.log(isMakers);
-
   const handleClickLogo = () => {
     if (pathname === '/') navigate(0);
     else navigate('/');

--- a/src/common/components/Layout/components/Header/index.tsx
+++ b/src/common/components/Layout/components/Header/index.tsx
@@ -15,10 +15,8 @@ const Header = () => {
   const { pathname } = useLocation();
   const isSignedIn = localStorage.getItem('soptApplyAccessToken');
   const {
-    recruitingInfo: { name, soptName },
+    recruitingInfo: { name, isMakers },
   } = useContext(RecruitingInfoContext);
-
-  const isMakers = soptName?.toLowerCase().includes('makers');
 
   const handleClickLogo = () => {
     if (pathname === '/') navigate(0);

--- a/src/common/components/Layout/components/Header/index.tsx
+++ b/src/common/components/Layout/components/Header/index.tsx
@@ -18,6 +18,8 @@ const Header = () => {
     recruitingInfo: { name, isMakers },
   } = useContext(RecruitingInfoContext);
 
+  console.log(isMakers);
+
   const handleClickLogo = () => {
     if (pathname === '/') navigate(0);
     else navigate('/');
@@ -34,7 +36,7 @@ const Header = () => {
   return (
     <header className={container}>
       <button onClick={handleClickLogo} className={logo}>
-        {isMakers ? <MakersLogo /> : <NowsoptLogo />}
+        {isMakers ? <MakersLogo /> : isMakers === false ? <NowsoptLogo /> : null}
       </button>
       <nav>
         <ul className={menuList}>

--- a/src/common/hooks/useDate.tsx
+++ b/src/common/hooks/useDate.tsx
@@ -1,11 +1,18 @@
 import { isAfter, isBefore } from 'date-fns';
+import { useContext, useEffect } from 'react';
+
+import { RecruitingInfoContext } from '@store/recruitingInfoContext';
 
 import useGetRecruitingInfo from './useGetRecruitingInfo';
 
 const useDate = () => {
+  const { handleSaveRecruitingInfo } = useContext(RecruitingInfoContext);
+
   const { data, isLoading } = useGetRecruitingInfo();
 
   const {
+    name,
+    season,
     group,
     ybApplicationStart,
     obApplicationStart,
@@ -23,8 +30,8 @@ const useDate = () => {
     obFinalPassConfirmStart,
     ybFinalPassConfirmEnd,
     obFinalPassConfirmEnd,
-    // ybInterviewStart,
-    // obInterviewStart,
+    ybInterviewStart,
+    obInterviewStart,
     ybInterviewEnd,
     obInterviewEnd,
   } = data?.data.season || {};
@@ -35,12 +42,11 @@ const useDate = () => {
   // const applicationConfirmEndValue = group === 'YB' ? ybApplicationConfirmEnd : obApplicationConfirmEnd; // 서류 검사 마감
   const applicationPassConfirmStart = group === 'YB' ? ybApplicationPassConfirmStart : obApplicationPassConfirmStart; // 서류 합격 시작
   const applicationPassConfirmEnd = group === 'YB' ? ybApplicationPassConfirmEnd : obApplicationPassConfirmEnd; // 서류 합격 마감
-  // const interviewStart = group === 'YB' ? ybInterviewStart : obInterviewStart; // 면접 시작
-  const interviewEnd = group === 'YB' ? ybInterviewEnd : obInterviewEnd; // 면접 마감
+  const interviewStart = group === 'YB' ? ybInterviewStart : obInterviewStart;
+  const interviewEnd = group === 'YB' ? ybInterviewEnd : obInterviewEnd;
   const finalPassConfirmStart = group === 'YB' ? ybFinalPassConfirmStart : obFinalPassConfirmStart; // 최종 합격 시작
   const finalPassConfirmEnd = group === 'YB' ? ybFinalPassConfirmEnd : obFinalPassConfirmEnd; // 최종 합격 마감
 
-  // 서류 전 / 서류 중간 / 서류 마감 / 합격 기다리는 중 / 서류 합격 시작 / 서률 합격 중 / 서류 합격 마감 / 기다리는 중 / 면접 시작 / 면접 마감 / 기다리는 중 / 최종 합격 / 최종 합격 마감
   const beforeRecruiting = isAfter(new Date(applicationStart || ''), new Date());
   const afterRecruiting = isBefore(new Date(finalPassConfirmEnd || ''), new Date());
   const afterApply = isBefore(new Date(applicationEnd || ''), new Date());
@@ -54,6 +60,37 @@ const useDate = () => {
   const NoMoreScreeningResult = beforeScreeningResult || afterScreeningResult; // 서류 합불 확인 기간 아님
   const NoMoreReview = afterInterview; // 면접 마감 -> 지원서 확인 불가
   const NoMoreFinalResult = beforeFinalResult || afterRecruiting; // 최종 합불 확인 기간 아님
+
+  useEffect(() => {
+    handleSaveRecruitingInfo({
+      soptName: name,
+      season,
+      group,
+      applicationStart, // 서류 지원 시작
+      applicationEnd, // 서류 지원 끝
+      // applicationConfirmStart, // 서류 지원 확인 시작
+      // applicationConfirmEnd, // 서류 지원 확인 종료
+      applicationPassConfirmStart, // 서류 합격 확인 시작
+      applicationPassConfirmEnd, // 서류 합격 확인 종료
+      finalPassConfirmStart, // 최종 합격 확인 시작
+      finalPassConfirmEnd, // 최종 합격 확인 종료
+      interviewStart, // 면접 시작
+      interviewEnd, // 면접 끝
+    });
+  }, [
+    name,
+    season,
+    group,
+    applicationStart,
+    applicationEnd,
+    applicationPassConfirmStart,
+    applicationPassConfirmEnd,
+    finalPassConfirmStart,
+    finalPassConfirmEnd,
+    interviewStart,
+    interviewEnd,
+    handleSaveRecruitingInfo,
+  ]);
 
   return {
     ...data?.data.season,

--- a/src/common/hooks/useDate.tsx
+++ b/src/common/hooks/useDate.tsx
@@ -61,6 +61,8 @@ const useDate = () => {
   const NoMoreReview = afterInterview; // 면접 마감 -> 지원서 확인 불가
   const NoMoreFinalResult = beforeFinalResult || afterRecruiting; // 최종 합불 확인 기간 아님
 
+  const isMakers = name?.toLowerCase().includes('makers');
+
   useEffect(() => {
     handleSaveRecruitingInfo({
       soptName: name,
@@ -100,6 +102,7 @@ const useDate = () => {
     NoMoreReview,
     NoMoreFinalResult,
     isLoading,
+    isMakers,
   };
 };
 

--- a/src/common/hooks/useDate.tsx
+++ b/src/common/hooks/useDate.tsx
@@ -78,6 +78,7 @@ const useDate = () => {
       finalPassConfirmEnd, // 최종 합격 확인 종료
       interviewStart, // 면접 시작
       interviewEnd, // 면접 끝
+      isMakers,
     });
   }, [
     name,
@@ -91,6 +92,7 @@ const useDate = () => {
     finalPassConfirmEnd,
     interviewStart,
     interviewEnd,
+    isMakers,
     handleSaveRecruitingInfo,
   ]);
 

--- a/src/common/store/recruitingInfoContext.ts
+++ b/src/common/store/recruitingInfoContext.ts
@@ -15,6 +15,7 @@ export type RecruitingInfoType = {
   finalPassConfirmEnd?: string;
   interviewStart?: string;
   interviewEnd?: string;
+  isMakers?: boolean;
 };
 
 interface RecruitingInfoContextType {

--- a/src/views/ApplyPage/components/ApplyHeader/index.tsx
+++ b/src/views/ApplyPage/components/ApplyHeader/index.tsx
@@ -15,10 +15,8 @@ interface ApplyHeaderProps {
 
 const ApplyHeader = ({ isReview, isLoading, onSaveDraft, onSubmitData }: ApplyHeaderProps) => {
   const {
-    recruitingInfo: { soptName, season, group },
+    recruitingInfo: { soptName, season, group, isMakers },
   } = useContext(RecruitingInfoContext);
-
-  const isMakers = soptName?.toLowerCase().includes('makers');
 
   return (
     <header className={headerContainer}>

--- a/src/views/ApplyPage/index.tsx
+++ b/src/views/ApplyPage/index.tsx
@@ -51,7 +51,7 @@ const ApplyPage = ({ isReview, onSetComplete, draftData }: ApplyPageProps) => {
     partQuestions: partQuestionsDraft,
   } = draftData?.data || {};
 
-  const { name: soptName, NoMoreReview, isLoading } = useDate();
+  const { NoMoreReview, isLoading, isMakers } = useDate();
   const { questionsData, questionsIsLoading } = useGetQuestions(applicantDraft);
   const { commonQuestions, partQuestions, questionTypes } = questionsData?.data || {};
 
@@ -88,8 +88,6 @@ const ApplyPage = ({ isReview, onSetComplete, draftData }: ApplyPageProps) => {
     phone,
     ...rest
   } = getValues();
-
-  const isMakers = soptName?.toLowerCase().includes('makers');
 
   useEffect(() => {
     if (applicantDraft?.part) {

--- a/src/views/MainPage/index.tsx
+++ b/src/views/MainPage/index.tsx
@@ -1,86 +1,8 @@
-import { isAfter, isBefore } from 'date-fns';
-import { useContext, useEffect } from 'react';
-
-import useGetRecruitingInfo from '@hooks/useGetRecruitingInfo';
-import { RecruitingInfoContext } from '@store/recruitingInfoContext';
-import NoMore from 'views/ErrorPage/components/NoMore';
-import BigLoading from 'views/loadings/BigLoding';
 import SignedInPage from 'views/SignedInPage';
 import SignInPage from 'views/SignInPage';
 
 const MainPage = () => {
-  const {
-    recruitingInfo: { applicationStart, finalPassConfirmEnd },
-    handleSaveRecruitingInfo,
-  } = useContext(RecruitingInfoContext);
-  const isSignedIn = localStorage.getItem('soptApplyAccessToken');
-
-  const { data, isLoading } = useGetRecruitingInfo();
-
-  useEffect(() => {
-    if (!data) return;
-
-    const {
-      name,
-      season,
-      group,
-      ybApplicationStart,
-      obApplicationStart,
-      ybApplicationEnd,
-      obApplicationEnd,
-      // ybApplicationConfirmStart,
-      // obApplicationConfirmStart,
-      // ybApplicationConfirmEnd,
-      // obApplicationConfirmEnd,
-      ybApplicationPassConfirmStart,
-      obApplicationPassConfirmStart,
-      ybApplicationPassConfirmEnd,
-      obApplicationPassConfirmEnd,
-      ybFinalPassConfirmStart,
-      obFinalPassConfirmStart,
-      ybFinalPassConfirmEnd,
-      obFinalPassConfirmEnd,
-      ybInterviewStart,
-      obInterviewStart,
-      ybInterviewEnd,
-      obInterviewEnd,
-    } = data.data.season;
-
-    const applicationStart = group === 'YB' ? ybApplicationStart : obApplicationStart;
-    const applicationEnd = group === 'YB' ? ybApplicationEnd : obApplicationEnd;
-    // const applicationConfirmStartValue = group === 'YB' ? ybApplicationConfirmStart : obApplicationConfirmStart;
-    // const applicationConfirmEndValue = group === 'YB' ? ybApplicationConfirmEnd : obApplicationConfirmEnd;
-    const applicationPassConfirmStart = group === 'YB' ? ybApplicationPassConfirmStart : obApplicationPassConfirmStart;
-    const applicationPassConfirmEnd = group === 'YB' ? ybApplicationPassConfirmEnd : obApplicationPassConfirmEnd;
-    const finalPassConfirmStart = group === 'YB' ? ybFinalPassConfirmStart : obFinalPassConfirmStart;
-    const finalPassConfirmEnd = group === 'YB' ? ybFinalPassConfirmEnd : obFinalPassConfirmEnd;
-    const interviewStart = group === 'YB' ? ybInterviewStart : obInterviewStart;
-    const interviewEnd = group === 'YB' ? ybInterviewEnd : obInterviewEnd;
-
-    handleSaveRecruitingInfo({
-      soptName: name,
-      season,
-      group,
-      applicationStart, // 서류 지원 시작
-      applicationEnd, // 서류 지원 끝
-      // applicationConfirmStart, // 서류 지원 확인 시작
-      // applicationConfirmEnd, // 서류 지원 확인 종료
-      applicationPassConfirmStart, // 서류 합격 확인 시작
-      applicationPassConfirmEnd, // 서류 합격 확인 종료
-      finalPassConfirmStart, // 최종 합격 확인 시작
-      finalPassConfirmEnd, // 최종 합격 확인 종료
-      interviewStart, // 면접 시작
-      interviewEnd, // 면접 끝
-    });
-  }, [data, handleSaveRecruitingInfo]);
-
-  if (isLoading) return <BigLoading />;
-
-  const beforeRecruiting = isAfter(new Date(applicationStart || ''), new Date());
-  const afterRecruiting = isBefore(new Date(finalPassConfirmEnd || ''), new Date());
-  const isMakers = data?.data.season.name.toLowerCase().includes('makers');
-
-  if (beforeRecruiting || afterRecruiting) return <NoMore isMakers={isMakers} content="모집 기간이 아니에요" />;
+  const isSignedIn = sessionStorage.getItem('soptApplyAccessToken');
 
   return <>{isSignedIn ? <SignedInPage /> : <SignInPage />}</>;
 };

--- a/src/views/MainPage/index.tsx
+++ b/src/views/MainPage/index.tsx
@@ -2,7 +2,7 @@ import SignedInPage from 'views/SignedInPage';
 import SignInPage from 'views/SignInPage';
 
 const MainPage = () => {
-  const isSignedIn = sessionStorage.getItem('soptApplyAccessToken');
+  const isSignedIn = localStorage.getItem('soptApplyAccessToken');
 
   return <>{isSignedIn ? <SignedInPage /> : <SignInPage />}</>;
 };

--- a/src/views/MyPage/index.tsx
+++ b/src/views/MyPage/index.tsx
@@ -20,9 +20,9 @@ const MyInfoItem = ({ label, value }: { label: string; value?: string | number |
 
 const MyPage = ({ onShowReview }: { onShowReview: () => void }) => {
   const { myInfoData, myInfoIsLoading } = useGetMyInfo();
-  const { NoMoreReview, NoMoreScreeningResult, NoMoreFinalResult } = useDate();
+  const { NoMoreReview, NoMoreScreeningResult, NoMoreFinalResult, isLoading } = useDate();
 
-  if (myInfoIsLoading) return <BigLoading />;
+  if (myInfoIsLoading || isLoading) return <BigLoading />;
 
   const { season, name, part } = myInfoData?.data || {};
 

--- a/src/views/PasswordPage/index.tsx
+++ b/src/views/PasswordPage/index.tsx
@@ -7,12 +7,9 @@ import PasswordForm from './components/PasswordForm';
 import { container } from './style.css';
 
 const PasswordPage = () => {
-  const { name: soptName, season, group, NoMoreRecruit, isLoading } = useDate();
+  const { season, group, NoMoreRecruit, isLoading, isMakers } = useDate();
 
   if (isLoading) return <BigLoading />;
-
-  const isMakers = soptName?.toLowerCase().includes('makers');
-
   if (NoMoreRecruit) return <NoMore isMakers={isMakers} content="모집 기간이 아니에요" />;
 
   return (

--- a/src/views/ResultPage/components/FinalResult.tsx
+++ b/src/views/ResultPage/components/FinalResult.tsx
@@ -56,13 +56,11 @@ const Content = ({ isMakers, pass }: { isMakers?: boolean; pass?: boolean }) => 
 const FinalResult = () => {
   const { finalResult, finalResultIsLoading } = useGetFinalResult();
   const {
-    recruitingInfo: { soptName },
+    recruitingInfo: { isMakers },
     handleSaveRecruitingInfo,
   } = useContext(RecruitingInfoContext);
 
   const { name, pass } = finalResult?.data || {};
-
-  const isMakers = soptName?.toLowerCase().includes('makers');
 
   const imgLogo = isMakers ? imgMakersLogo : imgSoptLogo;
   const imgLogoWebp = isMakers ? imgMakersLogoWebp : imgSoptLogoWebp;

--- a/src/views/ResultPage/components/ScreeningResult.tsx
+++ b/src/views/ResultPage/components/ScreeningResult.tsx
@@ -79,10 +79,9 @@ const Content = ({ isMakers, pass }: { isMakers?: boolean; pass?: boolean }) => 
 
 const ScreeningResult = () => {
   const {
-    recruitingInfo: { soptName },
+    recruitingInfo: { isMakers },
     handleSaveRecruitingInfo,
   } = useContext(RecruitingInfoContext);
-
   const { screeningResult, screeningResultIsLoading } = useGetScreeningResult();
 
   const { name, interviewStart, interviewEnd, pass } = screeningResult?.data || {};
@@ -96,8 +95,6 @@ const ScreeningResult = () => {
   }, [name, interviewStart, interviewEnd, handleSaveRecruitingInfo]);
 
   if (screeningResultIsLoading) return <BigLoading />;
-
-  const isMakers = soptName?.toLowerCase().includes('makers');
 
   const imgLogo = isMakers ? imgMakersLogo : imgSoptLogo;
   const imgLogoWebp = isMakers ? imgMakersLogoWebp : imgSoptLogoWebp;

--- a/src/views/ResultPage/index.tsx
+++ b/src/views/ResultPage/index.tsx
@@ -1,7 +1,6 @@
 import { useContext, useEffect } from 'react';
 
 import useDate from '@hooks/useDate';
-import { RecruitingInfoContext } from '@store/recruitingInfoContext';
 import { ThemeContext } from '@store/themeContext';
 import NoMore from 'views/ErrorPage/components/NoMore';
 import BigLoading from 'views/loadings/BigLoding';
@@ -10,23 +9,9 @@ import FinalResult from './components/FinalResult';
 import ScreeningResult from './components/ScreeningResult';
 
 const ResultPage = () => {
-  const { handleSaveRecruitingInfo } = useContext(RecruitingInfoContext);
   const { handleChangeMode } = useContext(ThemeContext);
 
-  const {
-    name: soptName,
-    season,
-    group,
-    obApplicationPassConfirmStart,
-    ybApplicationPassConfirmStart,
-    NoMoreRecruit,
-    NoMoreScreeningResult,
-    NoMoreFinalResult,
-    isLoading,
-    isMakers,
-  } = useDate();
-
-  const applicationPassConfirmStart = group === 'OB' ? obApplicationPassConfirmStart : ybApplicationPassConfirmStart;
+  const { NoMoreRecruit, NoMoreScreeningResult, NoMoreFinalResult, isLoading, isMakers } = useDate();
 
   useEffect(() => {
     handleChangeMode('dark');
@@ -35,15 +20,6 @@ const ResultPage = () => {
       handleChangeMode('light');
     };
   }, [handleChangeMode]);
-
-  useEffect(() => {
-    handleSaveRecruitingInfo({
-      soptName,
-      season,
-      group,
-      applicationPassConfirmStart,
-    });
-  }, [soptName, season, group, applicationPassConfirmStart, handleSaveRecruitingInfo]);
 
   if (isLoading) return <BigLoading />;
   if (NoMoreRecruit || (NoMoreScreeningResult && NoMoreFinalResult))

--- a/src/views/ResultPage/index.tsx
+++ b/src/views/ResultPage/index.tsx
@@ -23,10 +23,10 @@ const ResultPage = () => {
     NoMoreScreeningResult,
     NoMoreFinalResult,
     isLoading,
+    isMakers,
   } = useDate();
 
   const applicationPassConfirmStart = group === 'OB' ? obApplicationPassConfirmStart : ybApplicationPassConfirmStart;
-  const isMakers = soptName?.toLowerCase().includes('makers');
 
   useEffect(() => {
     handleChangeMode('dark');
@@ -46,7 +46,6 @@ const ResultPage = () => {
   }, [soptName, season, group, applicationPassConfirmStart, handleSaveRecruitingInfo]);
 
   if (isLoading) return <BigLoading />;
-
   if (NoMoreRecruit || (NoMoreScreeningResult && NoMoreFinalResult))
     return <NoMore isMakers={isMakers} content="합불 확인 기간이 아니에요" />;
 

--- a/src/views/SignInPage/components/SignInInfo/index.tsx
+++ b/src/views/SignInPage/components/SignInInfo/index.tsx
@@ -10,11 +10,10 @@ import type { SeasonGroupType } from '@type/seasonAndGroup';
 
 interface SignInInfoProps extends SeasonGroupType {
   soptName?: string;
+  isMakers?: boolean;
 }
 
-const SignInInfo = ({ soptName, season, group }: SignInInfoProps) => {
-  const isMakers = soptName?.toLowerCase().includes('makers');
-
+const SignInInfo = ({ soptName, isMakers, season, group }: SignInInfoProps) => {
   return (
     <>
       <Title>

--- a/src/views/SignInPage/index.tsx
+++ b/src/views/SignInPage/index.tsx
@@ -14,7 +14,7 @@ const SignInPage = () => {
 
   return (
     <div className={container}>
-      <SignInInfo soptName={soptName} season={season} group={group} />
+      <SignInInfo soptName={soptName} isMakers={isMakers} season={season} group={group} />
       <SignInForm season={season} group={group} />
     </div>
   );

--- a/src/views/SignInPage/index.tsx
+++ b/src/views/SignInPage/index.tsx
@@ -1,15 +1,16 @@
-import { useContext } from 'react';
-
-import { RecruitingInfoContext } from '@store/recruitingInfoContext';
+import useDate from '@hooks/useDate';
+import NoMore from 'views/ErrorPage/components/NoMore';
+import BigLoading from 'views/loadings/BigLoding';
 
 import SignInForm from './components/SignInForm';
 import SignInInfo from './components/SignInInfo';
 import { container } from './style.css';
 
 const SignInPage = () => {
-  const {
-    recruitingInfo: { soptName, season, group },
-  } = useContext(RecruitingInfoContext);
+  const { name: soptName, season, group, isLoading, NoMoreRecruit, isMakers } = useDate();
+
+  if (isLoading) return <BigLoading />;
+  if (NoMoreRecruit) return <NoMore isMakers={isMakers} content="모집 기간이 아니에요" />;
 
   return (
     <div className={container}>

--- a/src/views/SignupPage/index.tsx
+++ b/src/views/SignupPage/index.tsx
@@ -7,12 +7,9 @@ import SignupForm from './components/SignupForm';
 import { container } from './style.css';
 
 const SignupPage = () => {
-  const { name: soptName, season, group, NoMoreRecruit, NoMoreApply, isLoading } = useDate();
+  const { season, group, NoMoreRecruit, NoMoreApply, isLoading, isMakers } = useDate();
 
   if (isLoading) return <BigLoading />;
-
-  const isMakers = soptName?.toLowerCase().includes('makers');
-
   if (NoMoreRecruit || NoMoreApply) return <NoMore isMakers={isMakers} content="모집 기간이 아니에요" />;
 
   return (


### PR DESCRIPTION
**Related Issue :** Closes #224 

---

## 🧑‍🎤 Summary
- [x] latest api 2번 요청 가는 에러 해결
- [x] isMakers -> useDate에서 관리
- [x] GNB 메이커스 로고 보이기 전 sopt 로고 살짝 보이는 에러 해결



## 🧑‍🎤 Screenshot
<img width="223" alt="스크린샷 2024-07-25 오후 3 42 08" src="https://github.com/user-attachments/assets/56082739-9873-4630-bb5e-96d87183597d">

전

<br/>

![스크린샷 2024-07-25 오후 3 41 39](https://github.com/user-attachments/assets/21a2b3b5-fa44-47ff-bbda-db234ca4d305)
후

## 🧑‍🎤 Comment
- ### latest api 2번 요청 가는 에러 해결
코리 달린 거 확인하고 코드를 다시 보니 api 요청을 두 번씩이나 보내고 있더라고요
한 번만 보낼 수 있도록 수정해줬어요

- ### isMakers -> useDate에서 관리
soptName을 통해 매번 계산 해주고 있던 거를 useDate return 값으로 보내도록 수정했어요

- ### GNB 메이커스 로고 보이기 전 sopt 로고 살짝 보이는 에러 해결
isMakers 판단하기 동안 undefined 상태일 때 sopt 로고가 보이게 되는데 수정해줬습니다