### PR TITLE
[Fix] 포트폴리오 파일 형식 제한

### DIFF
--- a/src/views/ApplyPage/components/FileInput/index.tsx
+++ b/src/views/ApplyPage/components/FileInput/index.tsx
@@ -18,7 +18,7 @@ interface FileInputProps {
 }
 
 const LIMIT_SIZE = 1024 ** 2 * 50; // 50MB
-const ACCEPTED_FORMATS = '.pdf, .pptx';
+const ACCEPTED_FORMATS = '.pdf';
 
 const FileInput = ({ section, id, isReview, disabled, defaultFile }: FileInputProps) => {
   const [isError, setIsError] = useState(false);
@@ -135,7 +135,7 @@ const FileInput = ({ section, id, isReview, disabled, defaultFile }: FileInputPr
           {(uploadPercent !== -1 || !defaultFileName) && (
             <span className={fileNameVar[fileName === '' ? 'default' : 'selected']}>
               {uploadPercent < 0 && fileName === ''
-                ? '50mb 이하 | pdf, pptx'
+                ? '50mb 이하 | pdf'
                 : uploadPercent < 100
                   ? `업로드 중... ${uploadPercent}/100% 완료`
                   : uploadPercent === 100 && fileName === ''


### PR DESCRIPTION
**Related Issue :** Closes #333 

---

## 🧑‍🎤 Summary
pptx, pdf 에서 pdf 로 제출 형식 제한을 수정합니다. 

## 🧑‍🎤 Comment
디자인 측에서는 placeholder 라이팅을 바꿔달라고 요청하였지만, 
그 뜻은 결국 사용자가 pdf만 제출하길 바란다는 의미이므로 제출 accept 형식 자체를 pdf만 받도록 구정하였습니다 