### PR TITLE
[Fix] 프로필 이미지 아이콘 배치 깨짐 해결

### DIFF
--- a/src/views/ApplyPage/components/DefaultSection/style.css.ts
+++ b/src/views/ApplyPage/components/DefaultSection/style.css.ts
@@ -30,6 +30,7 @@ const profileLabel = style({
   position: 'relative',
   display: 'flex',
   justifyContent: 'center',
+  alignItems: 'center',
   padding: 6,
   width: 134,
   height: 176,
@@ -72,6 +73,7 @@ export const errorText = style({
 export const profileImage = style({
   objectFit: 'cover',
   width: '100%',
+  height: '100%',
 });
 
 export const profileTextWrapper = style({


### PR DESCRIPTION
**Related Issue :** Closes  #252 

---

## 🧑‍🎤 Summary
object-fit 적용을 위해 align items center를 제거했더니 기본 아이콘 배치가 깨지는 이슈 해결 

## 🧑‍🎤 Screenshot
![image](https://github.com/user-attachments/assets/124185f3-f1b0-448a-8a00-4f4f3286cfcc)

![image](https://github.com/user-attachments/assets/2d7c17d3-91b8-4ccd-ae06-5a2bc20d2a75)


## 🧑‍🎤 Comment
align items center 속성은 다시 복구시키되, img 태그 스타일에 `height: 100%`를 추가하여 object fit 적용을 유지시켰습니다!
