### PR TITLE
[Feat] FileInput textarea height sm로 만들기

### DIFF
--- a/src/common/components/Textarea/components/Input/index.tsx
+++ b/src/common/components/Textarea/components/Input/index.tsx
@@ -14,9 +14,16 @@ import {
 interface InputProps<T extends FieldValues> extends TextareaHTMLAttributes<HTMLTextAreaElement> {
   name: Path<T>;
   maxCount: number;
+  isFileInput?: boolean;
 }
 
-const Input = <T extends FieldValues>({ name, maxCount, required, ...textareaElements }: InputProps<T>) => {
+const Input = <T extends FieldValues>({
+  name,
+  maxCount,
+  required,
+  isFileInput,
+  ...textareaElements
+}: InputProps<T>) => {
   const {
     watch,
     register,
@@ -26,7 +33,7 @@ const Input = <T extends FieldValues>({ name, maxCount, required, ...textareaEle
   } = useFormContext();
 
   const state = errors[name] ? 'error' : 'default';
-  const textareaSize = maxCount > 100 ? 'lg' : 'sm';
+  const textareaSize = isFileInput || maxCount <= 100 ? 'sm' : 'lg';
   const textCount = watch(name)?.length;
 
   useEffect(() => {

--- a/src/common/components/Textarea/index.tsx
+++ b/src/common/components/Textarea/index.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, type TextareaHTMLAttributes, useId } from 'react';
+import { type ReactElement, type TextareaHTMLAttributes, useId } from 'react';
 
 import Input from './components/Input';
 import Label from './components/Label';
@@ -10,7 +10,7 @@ interface TextareaProps<T extends FieldValues> extends TextareaHTMLAttributes<HT
   name: Path<T>;
   maxCount: number;
   children: string | number;
-  extraInput?: ReactNode;
+  extraInput?: ReactElement;
 }
 
 const Textarea = <T extends FieldValues>({
@@ -29,7 +29,14 @@ const Textarea = <T extends FieldValues>({
         {children}
       </Label>
       {extraInput}
-      <Input id={id} name={name} required={required} maxCount={maxCount} {...textareaElements} />
+      <Input
+        id={id}
+        name={name}
+        required={required}
+        maxCount={maxCount}
+        isFileInput={extraInput?.props.defaultFile}
+        {...textareaElements}
+      />
     </div>
   );
 };

--- a/src/views/ApplyPage/components/CommonSection/index.tsx
+++ b/src/views/ApplyPage/components/CommonSection/index.tsx
@@ -49,7 +49,7 @@ const CommonSection = ({ isReview, refCallback, questions, commonQuestionsDraft 
                     <FileInput section="common" id={id} isReview={isReview} defaultFile={defaultFile} />
                   ) : urls ? (
                     <LinkInput urls={urls} />
-                  ) : null
+                  ) : undefined
                 }
                 required={!optional}
                 disabled={isReview}>

--- a/src/views/ApplyPage/components/PartSection/index.tsx
+++ b/src/views/ApplyPage/components/PartSection/index.tsx
@@ -81,7 +81,7 @@ const PartSection = ({
                     <FileInput section="part" id={id} isReview={isReview} defaultFile={defaultFile} />
                   ) : urls ? (
                     <LinkInput urls={urls} />
-                  ) : null
+                  ) : undefined
                 }
                 required={!optional}
                 disabled={isReview}>


### PR DESCRIPTION
**Related Issue :** Closes #288 

---

## 🧑‍🎤 Summary
- [x] 파일 입력하는 문항일 시 글자수 100자 넘어도 단답형 textarea로 만들기

## 🧑‍🎤 Screenshot
![스크린샷 2024-07-30 오후 9 01 11](https://github.com/user-attachments/assets/930700b8-9918-4278-b67c-5b5551914bba)

## 🧑‍🎤 Comment
### file input인지 판단
file input이면 extra input의 props 속성에 defaultFile이 들어가고
url input이면 props 속성에 urls가 들어가는 차이를 가지고 비교를 진행했어요

![스크린샷 2024-07-30 오후 9 04 13](https://github.com/user-attachments/assets/83423228-36b1-4601-a845-7bc7c0837ad9)
![스크린샷 2024-07-30 오후 9 04 38](https://github.com/user-attachments/assets/1cde8338-11ac-4a93-a7f8-98434145affd)

```tsx
isFileInput={extraInput?.props.defaultFile}
```