### PR TITLE
[Fix] 지원서 다시보기에서 뒤로가기 안 되는 에러 수정

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,7 @@ import ErrorPage from 'views/ErrorPage';
 import MainPage from 'views/MainPage';
 import PasswordPage from 'views/PasswordPage';
 import ResultPage from 'views/ResultPage';
+import ReviewPage from 'views/ReviewPage';
 import SignupPage from 'views/SignupPage';
 
 import 'styles/reset.css';
@@ -33,6 +34,7 @@ const router = createBrowserRouter([
       { path: '/sign-up', element: <SignupPage /> },
       { path: '/password', element: <PasswordPage /> },
       { path: '/result', element: <ResultPage /> },
+      { path: '/review', element: <ReviewPage /> },
       { path: '/error', element: <ErrorPage code={500} /> },
       { path: '*', element: <ErrorPage code={404} /> },
     ],

--- a/src/views/ApplyPage/components/ApplyHeader/index.tsx
+++ b/src/views/ApplyPage/components/ApplyHeader/index.tsx
@@ -8,9 +8,9 @@ import { buttonWrapper, headerContainer } from './style.css';
 
 interface ApplyHeaderProps {
   isReview: boolean;
-  isLoading: boolean;
-  onSaveDraft: () => void;
-  onSubmitData: () => void;
+  isLoading?: boolean;
+  onSaveDraft?: () => void;
+  onSubmitData?: () => void;
 }
 
 const ApplyHeader = ({ isReview, isLoading, onSaveDraft, onSubmitData }: ApplyHeaderProps) => {

--- a/src/views/ApplyPage/hooks/useMutateSubmit.tsx
+++ b/src/views/ApplyPage/hooks/useMutateSubmit.tsx
@@ -6,7 +6,7 @@ import type { ApplyRequest, ApplyResponse } from '../types';
 import type { ErrorResponse } from '@type/errorResponse';
 import type { AxiosError, AxiosResponse } from 'axios';
 
-const useMutateSubmit = ({ onSuccess }: { onSuccess: () => void }) => {
+const useMutateSubmit = ({ onSuccess }: { onSuccess?: () => void }) => {
   const { mutate: submitMutate, isPending: submitIsPending } = useMutation<
     AxiosResponse<ApplyResponse, ApplyRequest>,
     AxiosError<ErrorResponse, ApplyRequest>,

--- a/src/views/ApplyPage/index.tsx
+++ b/src/views/ApplyPage/index.tsx
@@ -27,11 +27,10 @@ import { buttonWrapper, container, formContainer } from './style.css';
 import type { ApplyRequest } from './types';
 
 interface ApplyPageProps {
-  isReview: boolean;
   onSetComplete?: () => void;
 }
 
-const ApplyPage = ({ isReview, onSetComplete }: ApplyPageProps) => {
+const ApplyPage = ({ onSetComplete }: ApplyPageProps) => {
   const draftDialog = useRef<HTMLDialogElement>(null);
   const submitDialog = useRef<HTMLDialogElement>(null);
   const sectionsRef = useRef<HTMLSelectElement[]>([]);
@@ -41,6 +40,7 @@ const ApplyPage = ({ isReview, onSetComplete }: ApplyPageProps) => {
 
   const navigate = useNavigate();
 
+  const isReview = false;
   const minIndex = isInView.findIndex((value) => value === true);
 
   useScrollToHash(); // scrollTo 카테고리

--- a/src/views/ApplyPage/index.tsx
+++ b/src/views/ApplyPage/index.tsx
@@ -9,6 +9,7 @@ import useScrollToHash from '@hooks/useScrollToHash';
 import { DraftDialog, SubmitDialog } from 'views/dialogs';
 import NoMore from 'views/ErrorPage/components/NoMore';
 import BigLoading from 'views/loadings/BigLoding';
+import useGetDraft from 'views/SignedInPage/hooks/useGetDraft';
 
 import ApplyCategory from './components/ApplyCategory';
 import ApplyHeader from './components/ApplyHeader';
@@ -23,15 +24,14 @@ import useMutateDraft from './hooks/useMutateDraft';
 import useMutateSubmit from './hooks/useMutateSubmit';
 import { buttonWrapper, container, formContainer } from './style.css';
 
-import type { ApplyRequest, ApplyResponse } from './types';
+import type { ApplyRequest } from './types';
 
 interface ApplyPageProps {
   isReview: boolean;
   onSetComplete?: () => void;
-  draftData?: { data: ApplyResponse };
 }
 
-const ApplyPage = ({ isReview, onSetComplete, draftData }: ApplyPageProps) => {
+const ApplyPage = ({ isReview, onSetComplete }: ApplyPageProps) => {
   const draftDialog = useRef<HTMLDialogElement>(null);
   const submitDialog = useRef<HTMLDialogElement>(null);
   const sectionsRef = useRef<HTMLSelectElement[]>([]);
@@ -45,13 +45,14 @@ const ApplyPage = ({ isReview, onSetComplete, draftData }: ApplyPageProps) => {
 
   useScrollToHash(); // scrollTo 카테고리
 
+  const { NoMoreReview, isLoading, isMakers } = useDate();
+  const { draftData, draftIsLoading } = useGetDraft();
   const {
     applicant: applicantDraft,
     commonQuestions: commonQuestionsDraft,
     partQuestions: partQuestionsDraft,
   } = draftData?.data || {};
 
-  const { NoMoreReview, isLoading, isMakers } = useDate();
   const { questionsData, questionsIsLoading } = useGetQuestions(applicantDraft);
   const { commonQuestions, partQuestions, questionTypes } = questionsData?.data || {};
 
@@ -169,7 +170,7 @@ const ApplyPage = ({ isReview, onSetComplete, draftData }: ApplyPageProps) => {
     return () => window.removeEventListener('beforeunload', handleBeforeUnload);
   }, [isReview]);
 
-  if (questionsIsLoading || isLoading) return <BigLoading />;
+  if (questionsIsLoading || isLoading || draftIsLoading) return <BigLoading />;
   if (NoMoreReview) return <NoMore isMakers={isMakers} content="모집 기간이 아니에요" />;
 
   const selectedPartId = questionTypes?.find((type) => type.typeKr === getValues('part'))?.id;

--- a/src/views/ApplyPage/index.tsx
+++ b/src/views/ApplyPage/index.tsx
@@ -27,7 +27,7 @@ import type { ApplyRequest, ApplyResponse } from './types';
 
 interface ApplyPageProps {
   isReview: boolean;
-  onSetComplete: () => void;
+  onSetComplete?: () => void;
   draftData?: { data: ApplyResponse };
 }
 

--- a/src/views/ApplyPage/index.tsx
+++ b/src/views/ApplyPage/index.tsx
@@ -45,7 +45,7 @@ const ApplyPage = ({ isReview, onSetComplete }: ApplyPageProps) => {
 
   useScrollToHash(); // scrollTo 카테고리
 
-  const { NoMoreReview, isLoading, isMakers } = useDate();
+  const { NoMoreApply, isLoading, isMakers } = useDate();
   const { draftData, draftIsLoading } = useGetDraft();
   const {
     applicant: applicantDraft,
@@ -171,7 +171,7 @@ const ApplyPage = ({ isReview, onSetComplete }: ApplyPageProps) => {
   }, [isReview]);
 
   if (questionsIsLoading || isLoading || draftIsLoading) return <BigLoading />;
-  if (NoMoreReview) return <NoMore isMakers={isMakers} content="모집 기간이 아니에요" />;
+  if (NoMoreApply) return <NoMore isMakers={isMakers} content="모집 기간이 아니에요" />;
 
   const selectedPartId = questionTypes?.find((type) => type.typeKr === getValues('part'))?.id;
   const partQuestionsData = partQuestions?.find((part) => part.recruitingQuestionTypeId === selectedPartId);

--- a/src/views/MyPage/index.tsx
+++ b/src/views/MyPage/index.tsx
@@ -6,6 +6,7 @@ import Callout from '@components/Callout';
 import Title from '@components/Title';
 import useDate from '@hooks/useDate';
 import { RecruitingInfoContext } from '@store/recruitingInfoContext';
+import NoMore from 'views/ErrorPage/components/NoMore';
 import BigLoading from 'views/loadings/BigLoding';
 
 import { buttonWidth, container, infoContainer, infoLabel, infoValue, itemWrapper, buttonValue } from './style.css';
@@ -27,9 +28,10 @@ const MyPage = ({ part }: MaPageProps) => {
   const {
     recruitingInfo: { name, season },
   } = useContext(RecruitingInfoContext);
-  const { NoMoreReview, NoMoreScreeningResult, NoMoreFinalResult, isLoading } = useDate();
+  const { NoMoreReview, NoMoreScreeningResult, NoMoreFinalResult, NoMoreRecruit, isLoading, isMakers } = useDate();
 
   if (isLoading) return <BigLoading />;
+  if (NoMoreRecruit) return <NoMore isMakers={isMakers} content="모집 기간이 아니에요" />;
 
   return (
     <section className={container}>

--- a/src/views/MyPage/index.tsx
+++ b/src/views/MyPage/index.tsx
@@ -51,7 +51,7 @@ const MyPage = ({ onShowReview }: { onShowReview: () => void }) => {
         {!NoMoreReview && (
           <li className={buttonValue}>
             <span className={infoLabel}>지원서</span>
-            <Button className={buttonWidth} onClick={onShowReview} padding="15x25">
+            <Button isLink to="/review" className={buttonWidth} onClick={onShowReview} padding="15x25">
               지원서 확인
             </Button>
           </li>

--- a/src/views/MyPage/index.tsx
+++ b/src/views/MyPage/index.tsx
@@ -20,11 +20,11 @@ const MyInfoItem = ({ label, value }: { label: string; value?: string | number |
   );
 };
 
-interface MaPageProps {
+interface MyPageProps {
   part?: string;
 }
 
-const MyPage = ({ part }: MaPageProps) => {
+const MyPage = ({ part }: MyPageProps) => {
   const {
     recruitingInfo: { name, season },
   } = useContext(RecruitingInfoContext);

--- a/src/views/MyPage/index.tsx
+++ b/src/views/MyPage/index.tsx
@@ -1,12 +1,13 @@
 import { track } from '@amplitude/analytics-browser';
+import { useContext } from 'react';
 
 import Button from '@components/Button';
 import Callout from '@components/Callout';
 import Title from '@components/Title';
 import useDate from '@hooks/useDate';
+import { RecruitingInfoContext } from '@store/recruitingInfoContext';
 import BigLoading from 'views/loadings/BigLoding';
 
-import useGetMyInfo from './hooks/useGetMyInfo';
 import { buttonWidth, container, infoContainer, infoLabel, infoValue, itemWrapper, buttonValue } from './style.css';
 
 const MyInfoItem = ({ label, value }: { label: string; value?: string | number | boolean }) => {
@@ -18,13 +19,17 @@ const MyInfoItem = ({ label, value }: { label: string; value?: string | number |
   );
 };
 
-const MyPage = ({ onShowReview }: { onShowReview: () => void }) => {
-  const { myInfoData, myInfoIsLoading } = useGetMyInfo();
+interface MaPageProps {
+  part?: string;
+}
+
+const MyPage = ({ part }: MaPageProps) => {
+  const {
+    recruitingInfo: { name, season },
+  } = useContext(RecruitingInfoContext);
   const { NoMoreReview, NoMoreScreeningResult, NoMoreFinalResult, isLoading } = useDate();
 
-  if (myInfoIsLoading || isLoading) return <BigLoading />;
-
-  const { season, name, part } = myInfoData?.data || {};
+  if (isLoading) return <BigLoading />;
 
   return (
     <section className={container}>
@@ -51,7 +56,12 @@ const MyPage = ({ onShowReview }: { onShowReview: () => void }) => {
         {!NoMoreReview && (
           <li className={buttonValue}>
             <span className={infoLabel}>지원서</span>
-            <Button isLink to="/review" className={buttonWidth} onClick={onShowReview} padding="15x25">
+            <Button
+              isLink
+              to="/review"
+              className={buttonWidth}
+              onClick={() => track('click-my-review')}
+              padding="15x25">
               지원서 확인
             </Button>
           </li>

--- a/src/views/ReviewPage/index.tsx
+++ b/src/views/ReviewPage/index.tsx
@@ -1,8 +1,9 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useContext, useEffect, useRef, useState } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 
 import useDate from '@hooks/useDate';
 import useScrollToHash from '@hooks/useScrollToHash';
+import { RecruitingInfoContext } from '@store/recruitingInfoContext';
 import ApplyCategory from 'views/ApplyPage/components/ApplyCategory';
 import ApplyHeader from 'views/ApplyPage/components/ApplyHeader';
 import ApplyInfo from 'views/ApplyPage/components/ApplyInfo';
@@ -18,6 +19,8 @@ import useGetDraft from 'views/SignedInPage/hooks/useGetDraft';
 
 const ReviewPage = () => {
   const isReview = true;
+
+  const { handleSaveRecruitingInfo } = useContext(RecruitingInfoContext);
   const { draftData, draftIsLoading } = useGetDraft();
   const sectionsRef = useRef<HTMLSelectElement[]>([]);
 
@@ -45,6 +48,10 @@ const ReviewPage = () => {
     if (applicantDraft?.part) {
       setValue('part', applicantDraft?.part);
     }
+
+    handleSaveRecruitingInfo({
+      name: applicantDraft?.name,
+    });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [applicantDraft]);
 

--- a/src/views/ReviewPage/index.tsx
+++ b/src/views/ReviewPage/index.tsx
@@ -1,0 +1,126 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { FormProvider, useForm } from 'react-hook-form';
+
+import useDate from '@hooks/useDate';
+import useScrollToHash from '@hooks/useScrollToHash';
+import ApplyCategory from 'views/ApplyPage/components/ApplyCategory';
+import ApplyHeader from 'views/ApplyPage/components/ApplyHeader';
+import ApplyInfo from 'views/ApplyPage/components/ApplyInfo';
+import BottomSection from 'views/ApplyPage/components/BottomSection';
+import CommonSection from 'views/ApplyPage/components/CommonSection';
+import DefaultSection from 'views/ApplyPage/components/DefaultSection';
+import PartSection from 'views/ApplyPage/components/PartSection';
+import useGetQuestions from 'views/ApplyPage/hooks/useGetQuestions';
+import { container, formContainer } from 'views/ApplyPage/style.css';
+import NoMore from 'views/ErrorPage/components/NoMore';
+import BigLoading from 'views/loadings/BigLoding';
+import useGetDraft from 'views/SignedInPage/hooks/useGetDraft';
+
+const ReviewPage = () => {
+  const isReview = true;
+  const { draftData, draftIsLoading } = useGetDraft();
+  const sectionsRef = useRef<HTMLSelectElement[]>([]);
+
+  const [isInView, setIsInView] = useState([true, false, false]);
+  const [sectionsUpdated, setSectionsUpdated] = useState(false);
+
+  const minIndex = isInView.findIndex((value) => value === true);
+
+  useScrollToHash(); // scrollTo 카테고리
+
+  const {
+    applicant: applicantDraft,
+    commonQuestions: commonQuestionsDraft,
+    partQuestions: partQuestionsDraft,
+  } = draftData?.data || {};
+
+  const { NoMoreReview, isLoading, isMakers } = useDate();
+  const { questionsData, questionsIsLoading } = useGetQuestions(applicantDraft);
+  const { commonQuestions, partQuestions, questionTypes } = questionsData?.data || {};
+
+  const methods = useForm({ mode: 'onBlur' });
+  const { setValue } = methods;
+
+  useEffect(() => {
+    if (applicantDraft?.part) {
+      setValue('part', applicantDraft?.part);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [applicantDraft]);
+
+  const refCallback = useCallback((element: HTMLSelectElement) => {
+    if (element) {
+      sectionsRef.current.push(element);
+
+      if (sectionsRef.current.length === 3) {
+        setSectionsUpdated(true);
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!sectionsUpdated) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          const sectionId = entry.target.getAttribute('id');
+          const sectionIndex = ['default', 'common', 'partial'].indexOf(sectionId!);
+
+          setIsInView((prev) => {
+            const updatedState = [...prev];
+            updatedState[sectionIndex] = entry.isIntersecting;
+            return updatedState;
+          });
+        });
+      },
+      { root: null, rootMargin: '-220px' },
+    );
+
+    sectionsRef.current.forEach((section) => {
+      observer.observe(section);
+    });
+
+    return () => {
+      sectionsRef.current.forEach((section) => observer.unobserve(section));
+    };
+  }, [sectionsUpdated]);
+
+  if (questionsIsLoading || isLoading || draftIsLoading) return <BigLoading />;
+  if (NoMoreReview) return <NoMore isMakers={isMakers} content="모집 기간이 아니에요" />;
+
+  return (
+    <FormProvider {...methods}>
+      <div className={container}>
+        <ApplyHeader isReview={isReview} />
+        <ApplyInfo isReview={isReview} />
+        <ApplyCategory minIndex={minIndex} />
+        <form id="apply-form" name="apply-form" className={formContainer}>
+          <DefaultSection
+            isMakers={isMakers}
+            isReview={isReview}
+            refCallback={refCallback}
+            applicantDraft={applicantDraft}
+          />
+          <CommonSection
+            isReview={isReview}
+            refCallback={refCallback}
+            questions={commonQuestions?.questions}
+            commonQuestionsDraft={commonQuestionsDraft}
+          />
+          <PartSection
+            isReview={isReview}
+            refCallback={refCallback}
+            part={applicantDraft?.part}
+            questions={partQuestions}
+            partQuestionsDraft={partQuestionsDraft}
+            questionTypes={questionTypes}
+          />
+          <BottomSection isReview={isReview} knownPath={applicantDraft?.knownPath} />
+        </form>
+      </div>
+    </FormProvider>
+  );
+};
+
+export default ReviewPage;

--- a/src/views/ReviewPage/index.tsx
+++ b/src/views/ReviewPage/index.tsx
@@ -13,20 +13,22 @@ import DefaultSection from 'views/ApplyPage/components/DefaultSection';
 import PartSection from 'views/ApplyPage/components/PartSection';
 import useGetQuestions from 'views/ApplyPage/hooks/useGetQuestions';
 import { container, formContainer } from 'views/ApplyPage/style.css';
+import PreventReviewDialog from 'views/dialogs/PreventReviewDialog';
 import NoMore from 'views/ErrorPage/components/NoMore';
 import BigLoading from 'views/loadings/BigLoding';
 import useGetDraft from 'views/SignedInPage/hooks/useGetDraft';
 
 const ReviewPage = () => {
-  const isReview = true;
+  const preventReviewDialog = useRef<HTMLDialogElement>(null);
+  const sectionsRef = useRef<HTMLSelectElement[]>([]);
 
   const { handleSaveRecruitingInfo } = useContext(RecruitingInfoContext);
   const { draftData, draftIsLoading } = useGetDraft();
-  const sectionsRef = useRef<HTMLSelectElement[]>([]);
 
   const [isInView, setIsInView] = useState([true, false, false]);
   const [sectionsUpdated, setSectionsUpdated] = useState(false);
 
+  const isReview = true;
   const minIndex = isInView.findIndex((value) => value === true);
 
   useScrollToHash(); // scrollTo 카테고리
@@ -45,6 +47,10 @@ const ReviewPage = () => {
   const { setValue } = methods;
 
   useEffect(() => {
+    if (preventReviewDialog.current && !applicantDraft?.submit) {
+      preventReviewDialog.current.showModal();
+    }
+
     if (applicantDraft?.part) {
       setValue('part', applicantDraft?.part);
     }
@@ -53,7 +59,7 @@ const ReviewPage = () => {
       name: applicantDraft?.name,
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [applicantDraft]);
+  }, [applicantDraft, preventReviewDialog.current]);
 
   const refCallback = useCallback((element: HTMLSelectElement) => {
     if (element) {
@@ -97,36 +103,39 @@ const ReviewPage = () => {
   if (NoMoreReview) return <NoMore isMakers={isMakers} content="모집 기간이 아니에요" />;
 
   return (
-    <FormProvider {...methods}>
-      <div className={container}>
-        <ApplyHeader isReview={isReview} />
-        <ApplyInfo isReview={isReview} />
-        <ApplyCategory minIndex={minIndex} />
-        <form id="apply-form" name="apply-form" className={formContainer}>
-          <DefaultSection
-            isMakers={isMakers}
-            isReview={isReview}
-            refCallback={refCallback}
-            applicantDraft={applicantDraft}
-          />
-          <CommonSection
-            isReview={isReview}
-            refCallback={refCallback}
-            questions={commonQuestions?.questions}
-            commonQuestionsDraft={commonQuestionsDraft}
-          />
-          <PartSection
-            isReview={isReview}
-            refCallback={refCallback}
-            part={applicantDraft?.part}
-            questions={partQuestions}
-            partQuestionsDraft={partQuestionsDraft}
-            questionTypes={questionTypes}
-          />
-          <BottomSection isReview={isReview} knownPath={applicantDraft?.knownPath} />
-        </form>
-      </div>
-    </FormProvider>
+    <>
+      <PreventReviewDialog ref={preventReviewDialog} />
+      <FormProvider {...methods}>
+        <div className={container}>
+          <ApplyHeader isReview={isReview} />
+          <ApplyInfo isReview={isReview} />
+          <ApplyCategory minIndex={minIndex} />
+          <form id="apply-form" name="apply-form" className={formContainer}>
+            <DefaultSection
+              isMakers={isMakers}
+              isReview={isReview}
+              refCallback={refCallback}
+              applicantDraft={applicantDraft}
+            />
+            <CommonSection
+              isReview={isReview}
+              refCallback={refCallback}
+              questions={commonQuestions?.questions}
+              commonQuestionsDraft={commonQuestionsDraft}
+            />
+            <PartSection
+              isReview={isReview}
+              refCallback={refCallback}
+              part={applicantDraft?.part}
+              questions={partQuestions}
+              partQuestionsDraft={partQuestionsDraft}
+              questionTypes={questionTypes}
+            />
+            <BottomSection isReview={isReview} knownPath={applicantDraft?.knownPath} />
+          </form>
+        </div>
+      </FormProvider>
+    </>
   );
 };
 

--- a/src/views/SignedInPage/index.tsx
+++ b/src/views/SignedInPage/index.tsx
@@ -1,4 +1,3 @@
-import { track } from '@amplitude/analytics-browser';
 import { useContext, useEffect, useState } from 'react';
 
 import { RecruitingInfoContext } from '@store/recruitingInfoContext';
@@ -6,20 +5,15 @@ import ApplyPage from 'views/ApplyPage';
 import CompletePage from 'views/CompletePage';
 import BigLoading from 'views/loadings/BigLoding';
 import MyPage from 'views/MyPage';
-
-import useGetDraft from './hooks/useGetDraft';
+import useGetMyInfo from 'views/MyPage/hooks/useGetMyInfo';
 
 const SignedInPage = () => {
   const [isComplete, setIsComplete] = useState(false);
 
-  const { draftData, draftIsLoading } = useGetDraft();
-  const { applicant, isSubmit } = draftData?.data || {};
+  const { myInfoData, myInfoIsLoading } = useGetMyInfo();
+  const { name, season, part, submit } = myInfoData?.data || {};
 
   const { handleSaveRecruitingInfo } = useContext(RecruitingInfoContext);
-
-  const handleShowReview = () => {
-    track('click-my-review');
-  };
 
   const handleSetComplete = () => {
     setIsComplete(true);
@@ -27,19 +21,18 @@ const SignedInPage = () => {
 
   useEffect(() => {
     handleSaveRecruitingInfo({
-      name: applicant?.name,
+      name,
+      season,
     });
-  }, [applicant, handleSaveRecruitingInfo]);
+  }, [name, season, handleSaveRecruitingInfo]);
 
-  if (draftIsLoading) return <BigLoading />;
+  if (myInfoIsLoading) return <BigLoading />;
 
   return (
     <>
       {isComplete && <CompletePage />}
-      {!isComplete && isSubmit && <MyPage onShowReview={handleShowReview} />}
-      {!isComplete && !isSubmit && (
-        <ApplyPage isReview={false} onSetComplete={handleSetComplete} draftData={draftData} />
-      )}
+      {!isComplete && submit && <MyPage part={part} />}
+      {!isComplete && !submit && <ApplyPage isReview={false} onSetComplete={handleSetComplete} />}
     </>
   );
 };

--- a/src/views/SignedInPage/index.tsx
+++ b/src/views/SignedInPage/index.tsx
@@ -11,7 +11,6 @@ import useGetDraft from './hooks/useGetDraft';
 
 const SignedInPage = () => {
   const [isComplete, setIsComplete] = useState(false);
-  const [isReview, setIsReview] = useState(false);
 
   const { draftData, draftIsLoading } = useGetDraft();
   const { applicant, isSubmit } = draftData?.data || {};
@@ -20,7 +19,6 @@ const SignedInPage = () => {
 
   const handleShowReview = () => {
     track('click-my-review');
-    setIsReview(true);
   };
 
   const handleSetComplete = () => {
@@ -37,10 +35,10 @@ const SignedInPage = () => {
 
   return (
     <>
-      {!isReview && isComplete && <CompletePage />}
-      {!isReview && !isComplete && isSubmit && <MyPage onShowReview={handleShowReview} />}
-      {(isReview || (!isComplete && !isSubmit)) && (
-        <ApplyPage isReview={isReview} onSetComplete={handleSetComplete} draftData={draftData} />
+      {isComplete && <CompletePage />}
+      {!isComplete && isSubmit && <MyPage onShowReview={handleShowReview} />}
+      {!isComplete && !isSubmit && (
+        <ApplyPage isReview={false} onSetComplete={handleSetComplete} draftData={draftData} />
       )}
     </>
   );

--- a/src/views/SignedInPage/index.tsx
+++ b/src/views/SignedInPage/index.tsx
@@ -32,7 +32,7 @@ const SignedInPage = () => {
     <>
       {isComplete && <CompletePage />}
       {!isComplete && submit && <MyPage part={part} />}
-      {!isComplete && !submit && <ApplyPage isReview={false} onSetComplete={handleSetComplete} />}
+      {!isComplete && !submit && <ApplyPage onSetComplete={handleSetComplete} />}
     </>
   );
 };

--- a/src/views/dialogs/PreventReviewDialog/index.tsx
+++ b/src/views/dialogs/PreventReviewDialog/index.tsx
@@ -1,0 +1,28 @@
+import { forwardRef, type KeyboardEvent } from 'react';
+import { Link } from 'react-router-dom';
+
+import Dialog from '@components/Dialog';
+
+import { buttonInside, buttonOutside, buttonWrapper, mainText, subText } from '../style.css';
+
+const PreventReviewDialog = forwardRef<HTMLDialogElement>((_, ref) => {
+  const handlePreventESCKeyPress = (e: KeyboardEvent<HTMLDialogElement>) => {
+    if (e.key === 'Escape') e.preventDefault();
+  };
+
+  return (
+    <Dialog ref={ref} onKeyDown={handlePreventESCKeyPress}>
+      <p className={mainText}>지원서 제출을 먼저 해주세요.</p>
+      <p className={subText}>&apos;지원서&apos; 페이지로 이동할게요.</p>
+      <form method="dialog" className={`${buttonWrapper} ${buttonOutside.solid}`}>
+        <Link to="/" className={buttonInside.solid}>
+          확인
+        </Link>
+      </form>
+    </Dialog>
+  );
+});
+
+PreventReviewDialog.displayName = 'PreventReviewDialog';
+
+export default PreventReviewDialog;


### PR DESCRIPTION
**Related Issue :** Closes #234 

---

## 🧑‍🎤 Summary
- [x] 마이페이지에서 지원서 다시보기 클릭 후 뒤로 가기 눌렀을 때 이상한 페이지로 이동되는 에러 해결
- [x] submit 여부 my page api를 이용하도록 수정

## 🧑‍🎤 Comment
### review page 생성
뒤로 가기가 안 되었던 이유가 같은 페이지 내에서 my component와 review component(-> apply component)를 조건부로 렌더링 하고 있어서 그랬는데요
뒤로 가기 눌렀을 때 다시 my component로 이동하게 하기 위해 새로운 path를 생성해줬습니다

지원서 다시보기 클릭 시 -> `/review`로 이동
지원서 다시보기에서 뒤로가기 클릭 시 -> `/` 로 이동

---

### 폴더 구조
폴더 구조는 아래와 같아요
```
- ApplyPage
    ㄴ 여러 컴포넌트들 
- ReviewPage
    ㄴ index.tsx -> 이 안에서 ApplyPage의 컴포넌트 재사용
```
`ApplyPage > components > ReviewPage` 로 만들까 하다가
새로운 path라 `views > ReviewPage`로 만들어줬습니다
ApplyPage의 컴포넌트들을 재사용하고 있지만 공통 컴포넌트 까지는 못되므로
따로 폴더 이동 시켜주진 않았어요

이 부분에 대해 다른 의견 있다면 편하게 알려주세여~

---

### submit 여부 my page api를 이용하도록 수정
기존에는 임시저장 api를 이용해서 submit 여부를 파악했는데
submit을 판단하기 위해 많은 데이터를 받아오는 게 리소스가 많이 든다고 판단해서
더 간단한 api인 my page api를 이용해줬어요

---

### 문제점
my page에서 latest api 요청을 한 번 하는데
review page로 이동하면 latest api 요청을 한 번 더 하게 됩니다
my page에서 요청한 데이터를 그대로 이어 받아서 사용하고 싶지만
그럴 경우 review page에서 새로고침 할 때, 해당 데이터들이 초기화 되어서
원하는 값들을 얻을 수 없게 되어요

사실 위와 같은 이유로 `/`, `/result`, `/review`, `/sign-up`, `/password` 모두 첫 진입 시 latest api를 요청하게 됩니다!

latest api가 soptname, season, group, yb, ob 리크루팅 날짜 등 많은 양의 데이터를 담고 있어
여러 번 요청하는 것이 부담스러운데
이는 서버에게 data를 쪼개서 보내달라고 요청해야 할 거 같아요

근데 또 이렇게 할 경우 쪼갠 데이터 전부 필요한 곳에선
여러 번의 작은 데이터 요청이 발생하게 되어서
한 번의 큰 데이터 요청보다 오히려 리소스가 더 크게 될 수도 있을 거 같단 생각이 들어 고민이 되네요