### PR TITLE
[Fix] 파일 업로드 하는 동안 새로운 파일 업로드 못하도록 막기

### DIFF
--- a/src/views/ApplyPage/components/FileInput/index.tsx
+++ b/src/views/ApplyPage/components/FileInput/index.tsx
@@ -120,7 +120,7 @@ const FileInput = ({ section, id, isReview, disabled, defaultFile }: FileInputPr
         onChange={(e) => handleFileChange(e, id)}
         ref={inputRef}
         className={fileInput}
-        disabled={disabled || isReview}
+        disabled={disabled || isReview || (uploadPercent >= 0 && uploadPercent < 100)}
       />
       <label
         htmlFor={`file-${id}`}

--- a/src/views/ApplyPage/components/FileInput/index.tsx
+++ b/src/views/ApplyPage/components/FileInput/index.tsx
@@ -120,7 +120,12 @@ const FileInput = ({ section, id, isReview, disabled, defaultFile }: FileInputPr
         onChange={(e) => handleFileChange(e, id)}
         ref={inputRef}
         className={fileInput}
-        disabled={disabled || isReview || (uploadPercent >= 0 && uploadPercent < 100)}
+        disabled={
+          disabled ||
+          isReview ||
+          (uploadPercent >= 0 && uploadPercent < 100) ||
+          (uploadPercent === 100 && fileName === '')
+        }
       />
       <label
         htmlFor={`file-${id}`}


### PR DESCRIPTION
**Related Issue :** Closes #319 

---

## 🧑‍🎤 Summary
- [x] 파일 업로드 하는 동안 새로운 파일 업로드 막기

## 🧑‍🎤 Comment
파일을 업로드 하는 동안 새로운 파일을 입력 못하도록 disabled 처리 했습니다