### PR TITLE
[Fix] 지원 안했으면 결과 페이지 막기

### DIFF
--- a/src/views/ResultPage/index.tsx
+++ b/src/views/ResultPage/index.tsx
@@ -4,12 +4,15 @@ import useDate from '@hooks/useDate';
 import { ThemeContext } from '@store/themeContext';
 import NoMore from 'views/ErrorPage/components/NoMore';
 import BigLoading from 'views/loadings/BigLoding';
+import useGetMyInfo from 'views/SignedInPage/hooks/useGetMyInfo';
 
 import FinalResult from './components/FinalResult';
 import ScreeningResult from './components/ScreeningResult';
 
 const ResultPage = () => {
   const { handleChangeMode } = useContext(ThemeContext);
+  const { myInfoData, myInfoIsLoading } = useGetMyInfo();
+  const { submit, applicationPass } = myInfoData?.data || {};
 
   const { NoMoreRecruit, NoMoreScreeningResult, NoMoreFinalResult, isLoading, isMakers } = useDate();
 
@@ -21,14 +24,15 @@ const ResultPage = () => {
     };
   }, [handleChangeMode]);
 
-  if (isLoading) return <BigLoading />;
-  if (NoMoreRecruit || (NoMoreScreeningResult && NoMoreFinalResult))
+  if (isLoading || myInfoIsLoading) return <BigLoading />;
+  if (!submit || NoMoreRecruit || (NoMoreScreeningResult && NoMoreFinalResult))
     return <NoMore isMakers={isMakers} content="합불 확인 기간이 아니에요" />;
 
   return (
     <>
       {!NoMoreScreeningResult && <ScreeningResult />}
-      {!NoMoreFinalResult && <FinalResult />}
+      {!NoMoreFinalResult &&
+        (applicationPass ? <FinalResult /> : <NoMore isMakers={isMakers} content="합불 확인 기간이 아니에요" />)}
     </>
   );
 };


### PR DESCRIPTION
**Related Issue :** Closes #314 

---

## 🧑‍🎤 Summary
- [x] 지원서 제출 안 했으면 결과 페이지 아예 못들어가게 막기
- [x] 서류 불합격 하면 최종 결과 페이지 아예 못들어가게 막기 