### PR TITLE
[Fix] CompletePage에 isMakers 반영

### DIFF
--- a/src/views/CompletePage/index.tsx
+++ b/src/views/CompletePage/index.tsx
@@ -12,8 +12,9 @@ import { container, icon, mainText, subText } from './style.css';
 const CompletePage = () => {
   const navigate = useNavigate();
   const {
-    recruitingInfo: { name, season, group },
+    recruitingInfo: { name, season, group, soptName },
   } = useContext(RecruitingInfoContext);
+  const isMakers = soptName?.toLowerCase().includes('makers');
 
   const handleClickMyPage = () => {
     track('click-complete-my');
@@ -25,7 +26,7 @@ const CompletePage = () => {
       <div className={icon}>
         <IconCheckmark />
       </div>
-      <p className={mainText}>{`${name}님의\n${season}기 ${group} 지원서가 접수되었습니다.`}</p>
+      <p className={mainText}>{`${name}님의\n${season}기 ${isMakers ? soptName : group} 지원서가 접수되었습니다.`}</p>
       <p className={subText}>이메일로 지원 접수 완료 알림이 발송되었습니다.</p>
       <Callout
         style={{


### PR DESCRIPTION
**Related Issue :** Closes  #228 

---

## 🧑‍🎤 Summary
접수 완료 페이지에도 IsMakers 여부에 따라 텍스트 조건부 렌더링 추가해줬습니다


## 🧑‍🎤 Comment
isMakers 조건부 처리 해주는 곳의 형태를 보니 
```tsx
{season}기 {soptName} {isMakers ? '' : group} 지원하기
```
- FinalResult (최종 합불페이지) 
- ScreeningResult (서류 합불페이지) 
- SignInPage (로그인 페이지) 

```tsx
{seasonS}기 {isMakers ? soptName : group} 지원서
```
- ApplyPage (지원서 작성 페이지) 

이렇게 두가지 형태로 갈리더라구요? 
무슨 기준일까 디자인 피그마도 찾아봤는데 모르겠어서 우선 제가 더 마음에 드는 아래 형태로 고쳐두었습니다! 
문제있다면 말씀해주세요 !! 