### PR TITLE
[Feat] 파트 안내 메세지 추가

### DIFF
--- a/src/views/ApplyPage/components/CommonSection/index.tsx
+++ b/src/views/ApplyPage/components/CommonSection/index.tsx
@@ -3,6 +3,7 @@ import { Answers, Questions } from 'views/ApplyPage/types';
 
 import { sectionContainer, title } from './style.css';
 import FileInput from '../FileInput';
+import Info from '../Info';
 import LinkInput from '../LinkInput';
 
 interface CommonSectionProps {
@@ -31,26 +32,29 @@ const CommonSection = ({ isReview, refCallback, questions, commonQuestionsDraft 
 
         return (
           <div key={value}>
-            <Textarea
-              name={`common${id}`}
-              defaultValue={defaultValue}
-              maxCount={charLimit}
-              placeholder={
-                isFile
-                  ? '링크로 제출할 경우, 이곳에 작성해주세요. (파일로 제출한 경우에는 ‘파일 제출’이라고 기재 후 제출해주세요.)'
-                  : ''
-              }
-              extraInput={
-                isFile ? (
-                  <FileInput section="common" id={id} isReview={isReview} defaultFile={defaultFile} />
-                ) : urls ? (
-                  <LinkInput urls={urls} />
-                ) : null
-              }
-              required
-              disabled={isReview}>
-              {value}
-            </Textarea>
+            {charLimit == null && <Info value={value} />}
+            {charLimit != null && (
+              <Textarea
+                name={`common${id}`}
+                defaultValue={defaultValue}
+                maxCount={charLimit}
+                placeholder={
+                  isFile
+                    ? '링크로 제출할 경우, 이곳에 작성해주세요. (파일로 제출한 경우에는 ‘파일 제출’이라고 기재 후 제출해주세요.)'
+                    : ''
+                }
+                extraInput={
+                  isFile ? (
+                    <FileInput section="common" id={id} isReview={isReview} defaultFile={defaultFile} />
+                  ) : urls ? (
+                    <LinkInput urls={urls} />
+                  ) : null
+                }
+                required
+                disabled={isReview}>
+                {value}
+              </Textarea>
+            )}
           </div>
         );
       })}

--- a/src/views/ApplyPage/components/Info/index.tsx
+++ b/src/views/ApplyPage/components/Info/index.tsx
@@ -1,0 +1,15 @@
+import { container, info } from './style.css';
+
+const Info = ({ value }: { value: string }) => {
+  return (
+    <article className={container}>
+      {value.split('\n').map((text) => (
+        <p className={info} key={text}>
+          {text && <>&#183;</>} {text}
+        </p>
+      ))}
+    </article>
+  );
+};
+
+export default Info;

--- a/src/views/ApplyPage/components/Info/style.css.ts
+++ b/src/views/ApplyPage/components/Info/style.css.ts
@@ -1,0 +1,17 @@
+import { style } from '@vanilla-extract/css';
+
+import { theme } from 'styles/theme.css';
+
+export const container = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 16,
+  margin: '20px 0 50px',
+});
+
+export const info = style({
+  color: theme.color.lighterText,
+  ...theme.font.BODY_1_18_M,
+  whiteSpace: 'pre-line',
+  letterSpacing: '-0.27px',
+});

--- a/src/views/ApplyPage/components/PartSection/index.tsx
+++ b/src/views/ApplyPage/components/PartSection/index.tsx
@@ -8,6 +8,18 @@ import { partInfo, partInfoWrapper, sectionContainer, title } from './style.css'
 import FileInput from '../FileInput';
 import LinkInput from '../LinkInput';
 
+const PartInfo = ({ value }: { value: string }) => {
+  return (
+    <article className={partInfoWrapper}>
+      {value.split('\n').map((text) => (
+        <p className={partInfo} key={text}>
+          &#183; {text}
+        </p>
+      ))}
+    </article>
+  );
+};
+
 interface PartSectionProps {
   isReview: boolean;
   refCallback: (elem: HTMLSelectElement) => void;
@@ -63,15 +75,7 @@ const PartSection = ({
 
         return (
           <div key={value}>
-            {charLimit == null && (
-              <article className={partInfoWrapper}>
-                {value.split('\n').map((text) => (
-                  <p className={partInfo} key={text}>
-                    &#183; {text}
-                  </p>
-                ))}
-              </article>
-            )}
+            {charLimit == null && <PartInfo value={value} />}
             {charLimit != null && (
               <Textarea
                 name={`part${id}`}

--- a/src/views/ApplyPage/components/PartSection/index.tsx
+++ b/src/views/ApplyPage/components/PartSection/index.tsx
@@ -13,7 +13,7 @@ const PartInfo = ({ value }: { value: string }) => {
     <article className={partInfoWrapper}>
       {value.split('\n').map((text) => (
         <p className={partInfo} key={text}>
-          &#183; {text}
+          {text && <>&#183;</>} {text}
         </p>
       ))}
     </article>

--- a/src/views/ApplyPage/components/PartSection/index.tsx
+++ b/src/views/ApplyPage/components/PartSection/index.tsx
@@ -4,21 +4,10 @@ import SelectBox from '@components/Select';
 import Textarea from '@components/Textarea';
 import { Answers, Questions } from 'views/ApplyPage/types';
 
-import { partInfo, partInfoWrapper, sectionContainer, title } from './style.css';
+import { sectionContainer, title } from './style.css';
 import FileInput from '../FileInput';
+import Info from '../Info';
 import LinkInput from '../LinkInput';
-
-const PartInfo = ({ value }: { value: string }) => {
-  return (
-    <article className={partInfoWrapper}>
-      {value.split('\n').map((text) => (
-        <p className={partInfo} key={text}>
-          {text && <>&#183;</>} {text}
-        </p>
-      ))}
-    </article>
-  );
-};
 
 interface PartSectionProps {
   isReview: boolean;
@@ -75,7 +64,7 @@ const PartSection = ({
 
         return (
           <div key={value}>
-            {charLimit == null && <PartInfo value={value} />}
+            {charLimit == null && <Info value={value} />}
             {charLimit != null && (
               <Textarea
                 name={`part${id}`}

--- a/src/views/ApplyPage/components/PartSection/index.tsx
+++ b/src/views/ApplyPage/components/PartSection/index.tsx
@@ -4,7 +4,7 @@ import SelectBox from '@components/Select';
 import Textarea from '@components/Textarea';
 import { Answers, Questions } from 'views/ApplyPage/types';
 
-import { sectionContainer, title } from './style.css';
+import { partInfo, partInfoWrapper, sectionContainer, title } from './style.css';
 import FileInput from '../FileInput';
 import LinkInput from '../LinkInput';
 
@@ -63,26 +63,37 @@ const PartSection = ({
 
         return (
           <div key={value}>
-            <Textarea
-              name={`part${id}`}
-              defaultValue={defaultValue}
-              maxCount={charLimit}
-              placeholder={
-                isFile
-                  ? '링크로 제출할 경우, 이곳에 작성해주세요. (파일로 제출한 경우에는 ‘파일 제출’이라고 기재 후 제출해주세요.)'
-                  : ''
-              }
-              extraInput={
-                isFile ? (
-                  <FileInput section="part" id={id} isReview={isReview} defaultFile={defaultFile} />
-                ) : urls ? (
-                  <LinkInput urls={urls} />
-                ) : null
-              }
-              required
-              disabled={isReview}>
-              {value}
-            </Textarea>
+            {charLimit == null && (
+              <article className={partInfoWrapper}>
+                {value.split('\n').map((text) => (
+                  <p className={partInfo} key={text}>
+                    &#183; {text}
+                  </p>
+                ))}
+              </article>
+            )}
+            {charLimit != null && (
+              <Textarea
+                name={`part${id}`}
+                defaultValue={defaultValue}
+                maxCount={charLimit}
+                placeholder={
+                  isFile
+                    ? '링크로 제출할 경우, 이곳에 작성해주세요. (파일로 제출한 경우에는 ‘파일 제출’이라고 기재 후 제출해주세요.)'
+                    : ''
+                }
+                extraInput={
+                  isFile ? (
+                    <FileInput section="part" id={id} isReview={isReview} defaultFile={defaultFile} />
+                  ) : urls ? (
+                    <LinkInput urls={urls} />
+                  ) : null
+                }
+                required
+                disabled={isReview}>
+                {value}
+              </Textarea>
+            )}
           </div>
         );
       })}

--- a/src/views/ApplyPage/components/PartSection/style.css.ts
+++ b/src/views/ApplyPage/components/PartSection/style.css.ts
@@ -13,17 +13,3 @@ export const title = style({
   ...theme.font.TITLE_2_28_SB,
   color: theme.color.baseText,
 });
-
-export const partInfoWrapper = style({
-  display: 'flex',
-  flexDirection: 'column',
-  gap: 16,
-  margin: '20px 0 50px',
-});
-
-export const partInfo = style({
-  color: theme.color.lighterText,
-  ...theme.font.BODY_1_18_M,
-  whiteSpace: 'pre-line',
-  letterSpacing: '-0.27px',
-});

--- a/src/views/ApplyPage/components/PartSection/style.css.ts
+++ b/src/views/ApplyPage/components/PartSection/style.css.ts
@@ -13,3 +13,17 @@ export const title = style({
   ...theme.font.TITLE_2_28_SB,
   color: theme.color.baseText,
 });
+
+export const partInfoWrapper = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 16,
+  margin: '20px 0 50px',
+});
+
+export const partInfo = style({
+  color: theme.color.lighterText,
+  ...theme.font.BODY_1_18_M,
+  whiteSpace: 'pre-line',
+  letterSpacing: '-0.27px',
+});


### PR DESCRIPTION
**Related Issue :** Closes #269 

---

## 🧑‍🎤 Summary
- [x] 파트 선택 시 지원할 때 주의할 점에 대한 안내 메세지 보여주기

## 🧑‍🎤 Screenshot
![스크린샷 2024-07-30 오전 3 22 36](https://github.com/user-attachments/assets/c4cdd6eb-1007-4064-b27f-36964b5c0178)


## 🧑‍🎤 Comment
### 디자인
디자인은 지원하기 페이지 젤 윗 부분의 지원서 안내 메세지와 동일하게 가져갔어요
![스크린샷 2024-07-30 오전 3 23 19](https://github.com/user-attachments/assets/e9238f91-2162-4775-96ad-2cddb8684f88)
서버에서 텍스트를 그대로 받아오기 때문에 강조하는 부분에 대해서는 아직 처리를 못했는데 이건 다음 기수 때 추가해 봐도 좋을 거 같아요

### 사용법
admin 페이지에서 질문 적는 곳에 안내 메세지 작성하고 글자 수 제한을 0으로 설정한 뒤 저장하면 돼요!