### PR TITLE
[Fix] 사파리 - navigate(0) 작동 되지 않는 이슈 해결

### DIFF
--- a/src/common/components/Layout/components/Header/index.tsx
+++ b/src/common/components/Layout/components/Header/index.tsx
@@ -25,7 +25,7 @@ const Header = () => {
   const menuItems = isMakers ? MENU_ITEMS_MAKERS : MENU_ITEMS;
 
   const handleClickLogo = () => {
-    pathname === '/' ? navigate(0) : navigate('/');
+    pathname === '/' ? window.location.reload() : navigate('/');
   };
 
   const handleLogout = () => {
@@ -33,7 +33,7 @@ const Header = () => {
     reset();
     localStorage.removeItem('soptApplyAccessToken');
     localStorage.removeItem('soptApplyAccessTokenExpiredTime');
-    pathname === '/' ? navigate(0) : navigate('/');
+    pathname === '/' ? window.location.reload() : navigate('/');
   };
   return (
     <>

--- a/src/views/CompletePage/index.tsx
+++ b/src/views/CompletePage/index.tsx
@@ -1,6 +1,5 @@
 import { track } from '@amplitude/analytics-browser';
 import { useContext } from 'react';
-import { useNavigate } from 'react-router-dom';
 
 import Button from '@components/Button';
 import Callout from '@components/Callout';
@@ -10,7 +9,6 @@ import IconCheckmark from './icons/IconCheckmark';
 import { container, icon, mainText, subText } from './style.css';
 
 const CompletePage = () => {
-  const navigate = useNavigate();
   const {
     recruitingInfo: { name, season, group, soptName },
   } = useContext(RecruitingInfoContext);
@@ -18,7 +16,7 @@ const CompletePage = () => {
 
   const handleClickMyPage = () => {
     track('click-complete-my');
-    navigate(0);
+    window.location.reload();
   };
 
   return (

--- a/src/views/SignInPage/hooks/useMutateSignIn.tsx
+++ b/src/views/SignInPage/hooks/useMutateSignIn.tsx
@@ -1,6 +1,5 @@
 import { setUserId } from '@amplitude/analytics-browser';
 import { useMutation } from '@tanstack/react-query';
-import { useNavigate } from 'react-router-dom';
 
 import { VALIDATION_CHECK } from '@constants/validationCheck';
 
@@ -16,8 +15,6 @@ interface MutateSignInProps {
 }
 
 const useMutateSignIn = ({ finalPassConfirmEnd, onSetError }: MutateSignInProps) => {
-  const navigate = useNavigate();
-
   const { mutate: signInMutate, isPending: signInIsPending } = useMutation<
     AxiosResponse<SignInResponse, SignInRequest>,
     AxiosError<ErrorResponse, SignInRequest>,
@@ -28,7 +25,7 @@ const useMutateSignIn = ({ finalPassConfirmEnd, onSetError }: MutateSignInProps)
       setUserId(email);
       localStorage.setItem('soptApplyAccessToken', token);
       localStorage.setItem('soptApplyAccessTokenExpiredTime', finalPassConfirmEnd || '');
-      navigate(0);
+      window.location.reload();
     },
     onError(error) {
       if (error.response?.status === 403) {


### PR DESCRIPTION
**Related Issue :** 
- Closes #306 
- Closes #301  

---

## 🧑‍🎤 Summary
navigate(0) -> `window.location.reload` 로대체


## 🧑‍🎤 Comment
로그아웃 시 리로드가 안되는 이슈, 
지원서 제출 완료 페이지에서 마이페이지로 이동이 안되는 이슈 
-> 공통점을 찾아보니 모두 `navigate(0)`을 통해 리로드를 시켜주고 있더라구요 

그래서 찾아보니 
[[Bug]: Navigate(0) won't work on Safari](https://github.com/remix-run/react-router/issues/8600#top)
해결되지 않은 위와 같은 이슈가 있더라구요! 
따라서 원인임을 파악하고 `navigate(0)` 사용해주고 있는 모든 코드를 `location.reload()`로 수정해주었습니다 