### PR TITLE
[Fix] 에러 페이지에서 헤더 없어지는 거 만큼 공백 추가

### DIFF
--- a/src/views/ErrorPage/components/NoMore/index.tsx
+++ b/src/views/ErrorPage/components/NoMore/index.tsx
@@ -9,7 +9,7 @@ interface NoMoreProps {
 
 const NoMore = ({ isMakers, content }: NoMoreProps) => {
   return (
-    <section className={container}>
+    <section className={container[isMakers == undefined ? 'withoutHeader' : 'withHeader']}>
       <article className={article}>
         <p className={errorText}>{content}</p>
         <a

--- a/src/views/ErrorPage/index.tsx
+++ b/src/views/ErrorPage/index.tsx
@@ -1,5 +1,8 @@
 import { track } from '@amplitude/analytics-browser';
+import { useContext } from 'react';
 import { useNavigate } from 'react-router-dom';
+
+import { RecruitingInfoContext } from '@store/recruitingInfoContext';
 
 import ErrorCode from './components/ErrorCode';
 import { ERROR_MESSAGE } from './constants';
@@ -7,6 +10,10 @@ import { article, contactButton, container, errorButton, errorText, instruction 
 
 const ErrorPage = ({ code }: { code: 404 | 500 }) => {
   const navigate = useNavigate();
+
+  const {
+    recruitingInfo: { isMakers },
+  } = useContext(RecruitingInfoContext);
 
   const handleGoBack = (code: 404 | 500) => {
     const hasPreviousPage = window.history.length > 1;
@@ -26,7 +33,7 @@ const ErrorPage = ({ code }: { code: 404 | 500 }) => {
   const CODE_KEY: 'CODE404' | 'CODE500' = `CODE${code}`;
 
   return (
-    <section className={container}>
+    <section className={container[isMakers != undefined ? 'withoutHeader' : 'withHeader']}>
       <article className={article}>
         <ErrorCode code={code} />
         <p className={errorText}>{ERROR_MESSAGE[CODE_KEY]?.text}</p>

--- a/src/views/ErrorPage/index.tsx
+++ b/src/views/ErrorPage/index.tsx
@@ -33,7 +33,7 @@ const ErrorPage = ({ code }: { code: 404 | 500 }) => {
   const CODE_KEY: 'CODE404' | 'CODE500' = `CODE${code}`;
 
   return (
-    <section className={container[isMakers != undefined ? 'withoutHeader' : 'withHeader']}>
+    <section className={container[isMakers == undefined ? 'withoutHeader' : 'withHeader']}>
       <article className={article}>
         <ErrorCode code={code} />
         <p className={errorText}>{ERROR_MESSAGE[CODE_KEY]?.text}</p>

--- a/src/views/ErrorPage/style.css.ts
+++ b/src/views/ErrorPage/style.css.ts
@@ -1,5 +1,4 @@
 import { style } from '@vanilla-extract/css';
-import { calc } from '@vanilla-extract/css-utils';
 
 import { theme } from 'styles/theme.css';
 
@@ -9,12 +8,12 @@ export const container = style({
   alignItems: 'center',
   justifyContent: 'center',
   width: '100%',
-  height: calc.subtract('100vh', '74px'),
+  height: '100vh',
   minHeight: 700,
 
   '@supports': {
     'height: (100dvh)': {
-      height: calc.subtract('100dvh', '74px'),
+      height: '100dvh',
     },
   },
 });

--- a/src/views/ErrorPage/style.css.ts
+++ b/src/views/ErrorPage/style.css.ts
@@ -1,8 +1,9 @@
-import { style } from '@vanilla-extract/css';
+import { style, styleVariants } from '@vanilla-extract/css';
+import { calc } from '@vanilla-extract/css-utils';
 
 import { theme } from 'styles/theme.css';
 
-export const container = style({
+const containerBase = style({
   display: 'flex',
   flexDirection: 'column',
   alignItems: 'center',
@@ -16,6 +17,33 @@ export const container = style({
       height: '100dvh',
     },
   },
+});
+
+export const container = styleVariants({
+  withHeader: [
+    containerBase,
+    {
+      height: calc.subtract('100vh', '74px'),
+
+      '@supports': {
+        'height: (100dvh)': {
+          height: calc.subtract('100dvh', '74px'),
+        },
+      },
+    },
+  ],
+  withoutHeader: [
+    containerBase,
+    {
+      height: '100vh',
+
+      '@supports': {
+        'height: (100dvh)': {
+          height: '100dvh',
+        },
+      },
+    },
+  ],
 });
 
 export const article = style({

--- a/src/views/ErrorPage/style.css.ts
+++ b/src/views/ErrorPage/style.css.ts
@@ -9,7 +9,6 @@ const containerBase = style({
   alignItems: 'center',
   justifyContent: 'center',
   width: '100%',
-  height: '100vh',
   minHeight: 700,
 
   '@supports': {


### PR DESCRIPTION
**Related Issue :** Closes #240 

---

## 🧑‍🎤 Summary
- [x] 에러 페이지 헤더 있을 때 없을 때 높이 수정

## 🧑‍🎤 Screenshot
### 있을 때

<img width="1470" alt="스크린샷 2024-07-28 오후 2 08 22" src="https://github.com/user-attachments/assets/d34b56b0-17b7-4809-9810-6fe1de6a4caf">

### 없을 때

<img width="770" alt="스크린샷 2024-07-28 오후 1 46 47" src="https://github.com/user-attachments/assets/c384e002-15fe-4954-8f6e-4517298ce781">


## 🧑‍🎤 Comment
### 헤더 제거
isMakers 여부가 판단이 안되면 header가 뜨지 않아요
이는 로고와 GNB가 동시에 뜨기 위함인데요
에러 페이지에선 api 요청을 하고 있지 않아
새로고침 할 경우 isMakers 여부를 파악할 수가 없어 header가 뜨지 않게 됩니다
이를 위해 헤더 없을 때를 대비해줬어요

<details>
<summary>코드 보기</summary>

```tsx
export const container = styleVariants({
  withHeader: [
    containerBase,
    {
      height: calc.subtract('100vh', '74px'),

      '@supports': {
        'height: (100dvh)': {
          height: calc.subtract('100dvh', '74px'),
        },
      },
    },
  ],
  withoutHeader: [
    containerBase,
    {
      height: '100vh',

      '@supports': {
        'height: (100dvh)': {
          height: '100dvh',
        },
      },
    },
  ],
});
```
</details>