### PR TITLE
[Fix] result page 500 에러 해결

### DIFF
--- a/src/views/ResultPage/components/FinalResult.tsx
+++ b/src/views/ResultPage/components/FinalResult.tsx
@@ -16,6 +16,8 @@ const Content = ({ isMakers, pass }: { isMakers?: boolean; pass?: boolean }) => 
     recruitingInfo: { name, soptName, season, group },
   } = useContext(RecruitingInfoContext);
 
+  if (!name) return;
+
   return (
     <>
       {pass ? (

--- a/src/views/ResultPage/components/ScreeningResult.tsx
+++ b/src/views/ResultPage/components/ScreeningResult.tsx
@@ -18,6 +18,8 @@ const Content = ({ isMakers, pass }: { isMakers?: boolean; pass?: boolean }) => 
     recruitingInfo: { name, soptName, season, group, interviewStart, interviewEnd, applicationPassConfirmStart },
   } = useContext(RecruitingInfoContext);
 
+  if (!name) return;
+
   const applicationDate = new Date(applicationPassConfirmStart || '');
   const applicationPassConfirmNextDay = new Date(applicationDate);
   applicationPassConfirmNextDay.setDate(applicationDate.getDate() + 1);


### PR DESCRIPTION
**Related Issue :** Closes #216 

---

## 🧑‍🎤 Summary
- [x] result page 500 에러 해결

## 🧑‍🎤 Comment
### 원인
context를 이용해서 데이터를 가져다 쓰고 있었는데
api data가 들어오지 않은 상태에서 context가 업데이트 되어 값으로 undefined가 뜨게 되었어요
어차피 api data 들어오면 다시 context가 업데이트 되어 정상값으로 바뀌게 되지만

문제는 
서류 결과 확인에서 면접 시간을 알려주기 위해 날짜 계산하는 과정이 있는데
undefined 값이 들어오면 날짜 계산을 못하게 되어 500 에러가 떴었던 겁니다!

따라서 api data 안 들어왔으면 그냥 return 해버리도록 구현했어요