### PR TITLE
[ Fix ] 프로필 사진 규격 제한 제거 

### DIFF
--- a/src/common/constants/validationCheck.ts
+++ b/src/common/constants/validationCheck.ts
@@ -48,7 +48,6 @@ export const VALIDATION_CHECK = {
   },
   IDPhoto: {
     errorText: '파일 크기가 너무 커요. 10MB 이하로 선택해주세요.',
-    wrongRadioErrorText: '이미지의 비율이 3:4가 아니에요.',
   },
   subway: {
     pattern: /^[가-힣\s.,·()-\d']+$/,

--- a/src/views/ApplyPage/components/DefaultSection/index.tsx
+++ b/src/views/ApplyPage/components/DefaultSection/index.tsx
@@ -54,20 +54,7 @@ const ProfileImage = ({ disabled, pic }: ProfileImageProps) => {
     clearErrors && clearErrors('picture');
     const reader = new FileReader();
     reader.readAsDataURL(imageFile);
-    reader.onloadend = (e) => {
-      const image = new Image();
-      image.src = e.target?.result as string;
-      image.onload = () => {
-        const { width, height } = image;
-        const exactRatio = Math.round((width / height) * 100);
-        if (exactRatio !== 75) {
-          setValue('picture', null);
-          setError('picture', { type: 'wrong-ratio', message: VALIDATION_CHECK.IDPhoto.wrongRadioErrorText });
-          setImage('');
-
-          return;
-        }
-      };
+    reader.onloadend = () => {
       clearErrors('picture');
       setImage(reader.result as string);
     };

--- a/src/views/ApplyPage/components/DefaultSection/style.css.ts
+++ b/src/views/ApplyPage/components/DefaultSection/style.css.ts
@@ -30,7 +30,6 @@ const profileLabel = style({
   position: 'relative',
   display: 'flex',
   justifyContent: 'center',
-  alignItems: 'center',
   padding: 6,
   width: 134,
   height: 176,


### PR DESCRIPTION
**Related Issue :** Closes  #227 

---

## 🧑‍🎤 Summary
기존엔 3x4 규격이 아닐 시 업로드가 되지 않도록 막았지만, `강제 -> 권장`으로 기능요구조건을 변경함에 따라 관련 코드를 삭제했습니다 

## 🧑‍🎤 Screenshot
![image](https://github.com/user-attachments/assets/ce2788ed-edd0-48b4-aee8-37c12ace2e38)


## 🧑‍🎤 Comment
- `object-fit : cover` 처리는 되어있었는데, img 태그의 컨테이너에서 `align-items: center `속성을 주고 있는 것 때문에 object-fit이 제 역할을 안하고 사진이 꽉 채워지지 않고 있더라구요! 그래서 해당 속성도 함께 제거해주었습니다
