### PR TITLE
[Feat] 토큰 만료 시간 추가

### DIFF
--- a/src/common/apis/tokenInstance.ts
+++ b/src/common/apis/tokenInstance.ts
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import { isBefore } from 'date-fns';
 
 const tokenInstance = axios.create({
   baseURL: import.meta.env.VITE_BASE_URL,
@@ -12,6 +13,17 @@ export default tokenInstance;
 tokenInstance.interceptors.request.use(
   (config) => {
     const soptApplyAccessToken = localStorage.getItem('soptApplyAccessToken');
+    const soptApplyAccessTokenExpiredTime = localStorage.getItem('soptApplyAccessTokenExpiredTime');
+    const afterRecruiting = isBefore(new Date(soptApplyAccessTokenExpiredTime || ''), new Date());
+
+    if (!soptApplyAccessTokenExpiredTime || afterRecruiting) {
+      localStorage.removeItem('soptApplyAccessToken');
+      localStorage.removeItem('soptApplyAccessTokenExpiredTime');
+
+      window.location.href = '/';
+
+      return config;
+    }
 
     if (!soptApplyAccessToken) {
       window.location.href = '/';

--- a/src/common/apis/tokenInstance.ts
+++ b/src/common/apis/tokenInstance.ts
@@ -13,9 +13,9 @@ export default tokenInstance;
 tokenInstance.interceptors.request.use(
   (config) => {
     const soptApplyAccessToken = localStorage.getItem('soptApplyAccessToken');
-    const soptApplyAccessTokenExpiredTime = localStorage.getItem('soptApplyAccessTokenExpiredTime');
-    const isValidDate = new Date(soptApplyAccessTokenExpiredTime || '').toDateString() !== 'Invalid Date';
-    const afterRecruiting = isBefore(new Date(soptApplyAccessTokenExpiredTime || ''), new Date());
+    const soptApplyAccessTokenExpiredTime = new Date(localStorage.getItem('soptApplyAccessTokenExpiredTime') || '');
+    const isValidDate = soptApplyAccessTokenExpiredTime.toDateString() !== 'Invalid Date';
+    const afterRecruiting = isBefore(soptApplyAccessTokenExpiredTime, new Date());
 
     if (!isValidDate || !soptApplyAccessTokenExpiredTime || afterRecruiting) {
       localStorage.removeItem('soptApplyAccessToken');

--- a/src/common/apis/tokenInstance.ts
+++ b/src/common/apis/tokenInstance.ts
@@ -14,9 +14,10 @@ tokenInstance.interceptors.request.use(
   (config) => {
     const soptApplyAccessToken = localStorage.getItem('soptApplyAccessToken');
     const soptApplyAccessTokenExpiredTime = localStorage.getItem('soptApplyAccessTokenExpiredTime');
+    const isValidDate = new Date(soptApplyAccessTokenExpiredTime || '').toDateString() !== 'Invalid Date';
     const afterRecruiting = isBefore(new Date(soptApplyAccessTokenExpiredTime || ''), new Date());
 
-    if (!soptApplyAccessTokenExpiredTime || afterRecruiting) {
+    if (!isValidDate || !soptApplyAccessTokenExpiredTime || afterRecruiting) {
       localStorage.removeItem('soptApplyAccessToken');
       localStorage.removeItem('soptApplyAccessTokenExpiredTime');
 

--- a/src/common/components/Layout/components/Header/index.tsx
+++ b/src/common/components/Layout/components/Header/index.tsx
@@ -1,6 +1,5 @@
 import { reset, track } from '@amplitude/analytics-browser';
-import { isBefore } from 'date-fns';
-import { useContext, useEffect } from 'react';
+import { useContext } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 
 import MakersLogo from '@assets/MakersLogo';
@@ -31,19 +30,6 @@ const Header = () => {
     localStorage.removeItem('soptApplyAccessTokenExpiredTime');
     pathname === '/' ? navigate(0) : navigate('/');
   };
-
-  useEffect(() => {
-    const soptApplyAccessTokenExpiredTime = localStorage.getItem('soptApplyAccessTokenExpiredTime');
-    const afterRecruiting = isBefore(new Date(soptApplyAccessTokenExpiredTime || ''), new Date());
-
-    if (afterRecruiting) {
-      localStorage.removeItem('soptApplyAccessToken');
-      localStorage.removeItem('soptApplyAccessTokenExpiredTime');
-
-      pathname === '/' ? navigate(0) : navigate('/');
-    }
-  }, [isSignedIn, pathname, navigate]);
-
   return (
     <header className={container}>
       <button onClick={handleClickLogo} className={logo}>

--- a/src/common/components/Layout/components/Header/index.tsx
+++ b/src/common/components/Layout/components/Header/index.tsx
@@ -28,6 +28,7 @@ const Header = () => {
     track('click-gnb-logout');
     reset();
     localStorage.removeItem('soptApplyAccessToken');
+    localStorage.removeItem('soptApplyAccessTokenExpiredTime');
     pathname === '/' ? navigate(0) : navigate('/');
   };
 

--- a/src/common/components/Layout/components/Header/index.tsx
+++ b/src/common/components/Layout/components/Header/index.tsx
@@ -1,5 +1,6 @@
 import { reset, track } from '@amplitude/analytics-browser';
-import { useContext } from 'react';
+import { isBefore } from 'date-fns';
+import { useContext, useEffect } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 
 import MakersLogo from '@assets/MakersLogo';
@@ -14,22 +15,33 @@ const Header = () => {
   const navigate = useNavigate();
   const { pathname } = useLocation();
   const isSignedIn = localStorage.getItem('soptApplyAccessToken');
+
   const {
     recruitingInfo: { name, isMakers },
   } = useContext(RecruitingInfoContext);
 
   const handleClickLogo = () => {
-    if (pathname === '/') navigate(0);
-    else navigate('/');
+    pathname === '/' ? navigate(0) : navigate('/');
   };
 
   const handleLogout = () => {
     track('click-gnb-logout');
     reset();
     localStorage.removeItem('soptApplyAccessToken');
-    if (pathname === '/') navigate(0);
-    else navigate('/');
+    pathname === '/' ? navigate(0) : navigate('/');
   };
+
+  useEffect(() => {
+    const soptApplyAccessTokenExpiredTime = localStorage.getItem('soptApplyAccessTokenExpiredTime');
+    const afterRecruiting = isBefore(new Date(soptApplyAccessTokenExpiredTime || ''), new Date());
+
+    if (afterRecruiting) {
+      localStorage.removeItem('soptApplyAccessToken');
+      localStorage.removeItem('soptApplyAccessTokenExpiredTime');
+
+      pathname === '/' ? navigate(0) : navigate('/');
+    }
+  }, [isSignedIn, pathname, navigate]);
 
   return (
     <header className={container}>

--- a/src/views/MainPage/index.tsx
+++ b/src/views/MainPage/index.tsx
@@ -1,27 +1,8 @@
-import { isBefore } from 'date-fns';
-import { useEffect } from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
-
 import SignedInPage from 'views/SignedInPage';
 import SignInPage from 'views/SignInPage';
 
 const MainPage = () => {
-  const navigate = useNavigate();
-  const { pathname } = useLocation();
-
   const isSignedIn = localStorage.getItem('soptApplyAccessToken');
-
-  useEffect(() => {
-    const soptApplyAccessTokenExpiredTime = localStorage.getItem('soptApplyAccessTokenExpiredTime');
-    const afterRecruiting = isBefore(new Date(soptApplyAccessTokenExpiredTime || ''), new Date());
-
-    if (afterRecruiting) {
-      localStorage.removeItem('soptApplyAccessToken');
-      localStorage.removeItem('soptApplyAccessTokenExpiredTime');
-
-      pathname === '/' ? navigate(0) : navigate('/');
-    }
-  }, [isSignedIn, pathname, navigate]);
 
   return <>{isSignedIn ? <SignedInPage /> : <SignInPage />}</>;
 };

--- a/src/views/MainPage/index.tsx
+++ b/src/views/MainPage/index.tsx
@@ -1,8 +1,27 @@
+import { isBefore } from 'date-fns';
+import { useEffect } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+
 import SignedInPage from 'views/SignedInPage';
 import SignInPage from 'views/SignInPage';
 
 const MainPage = () => {
+  const navigate = useNavigate();
+  const { pathname } = useLocation();
+
   const isSignedIn = localStorage.getItem('soptApplyAccessToken');
+
+  useEffect(() => {
+    const soptApplyAccessTokenExpiredTime = localStorage.getItem('soptApplyAccessTokenExpiredTime');
+    const afterRecruiting = isBefore(new Date(soptApplyAccessTokenExpiredTime || ''), new Date());
+
+    if (afterRecruiting) {
+      localStorage.removeItem('soptApplyAccessToken');
+      localStorage.removeItem('soptApplyAccessTokenExpiredTime');
+
+      pathname === '/' ? navigate(0) : navigate('/');
+    }
+  }, [isSignedIn, pathname, navigate]);
 
   return <>{isSignedIn ? <SignedInPage /> : <SignInPage />}</>;
 };

--- a/src/views/SignInPage/components/SignInForm/index.tsx
+++ b/src/views/SignInPage/components/SignInForm/index.tsx
@@ -1,10 +1,12 @@
 import { track } from '@amplitude/analytics-browser';
+import { useContext } from 'react';
 import { type FieldValues, FormProvider, useForm } from 'react-hook-form';
 import { Link } from 'react-router-dom';
 
 import Button from '@components/Button';
 import { Description, InputLine, TextBox } from '@components/Input';
 import { VALIDATION_CHECK } from '@constants/validationCheck';
+import { RecruitingInfoContext } from '@store/recruitingInfoContext';
 import useMutateSignIn from 'views/SignInPage/hooks/useMutateSignIn';
 
 import { inputWrapper, newPasswordButton } from './style.css';
@@ -12,9 +14,13 @@ import { inputWrapper, newPasswordButton } from './style.css';
 import type { SeasonGroupType } from '@type/seasonAndGroup';
 
 const SignInForm = ({ season, group }: SeasonGroupType) => {
+  const {
+    recruitingInfo: { finalPassConfirmEnd },
+  } = useContext(RecruitingInfoContext);
   const methods = useForm({ mode: 'onBlur' });
   const { handleSubmit, setError } = methods;
   const { signInMutate, signInIsPending } = useMutateSignIn({
+    finalPassConfirmEnd,
     onSetError: (name, type, message) => setError(name, { type, message }),
   });
 

--- a/src/views/SignInPage/hooks/useMutateSignIn.tsx
+++ b/src/views/SignInPage/hooks/useMutateSignIn.tsx
@@ -11,10 +11,11 @@ import type { ErrorResponse } from '@type/errorResponse';
 import type { AxiosError, AxiosResponse } from 'axios';
 
 interface MutateSignInProps {
+  finalPassConfirmEnd?: string;
   onSetError: (name: string, type: string, message: string) => void;
 }
 
-const useMutateSignIn = ({ onSetError }: MutateSignInProps) => {
+const useMutateSignIn = ({ finalPassConfirmEnd, onSetError }: MutateSignInProps) => {
   const navigate = useNavigate();
 
   const { mutate: signInMutate, isPending: signInIsPending } = useMutation<
@@ -26,6 +27,7 @@ const useMutateSignIn = ({ onSetError }: MutateSignInProps) => {
     onSuccess: ({ data: { email, token } }) => {
       setUserId(email);
       localStorage.setItem('soptApplyAccessToken', token);
+      localStorage.setItem('soptApplyAccessTokenExpiredTime', finalPassConfirmEnd || '');
       navigate(0);
     },
     onError(error) {

--- a/src/views/dialogs/SessionExpiredDialog/index.tsx
+++ b/src/views/dialogs/SessionExpiredDialog/index.tsx
@@ -13,6 +13,7 @@ const SessionExpiredDialog = forwardRef<HTMLDialogElement>((_, ref) => {
   const handleLogout = () => {
     track('click-session-okay');
     localStorage.removeItem('soptApplyAccessToken');
+    localStorage.removeItem('soptApplyAccessTokenExpiredTime');
     if (window.location.pathname === '/') {
       location.reload();
     } else {


### PR DESCRIPTION
**Related Issue :** Closes #230 

---

## 🧑‍🎤 Summary
- [x] 모집 마감 시간도 local storage에 저장
- [x] 마감 이후 로그인 시 local storage에 저장된 토큰 및 마감 시간 지우기
- [x] 비정상적인 마감 시간 입력 시 다시 로그인 하도록 구현

## 🧑‍🎤 Comment
어떤 페이지든 들어가게 되면 api 요청을 하게 되므로
`interceptors`에서 한 번에 처리해 줬습니다

<details>
<summary>코드 보기</summary>

```tsx
tokenInstance.interceptors.request.use(
  (config) => {
    const soptApplyAccessToken = localStorage.getItem('soptApplyAccessToken');
    const soptApplyAccessTokenExpiredTime = new Date(localStorage.getItem('soptApplyAccessTokenExpiredTime') || '');
    const isValidDate = soptApplyAccessTokenExpiredTime.toDateString() !== 'Invalid Date';
    const afterRecruiting = isBefore(soptApplyAccessTokenExpiredTime, new Date());

    if (!isValidDate || !soptApplyAccessTokenExpiredTime || afterRecruiting) {
      localStorage.removeItem('soptApplyAccessToken');
      localStorage.removeItem('soptApplyAccessTokenExpiredTime');

      window.location.href = '/';

      return config;
    }
   // ...
)
```
</details>

객체로 묶어서 저장시켜 주려고 했는데 stringify, parse 하기 귀찮아서 그냥 따로따로 저장해 줬어요

```
local storage에 기존 값 저장되어 있지 않은 경우
-> 그냥 로그인 하면 됨

OB 지원하고 YB 지원할 때 local storage에 기존 값 저장되어 있는 경우
-> 자동으로 삭제됨

임의로 누가 만료 시간에 이상한 값 넣은 경우
-> 로그인 풀리고 첫 페이지로 이동
```