### PR TITLE
[Fix] 글자 수와 required dot 위치 수정

### DIFF
--- a/src/common/components/Textarea/components/Label/index.tsx
+++ b/src/common/components/Textarea/components/Label/index.tsx
@@ -1,24 +1,50 @@
+import { Fragment, useId, type HTMLAttributes } from 'react';
+
 import { requireDot, labelStyle } from './style.css';
 
-import type { HTMLAttributes } from 'react';
-
 interface LabelProps extends HTMLAttributes<HTMLHeadingElement> {
-  children: string | number;
+  children: string;
   maxCount: number;
   required: boolean;
   label: string;
 }
 
 const Label = ({ children, maxCount, required, label, ...headerElementProps }: LabelProps) => {
+  const keyId = useId();
+  const questionArray = children.split('\n');
+  const firstEmptyIndex = questionArray.indexOf('');
+
+  const renderQuestions = (questions: string[], limit: number) =>
+    questions.slice(0, limit).map((item, idx) => (
+      <Fragment key={`${item}-${idx}`}>
+        {item}
+        {idx !== limit - 1 && '\n'}
+      </Fragment>
+    ));
+
+  const renderRestQuestions = (questions: string[]) =>
+    questions.slice(firstEmptyIndex).map((item, idx) => {
+      if (item === '') return <br key={`${keyId}-${idx}`} />;
+      return <Fragment key={`${item}-${idx}`}>{item}</Fragment>;
+    });
+
   return (
     <h4 className={labelStyle} {...headerElementProps}>
       <label style={{ cursor: 'pointer' }} htmlFor={label}>
-        <span>{children}</span>
-        <span style={{ position: 'relative' }}>
-          {' '}
-          ({maxCount}자)
-          {required && <i className={requireDot} />}
+        <span>
+          {firstEmptyIndex === -1 ? children : renderQuestions(questionArray, firstEmptyIndex)}
+          <span style={{ position: 'relative' }}>
+            {' '}
+            ({maxCount}자)
+            {required && <i className={requireDot} />}
+          </span>
         </span>
+        {firstEmptyIndex !== -1 && (
+          <>
+            <br />
+            <span>{renderRestQuestions(questionArray)}</span>
+          </>
+        )}
       </label>
     </h4>
   );

--- a/src/common/components/Textarea/index.tsx
+++ b/src/common/components/Textarea/index.tsx
@@ -9,7 +9,7 @@ import type { FieldValues, Path } from 'react-hook-form';
 interface TextareaProps<T extends FieldValues> extends TextareaHTMLAttributes<HTMLTextAreaElement> {
   name: Path<T>;
   maxCount: number;
-  children: string | number;
+  children: string;
   extraInput?: ReactNode;
 }
 

--- a/src/views/ApplyPage/components/Info/index.tsx
+++ b/src/views/ApplyPage/components/Info/index.tsx
@@ -3,8 +3,8 @@ import { container, info } from './style.css';
 const Info = ({ value }: { value: string }) => {
   return (
     <article className={container}>
-      {value.split('\n').map((text) => (
-        <p className={info} key={text}>
+      {value.split('\n').map((text, idx) => (
+        <p className={info} key={`${text}+${idx}`}>
           {text && <>&#183;</>} {text}
         </p>
       ))}

--- a/src/views/ApplyPage/components/PartSection/index.tsx
+++ b/src/views/ApplyPage/components/PartSection/index.tsx
@@ -64,8 +64,8 @@ const PartSection = ({
 
         return (
           <div key={value}>
-            {charLimit == null && <Info value={value} />}
-            {charLimit != null && (
+            {!charLimit && <Info value={value} />}
+            {!!charLimit && (
               <Textarea
                 name={`part${id}`}
                 defaultValue={defaultValue}


### PR DESCRIPTION
**Related Issue :** Closes #290 

---

## 🧑‍🎤 Summary
- [x] 글자 수와 required dot 위치 수정

## 🧑‍🎤 Screenshot
![스크린샷 2024-07-30 오후 10 08 54](https://github.com/user-attachments/assets/515c2e15-1508-41e2-89fa-e0d46490ad70)

## 🧑‍🎤 Comment
질문을 \n를 이용하여 구분을 해줘요

예)
```
파일을 입력해주세요.
(단, 파일만 입력해주세요.)

파일은 500MB 이내로 업로드 해주셔야 해요.
```
=> ['`파일을 입력해주세요.`', '`(단, 파일만 입력해주세요.)`', '` `', '`파일은 500MB 이내로 업로드 해주셔야 해요.'`] 이렇게 길이 4의 배열이 나와요

이때 첫 '` `'이 나오기 전까지가 핵심 질문이라 이를 추출하는 render 함수(renderQuestions)를 아래와 같이 만들었어요

```tsx
const renderQuestions = (questions: string[], limit: number) =>
  questions.slice(0, limit).map((item, idx) => (
    <Fragment key={`${item}-${idx}`}>
      {item}
      {idx !== limit - 1 && '\n'}
    </Fragment>
  ));
```

그 이후의 나머지 부분을 추출하는 render 함수(renderRestQuestions)는 아래와 같아요

```tsx
const renderRestQuestions = (questions: string[]) =>
  questions.slice(firstEmptyIndex).map((item, idx) => {
    if (item === '') return <br key={`${keyId}-${idx}`} />;
    return <Fragment key={`${item}-${idx}`}>{item}</Fragment>;
  });
```

이때 renderQuestions의 limit은 첫 번째로 '` `'가 나타나는 index 입니다
왜냐면 이 앞에서 끊어줘야 해서요!!
이는 아래와 같은 방식으로 찾고 있어요

```tsx
const firstEmptyIndex = questionArray.indexOf('');
```

근데 추가 설명 없이 짧은 한 문장의 질문일 경우 indexOf 했을 때 -1이 뜨기 때문에 slice(firstEmptyIndex)를 사용할 수 없었어요
그래서 이에 대한 분기 처리도 해주었습니다 :)

```tsx
{firstEmptyIndex === -1 ? children : renderQuestions(questionArray, firstEmptyIndex)}

{firstEmptyIndex !== -1 && ( //... }
```