### PR TITLE
[Feat] admin을 통해 등록된 placeholder 파싱하여 추가

### DIFF
--- a/src/views/ApplyPage/components/PartSection/index.tsx
+++ b/src/views/ApplyPage/components/PartSection/index.tsx
@@ -56,10 +56,11 @@ const PartSection = ({
         required
         disabled={isReview}
       />
-      {filteredQuestions?.map(({ value, charLimit, id, urls, isFile }) => {
+      {filteredQuestions?.map(({ value, charLimit, id, urls, isFile, question }) => {
         const draftItem = partQuestionsById?.[id];
         const defaultValue = draftItem ? draftItem.answer.answer : '';
         const defaultFile = { id, file: draftItem?.answer.file, fileName: draftItem?.answer.fileName };
+        const parsedPlaceholder = question.includes('<플레이스홀더>') && question.split('<플레이스홀더>')[1].trim();
 
         return (
           <div key={value}>
@@ -70,7 +71,7 @@ const PartSection = ({
               placeholder={
                 isFile
                   ? '링크로 제출할 경우, 이곳에 작성해주세요. (파일로 제출한 경우에는 ‘파일 제출’이라고 기재 후 제출해주세요.)'
-                  : ''
+                  : parsedPlaceholder || ''
               }
               extraInput={
                 isFile ? (

--- a/src/views/ApplyPage/components/PartSection/index.tsx
+++ b/src/views/ApplyPage/components/PartSection/index.tsx
@@ -56,11 +56,10 @@ const PartSection = ({
         required
         disabled={isReview}
       />
-      {filteredQuestions?.map(({ value, charLimit, id, urls, isFile, question }) => {
+      {filteredQuestions?.map(({ value, charLimit, id, urls, isFile, placeholder, optional }) => {
         const draftItem = partQuestionsById?.[id];
         const defaultValue = draftItem ? draftItem.answer.answer : '';
         const defaultFile = { id, file: draftItem?.answer.file, fileName: draftItem?.answer.fileName };
-        const parsedPlaceholder = question.includes('<플레이스홀더>') && question.split('<플레이스홀더>')[1].trim();
 
         return (
           <div key={value}>
@@ -69,9 +68,10 @@ const PartSection = ({
               defaultValue={defaultValue}
               maxCount={charLimit}
               placeholder={
-                isFile
+                placeholder ||
+                (isFile
                   ? '링크로 제출할 경우, 이곳에 작성해주세요. (파일로 제출한 경우에는 ‘파일 제출’이라고 기재 후 제출해주세요.)'
-                  : parsedPlaceholder || ''
+                  : '')
               }
               extraInput={
                 isFile ? (
@@ -80,7 +80,7 @@ const PartSection = ({
                   <LinkInput urls={urls} />
                 ) : null
               }
-              required
+              required={!optional}
               disabled={isReview}>
               {value}
             </Textarea>

--- a/src/views/ApplyPage/types.ts
+++ b/src/views/ApplyPage/types.ts
@@ -30,6 +30,8 @@ export interface Questions {
   urls: string[];
   charLimit: number;
   isFile: boolean;
+  placeholder: string;
+  optional: boolean;
 }
 
 export interface QuestionsResponse {


### PR DESCRIPTION
**Related Issue :** Closes #267 

---

## 🧑‍🎤 Summary
Admin에서 `<플레이스홀더>`로 명시된 placeholder 텍스트를 추출 후 textarea에 주입시켜줍니다 

## 🧑‍🎤 Screenshot

https://github.com/user-attachments/assets/3f250372-6099-43f4-8831-6d52601679d9



## 🧑‍🎤 Comment
1. question 요소에서 문자열에 `<플레이스홀더>`가 포함되어있는 요소에 한해서
2. `<플레이스홀더>` 구분자를 통해 문자열 분리 후 1번 index 문자열을 추출하고 (구분자 `뒤`에 있는 문자열 추출) 
3. `trim()`을 통해 혹시 모를 앞뒤 공백을 제거해주어 파싱
  ```tsx
  const parsedPlaceholder = question.includes('<플레이스홀더>') && question.split('<플레이스홀더>')[1].trim();
  ```
4. placeholder 속성 값 분기  
  - isFile 일 경우 : 링크로 제출할 경우, 이곳에 작성해주세요. (파일로 제출한 경우에는 ‘파일 제출’이라고 기재 후 제출해주세요.)
  - isFile이 아니고, placeholder가 존재할 경우 : placeholder 값 
  - isFile이 아니고, placeholder도 undefined일 경우 : 빈문자열
```tsx
placeholder={
  isFile
    ? '링크로 제출할 경우, 이곳에 작성해주세요. (파일로 제출한 경우에는 ‘파일 제출’이라고 기재 후 제출해주세요.)'
    : parsedPlaceholder || ''
}
```

