### PR TITLE
[Fix] 사진 에러 메세지 떠도 draft image 안 사라지는 에러 해결

### DIFF
--- a/src/views/ApplyPage/components/DefaultSection/index.tsx
+++ b/src/views/ApplyPage/components/DefaultSection/index.tsx
@@ -38,6 +38,8 @@ const ProfileImage = ({ disabled, pic }: ProfileImageProps) => {
   } = useFormContext();
   const [image, setImage] = useState('');
 
+  const hasImage = image !== 'max-size' && (pic || image);
+
   const handleChangeImage = (e: ChangeEvent<HTMLInputElement>) => {
     const imageFile = e.target.files?.[0];
 
@@ -71,7 +73,7 @@ const ProfileImage = ({ disabled, pic }: ProfileImageProps) => {
           style={{ display: 'none' }}
           disabled={disabled}
           {...register('picture', {
-            required: !pic && true && '필수 입력 항목이에요.',
+            required: !hasImage && '필수 입력 항목이에요.',
             onChange: handleChangeImage,
           })}
         />
@@ -79,11 +81,7 @@ const ProfileImage = ({ disabled, pic }: ProfileImageProps) => {
           <label
             htmlFor="picture"
             className={profileLabelVar[disabled ? 'disabled' : errors.picture ? 'error' : 'default']}>
-            {image !== 'max-size' && (pic || image) ? (
-              <img src={image || pic} alt="지원서 프로필 사진" className={profileImage} />
-            ) : (
-              <IconUser />
-            )}
+            {hasImage ? <img src={image || pic} alt="지원서 프로필 사진" className={profileImage} /> : <IconUser />}
             {errors.picture && <p className={errorText}>{errors.picture?.message as string}</p>}
           </label>
         </div>

--- a/src/views/ApplyPage/components/DefaultSection/index.tsx
+++ b/src/views/ApplyPage/components/DefaultSection/index.tsx
@@ -47,7 +47,8 @@ const ProfileImage = ({ disabled, pic }: ProfileImageProps) => {
     if (LIMIT_SIZE < imageFile.size) {
       setValue('picture', null);
       setError('picture', { type: 'max-size', message: VALIDATION_CHECK.IDPhoto.errorText });
-      setImage('');
+      setImage('max-size');
+
       return;
     }
 
@@ -78,7 +79,11 @@ const ProfileImage = ({ disabled, pic }: ProfileImageProps) => {
           <label
             htmlFor="picture"
             className={profileLabelVar[disabled ? 'disabled' : errors.picture ? 'error' : 'default']}>
-            {pic || image ? <img src={image || pic} alt="지원서 프로필 사진" className={profileImage} /> : <IconUser />}
+            {image !== 'max-size' && (pic || image) ? (
+              <img src={image || pic} alt="지원서 프로필 사진" className={profileImage} />
+            ) : (
+              <IconUser />
+            )}
             {errors.picture && <p className={errorText}>{errors.picture?.message as string}</p>}
           </label>
         </div>

--- a/src/views/ApplyPage/index.tsx
+++ b/src/views/ApplyPage/index.tsx
@@ -232,7 +232,7 @@ const ApplyPage = ({ isReview, onSetComplete, draftData }: ApplyPageProps) => {
     const answers = JSON.stringify(answersValue);
     const formValues: ApplyRequest = {
       picture: picture?.[0],
-      pictureUrl: applicantDraft?.pic,
+      pictureUrl: errors.picture ? undefined : applicantDraft?.pic,
       part,
       address,
       birthday,


### PR DESCRIPTION
**Related Issue :** Closes #255 

---

## 🧑‍🎤 Summary
- [x] 다른 사진 선택 시 에러 떠도 사진 초기화 시키기
- [x] 에러 뜬 상태에서 임시저장 후 새로고침할 때 기존 이미지 그대로 오는 에러 해결
- [x] 이미지 없어도 required 안 되는 에러 해결

## 🧑‍🎤 Comment
이미지가 10MB 사이즈를 초과해 버리면
setValue('picture', null); 을 이용해서 picture 값은 null이 되는데
실제로 이미지는 image state를 이용해서 보여주고 있기 때문에
이미지가 계속 표시되고 있었어요

기존 image state를 이용해서 10MB 초과 시
setImage('max-size') 로 설정하여
`<img src={image} />` 에서 이미지를 인식 못하도록 하여
이미지가 사라지도록 설정했습니다

그냥 setImage('')로 설정하면
이미지 있는지 없는지 여부를 판단하는 pic || image 
여기에서 판단이 조금 어려워져서 따로 max-size로 처리해줬어요
