### PR TITLE
[Fix] 최대글자수에 따라 textArea 높이 동적 설정

### DIFF
--- a/src/common/components/Textarea/components/Input/index.tsx
+++ b/src/common/components/Textarea/components/Input/index.tsx
@@ -1,8 +1,7 @@
+import { useEffect, type TextareaHTMLAttributes } from 'react';
 import { type FieldValues, type Path, useFormContext } from 'react-hook-form';
 
 import { container, errorMsgStyle, maxCountStyle, textCountStyle, textareaStyle, bottomStyle } from './style.css';
-
-import type { TextareaHTMLAttributes } from 'react';
 
 interface InputProps<T extends FieldValues> extends TextareaHTMLAttributes<HTMLTextAreaElement> {
   name: Path<T>;
@@ -13,11 +12,19 @@ const Input = <T extends FieldValues>({ name, maxCount, required, ...textareaEle
   const {
     watch,
     register,
+    setError,
+    clearErrors,
     formState: { errors },
   } = useFormContext();
 
   const state = errors[name] ? 'error' : 'default';
   const textCount = watch(name)?.length;
+
+  useEffect(() => {
+    maxCount < textCount
+      ? setError(name, { type: 'maxLength', message: '최대 글자 수를 초과했어요.' })
+      : clearErrors(name);
+  }, [textCount, maxCount, name, setError, clearErrors]);
 
   return (
     <div className={container}>

--- a/src/common/components/Textarea/components/Input/index.tsx
+++ b/src/common/components/Textarea/components/Input/index.tsx
@@ -1,7 +1,15 @@
 import { useEffect, type TextareaHTMLAttributes } from 'react';
 import { type FieldValues, type Path, useFormContext } from 'react-hook-form';
 
-import { container, errorMsgStyle, maxCountStyle, textCountStyle, textareaStyle, bottomStyle } from './style.css';
+import {
+  container,
+  errorMsgStyle,
+  maxCountStyle,
+  textCountStyle,
+  textareaStyle,
+  bottomStyle,
+  textareaHeight,
+} from './style.css';
 
 interface InputProps<T extends FieldValues> extends TextareaHTMLAttributes<HTMLTextAreaElement> {
   name: Path<T>;
@@ -18,6 +26,7 @@ const Input = <T extends FieldValues>({ name, maxCount, required, ...textareaEle
   } = useFormContext();
 
   const state = errors[name] ? 'error' : 'default';
+  const textareaSize = maxCount > 100 ? 'lg' : 'sm';
   const textCount = watch(name)?.length;
 
   useEffect(() => {
@@ -29,7 +38,7 @@ const Input = <T extends FieldValues>({ name, maxCount, required, ...textareaEle
   return (
     <div className={container}>
       <textarea
-        className={textareaStyle[state]}
+        className={`${textareaStyle[state]} ${textareaHeight[textareaSize]}`}
         {...register(name, {
           ...(required && { required: '필수 입력 항목이에요.' }),
           maxLength: {

--- a/src/common/components/Textarea/components/Input/index.tsx
+++ b/src/common/components/Textarea/components/Input/index.tsx
@@ -1,26 +1,21 @@
-import { FieldErrors, FieldValues, Path, UseFormRegister, UseFormWatch } from 'react-hook-form';
+import { type FieldValues, type Path, useFormContext } from 'react-hook-form';
 
 import { container, errorMsgStyle, maxCountStyle, textCountStyle, textareaStyle, bottomStyle } from './style.css';
 
 import type { TextareaHTMLAttributes } from 'react';
 
 interface InputProps<T extends FieldValues> extends TextareaHTMLAttributes<HTMLTextAreaElement> {
-  watch: UseFormWatch<T>;
-  register: UseFormRegister<T>;
   name: Path<T>;
-  errors: FieldErrors<FieldValues>;
   maxCount: number;
 }
 
-const Input = <T extends FieldValues>({
-  watch,
-  register,
-  name,
-  errors,
-  maxCount,
-  required,
-  ...textareaElements
-}: InputProps<T>) => {
+const Input = <T extends FieldValues>({ name, maxCount, required, ...textareaElements }: InputProps<T>) => {
+  const {
+    watch,
+    register,
+    formState: { errors },
+  } = useFormContext();
+
   const state = errors[name] ? 'error' : 'default';
   const textCount = watch(name)?.length;
 

--- a/src/common/components/Textarea/components/Input/style.css.ts
+++ b/src/common/components/Textarea/components/Input/style.css.ts
@@ -33,7 +33,7 @@ const textareaBase = style({
 
 export const textareaHeight = styleVariants({
   sm: {
-    height: 113,
+    height: 112,
   },
   lg: {
     height: 507,

--- a/src/common/components/Textarea/components/Input/style.css.ts
+++ b/src/common/components/Textarea/components/Input/style.css.ts
@@ -12,7 +12,6 @@ export const container = style({
 
 const textareaBase = style({
   width: '100%',
-  height: 507,
   padding: '16px 16px',
   borderRadius: 12,
   backgroundColor: theme.color.background,
@@ -29,6 +28,15 @@ const textareaBase = style({
 
   '::placeholder': {
     color: theme.color.placeholder,
+  },
+});
+
+export const textareaHeight = styleVariants({
+  sm: {
+    height: 113,
+  },
+  lg: {
+    height: 507,
   },
 });
 

--- a/src/common/components/Textarea/index.tsx
+++ b/src/common/components/Textarea/index.tsx
@@ -1,9 +1,10 @@
-import { ReactNode, TextareaHTMLAttributes, useId } from 'react';
-import { type FieldValues, type Path, useFormContext } from 'react-hook-form';
+import { type ReactNode, type TextareaHTMLAttributes, useId } from 'react';
 
 import Input from './components/Input';
 import Label from './components/Label';
 import { container } from './style.css';
+
+import type { FieldValues, Path } from 'react-hook-form';
 
 interface TextareaProps<T extends FieldValues> extends TextareaHTMLAttributes<HTMLTextAreaElement> {
   name: Path<T>;
@@ -21,11 +22,6 @@ const Textarea = <T extends FieldValues>({
   ...textareaElements
 }: TextareaProps<T>) => {
   const id = useId();
-  const {
-    register,
-    watch,
-    formState: { errors },
-  } = useFormContext();
 
   return (
     <div className={container}>
@@ -33,16 +29,7 @@ const Textarea = <T extends FieldValues>({
         {children}
       </Label>
       {extraInput}
-      <Input
-        id={id}
-        name={name}
-        register={register}
-        watch={watch}
-        required={required}
-        errors={errors}
-        maxCount={maxCount}
-        {...textareaElements}
-      />
+      <Input id={id} name={name} required={required} maxCount={maxCount} {...textareaElements} />
     </div>
   );
 };

--- a/src/common/components/Textarea/index.tsx
+++ b/src/common/components/Textarea/index.tsx
@@ -48,10 +48,3 @@ const Textarea = <T extends FieldValues>({
 };
 
 export default Textarea;
-
-{
-  /* <TextareaHeader maxCount={maxCount} required>
-            {`3. 최근 1년 이내로 머릿속으로만 생각하고 있던 계획을 행동으로 옮겨본 경험이 있나요? 만약 있다면 어떤. 계획이. 었으며, 행동을 통해 어떤 성장을 이루어냈는지에 대해 구체적으로 서술해 주세요. 만약 없다면, 해당 계획을 행동으로 옮기기 위한 액션 플랜을 서술해 주세요.`}
-          </TextareaHeader>
-          <Textarea label="q1" register={register} watch={watch} required errors={errors} maxCount={maxCount} /> */
-}


### PR DESCRIPTION
**Related Issue :** Closes #260 

---

## 🧑‍🎤 Summary
- [x] 텍스트가 최대 글자수 넘어갔을 때 바로 에러 뜨도록 구현
- [x] 단답형 질문에 대한 textarea 사이즈 조절
- [x] 불필요한 prop 전달 제거

## 🧑‍🎤 Comment
![스크린샷 2024-07-29 오후 8 40 50](https://github.com/user-attachments/assets/2c6a6c8c-631a-4aba-a800-5b65744af546)

![스크린샷 2024-07-29 오후 8 41 12](https://github.com/user-attachments/assets/49b336fb-c1d3-43e1-9302-969782f8f5ac)

넉넉하게 100 이하일 때 위와 같은 사이즈가 뜨도록 했어요
세 줄 기준 이 이하의 높이에선 스크롤이 발생해서 딱 스크롤 발생하기 전인 height 112로 설정해줬습니다