### PR TITLE
[Fix] 공통질문에서 0자 입력 시 textarea 뜨는 에러 해결

### DIFF
--- a/src/views/ApplyPage/components/CommonSection/index.tsx
+++ b/src/views/ApplyPage/components/CommonSection/index.tsx
@@ -32,8 +32,8 @@ const CommonSection = ({ isReview, refCallback, questions, commonQuestionsDraft 
 
         return (
           <div key={value}>
-            {charLimit == null && <Info value={value} />}
-            {charLimit != null && (
+            {!charLimit && <Info value={value} />}
+            {!!charLimit && (
               <Textarea
                 name={`common${id}`}
                 defaultValue={defaultValue}


### PR DESCRIPTION
**Related Issue :** Closes #299 

---

## 🧑‍🎤 Summary
- [x] 공통 질문에서 글자 수 제한 0으로 설정했을 때 textarea 뜨는 에러 해결

## 🧑‍🎤 Screenshot
![스크린샷 2024-07-31 오전 2 26 56](https://github.com/user-attachments/assets/e98adff5-f3a0-4429-bcc1-57c063b8f4b4)