### PR TITLE
[Fix] isMakers에 따라 텍스트 조건부 렌더링

### DIFF
--- a/src/common/components/Checkbox/components/Contentbox/style.css.ts
+++ b/src/common/components/Checkbox/components/Contentbox/style.css.ts
@@ -13,4 +13,5 @@ export const container = style({
   transition: 'all 0.3s ease',
   marginTop: 12,
   ...theme.font.BODY_2_16_R,
+  letterSpacing: '-0.24px',
 });

--- a/src/views/ApplyPage/components/BottomSection/index.tsx
+++ b/src/views/ApplyPage/components/BottomSection/index.tsx
@@ -7,11 +7,12 @@ import { SELECT_OPTIONS } from 'views/ApplyPage/constant';
 import { doubleLineCheck, label, line, sectionContainer } from './style.css';
 
 interface BottomSectionProps {
+  isMakers?: boolean;
   isReview: boolean;
   knownPath?: string;
 }
 
-const BottomSection = ({ isReview, knownPath }: BottomSectionProps) => {
+const BottomSection = ({ isMakers, isReview, knownPath }: BottomSectionProps) => {
   return (
     <section className={sectionContainer}>
       <hr className={line} />
@@ -25,7 +26,11 @@ const BottomSection = ({ isReview, knownPath }: BottomSectionProps) => {
         disabled={isReview}
       />
       <div id="check-necessary" className={doubleLineCheck}>
-        <p className={label}>SOPT의 행사 및 세미나는 매주 토요일에 진행됩니다.</p>
+        <p className={label}>
+          {isMakers
+            ? 'SOPT Makers의 행사 및 정기 모임은 매주 일요일에 진행됩니다.'
+            : 'SOPT의 행사 및 세미나는 매주 토요일에 진행됩니다.'}
+        </p>
         <Checkbox checked={isReview ? true : undefined} name="attendance" required>
           참석 가능합니다.
         </Checkbox>

--- a/src/views/ApplyPage/components/BottomSection/index.tsx
+++ b/src/views/ApplyPage/components/BottomSection/index.tsx
@@ -1,18 +1,23 @@
+import { useContext } from 'react';
+
 import Checkbox from '@components/Checkbox';
 import Contentbox from '@components/Checkbox/components/Contentbox';
 import SelectBox from '@components/Select';
 import { PRIVACY_POLICY } from '@constants/policy';
+import { RecruitingInfoContext } from '@store/recruitingInfoContext';
 import { SELECT_OPTIONS } from 'views/ApplyPage/constant';
 
 import { doubleLineCheck, label, line, sectionContainer } from './style.css';
 
 interface BottomSectionProps {
-  isMakers?: boolean;
   isReview: boolean;
   knownPath?: string;
 }
 
-const BottomSection = ({ isMakers, isReview, knownPath }: BottomSectionProps) => {
+const BottomSection = ({ isReview, knownPath }: BottomSectionProps) => {
+  const {
+    recruitingInfo: { isMakers },
+  } = useContext(RecruitingInfoContext);
   return (
     <section className={sectionContainer}>
       <hr className={line} />

--- a/src/views/ApplyPage/index.tsx
+++ b/src/views/ApplyPage/index.tsx
@@ -304,7 +304,7 @@ const ApplyPage = ({ isReview, onSetComplete, draftData }: ApplyPageProps) => {
             partQuestionsDraft={partQuestionsDraft}
             questionTypes={questionTypes}
           />
-          <BottomSection isReview={isReview} knownPath={applicantDraft?.knownPath} />
+          <BottomSection isMakers={isMakers} isReview={isReview} knownPath={applicantDraft?.knownPath} />
           {!isReview && (
             <div className={buttonWrapper}>
               <Button

--- a/src/views/ApplyPage/index.tsx
+++ b/src/views/ApplyPage/index.tsx
@@ -304,7 +304,7 @@ const ApplyPage = ({ isReview, onSetComplete, draftData }: ApplyPageProps) => {
             partQuestionsDraft={partQuestionsDraft}
             questionTypes={questionTypes}
           />
-          <BottomSection isMakers={isMakers} isReview={isReview} knownPath={applicantDraft?.knownPath} />
+          <BottomSection isReview={isReview} knownPath={applicantDraft?.knownPath} />
           {!isReview && (
             <div className={buttonWrapper}>
               <Button


### PR DESCRIPTION
**Related Issue :** Closes  #245 

---

## 🧑‍🎤 Summary
- isMakers에 따라 동아리참석가능여부 텍스트 조건부렌더링 추가 
- ApplyPage의 개인정보 수집 정책 줄바꿈 해결 

## 🧑‍🎤 Screenshot
![image](https://github.com/user-attachments/assets/2d17ece3-b835-4d6a-b30b-2549915e7a10)



## 🧑‍🎤 Comment
1) SOPT Makers의 행사 및 `정기 모임 / 세미나`은 매주 일요일에 진행됩니다.
-> 이거 워딩 기디에게 답장 오는대로 반영할게요! 일단 정기 모임으로 해뒀습니다 

2) ApplyPage의 개인정보 수집 정책 줄바꿈 해결 
이슈에도 코멘트했지만 아래와 같이 줄바꿈이 발생하고 있더라고요 
![image](https://github.com/user-attachments/assets/819b6176-43a4-43ab-9b6f-57ac288ef71a)

보니까 letter-spacing의 `%` 단위가 안먹고 있어서 발생한 이슈더라구요 

![image](https://github.com/user-attachments/assets/8ed8f167-5c33-486b-aeb8-11684a94f0be)


그래서 figma 개발자도구에서 px값 가져와서 px로 변환시켜주어 해결했습니다 

![image](https://github.com/user-attachments/assets/7ecf15a5-f556-4ae0-af09-64156856e649)

