### PR TITLE
[Feat] CompletePage 사용자 만족도 조사 추가 

### DIFF
--- a/src/views/CompletePage/apis.ts
+++ b/src/views/CompletePage/apis.ts
@@ -1,0 +1,7 @@
+import tokenInstance from '@apis/tokenInstance';
+
+export const postSatisfaction = (satisfaction: number) => {
+  return tokenInstance.post('/recruiting-applicant/satisfaction', {
+    satisfaction,
+  });
+};

--- a/src/views/CompletePage/components/Survey.tsx
+++ b/src/views/CompletePage/components/Survey.tsx
@@ -5,19 +5,22 @@ import { pointBoxVar, pointContainerVar, surveyBox, thanksTextVar } from '../sty
 
 const Survey = () => {
   const [point, setPoint] = useState<number | 'CHANGED'>(-1);
-  const { mutate } = useMutateSatisfaction();
 
-  const handleClickPoint = (i: number) => {
-    if (point === 'CHANGED') return;
-
-    mutate({ satisfaction: i });
-    setPoint(i);
+  const handleSatisfaction = () => {
     setTimeout(() => {
       setPoint('CHANGED');
     }, 200);
     setTimeout(() => {
       setPoint(-1);
-    }, 2500);
+    }, 2200);
+  };
+
+  const { mutate } = useMutateSatisfaction({ onSuccess: handleSatisfaction });
+
+  const handleClickPoint = (i: number) => {
+    if (point === 'CHANGED') return;
+    mutate({ satisfaction: i });
+    setPoint(i);
   };
 
   return (

--- a/src/views/CompletePage/components/Survey.tsx
+++ b/src/views/CompletePage/components/Survey.tsx
@@ -1,0 +1,47 @@
+import { useState } from 'react';
+
+import useMutateSatisfaction from '../hooks/useMutateSatisfaction';
+import { pointBoxVar, pointContainerVar, surveyBox, thanksTextVar } from '../style.css';
+
+const Survey = () => {
+  const [point, setPoint] = useState<number | 'CHANGED'>(-1);
+  const { mutate } = useMutateSatisfaction();
+
+  const handleClickPoint = (i: number) => {
+    if (point === 'CHANGED') return;
+
+    mutate({ satisfaction: i });
+    setPoint(i);
+    setTimeout(() => {
+      setPoint('CHANGED');
+    }, 200);
+    setTimeout(() => {
+      setPoint(-1);
+    }, 2500);
+  };
+
+  return (
+    <div className={surveyBox}>
+      <span
+        style={{
+          textAlign: 'center',
+          whiteSpace: 'pre-line',
+        }}>{`지원서 이용 만족도를 0-10점 중에 선택해주세요.\n의견을 주시면 프로덕트 개선에 도움이 됩니다.`}</span>
+      <div style={{ position: 'relative', width: 348, height: 36 }}>
+        <span className={thanksTextVar[point === 'CHANGED' ? 'in' : 'out']}>소중한 의견 감사합니다 :&#41;</span>
+        <ul className={pointContainerVar[point !== 'CHANGED' ? 'in' : 'out']}>
+          {Array.from({ length: 11 }, (_, i) => i).map((v) => (
+            <li
+              key={v}
+              className={pointBoxVar[point === 'CHANGED' ? 'changed' : v === point ? 'selected' : 'default']}
+              onClick={() => handleClickPoint(v)}>
+              <span style={{ paddingTop: 5 }}>{v}</span>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+};
+
+export default Survey;

--- a/src/views/CompletePage/hooks/useMutateSatisfaction.ts
+++ b/src/views/CompletePage/hooks/useMutateSatisfaction.ts
@@ -6,13 +6,14 @@ import { ErrorResponse } from '@type/errorResponse';
 import { postSatisfaction } from '../apis';
 import { PostSatisfactionRequest, PostSatisfactionResponse } from '../types';
 
-const useMutateSatisfaction = () => {
+const useMutateSatisfaction = ({ onSuccess }: { onSuccess?: () => void }) => {
   const { mutate } = useMutation<
     AxiosResponse<PostSatisfactionResponse, PostSatisfactionRequest>,
     AxiosError<ErrorResponse, PostSatisfactionRequest>,
     PostSatisfactionRequest
   >({
     mutationFn: ({ satisfaction }) => postSatisfaction(satisfaction),
+    onSuccess,
   });
 
   return { mutate };

--- a/src/views/CompletePage/hooks/useMutateSatisfaction.ts
+++ b/src/views/CompletePage/hooks/useMutateSatisfaction.ts
@@ -1,0 +1,21 @@
+import { useMutation } from '@tanstack/react-query';
+import { AxiosError, AxiosResponse } from 'axios';
+
+import { ErrorResponse } from '@type/errorResponse';
+
+import { postSatisfaction } from '../apis';
+import { postSatisfactionRequest, postSatisfactionResponse } from '../types';
+
+const useMutateSatisfaction = () => {
+  const { mutate } = useMutation<
+    AxiosResponse<postSatisfactionResponse, postSatisfactionRequest>,
+    AxiosError<ErrorResponse, postSatisfactionRequest>,
+    postSatisfactionRequest
+  >({
+    mutationFn: ({ satisfaction }) => postSatisfaction(satisfaction),
+  });
+
+  return { mutate };
+};
+
+export default useMutateSatisfaction;

--- a/src/views/CompletePage/hooks/useMutateSatisfaction.ts
+++ b/src/views/CompletePage/hooks/useMutateSatisfaction.ts
@@ -4,13 +4,13 @@ import { AxiosError, AxiosResponse } from 'axios';
 import { ErrorResponse } from '@type/errorResponse';
 
 import { postSatisfaction } from '../apis';
-import { postSatisfactionRequest, postSatisfactionResponse } from '../types';
+import { PostSatisfactionRequest, PostSatisfactionResponse } from '../types';
 
 const useMutateSatisfaction = () => {
   const { mutate } = useMutation<
-    AxiosResponse<postSatisfactionResponse, postSatisfactionRequest>,
-    AxiosError<ErrorResponse, postSatisfactionRequest>,
-    postSatisfactionRequest
+    AxiosResponse<PostSatisfactionResponse, PostSatisfactionRequest>,
+    AxiosError<ErrorResponse, PostSatisfactionRequest>,
+    PostSatisfactionRequest
   >({
     mutationFn: ({ satisfaction }) => postSatisfaction(satisfaction),
   });

--- a/src/views/CompletePage/index.tsx
+++ b/src/views/CompletePage/index.tsx
@@ -1,12 +1,21 @@
 import { track } from '@amplitude/analytics-browser';
-import { useContext, useEffect, useState } from 'react';
+import { useContext, useState } from 'react';
 
 import Button from '@components/Button';
 import Callout from '@components/Callout';
 import { RecruitingInfoContext } from '@store/recruitingInfoContext';
 
 import IconCheckmark from './icons/IconCheckmark';
-import { container, icon, mainText, pointBoxVar, pointContainer, subText, surveyBox, thanksText } from './style.css';
+import {
+  container,
+  icon,
+  mainText,
+  pointBoxVar,
+  pointContainerVar,
+  subText,
+  surveyBox,
+  thanksTextVar,
+} from './style.css';
 
 const CompletePage = () => {
   const {
@@ -24,7 +33,10 @@ const CompletePage = () => {
     setPoint(i);
     setTimeout(() => {
       setPoint('CHANGED');
-    }, 1000);
+    }, 500);
+    setTimeout(() => {
+      setPoint(-1);
+    }, 2500);
   };
 
   return (
@@ -45,10 +57,9 @@ const CompletePage = () => {
             textAlign: 'center',
             whiteSpace: 'pre-line',
           }}>{`지원서 이용 만족도를 0-10점 중에 선택해주세요.\n의견을 주시면 프로덕트 개선에 도움이 됩니다.`}</span>
-        {point === 'CHANGED' ? (
-          <span className={thanksText}>소중한 의견 감사합니다 :&#41;</span>
-        ) : (
-          <ul className={pointContainer}>
+        <div style={{ position: 'relative', width: 348, height: 36 }}>
+          <span className={thanksTextVar[point === 'CHANGED' ? 'default' : 'out']}>소중한 의견 감사합니다 :&#41;</span>
+          <ul className={pointContainerVar[point !== 'CHANGED' ? 'default' : 'out']}>
             {Array.from({ length: 11 }, (_, i) => i).map((v) => (
               <li
                 key={v}
@@ -58,7 +69,7 @@ const CompletePage = () => {
               </li>
             ))}
           </ul>
-        )}
+        </div>
       </div>
     </section>
   );

--- a/src/views/CompletePage/index.tsx
+++ b/src/views/CompletePage/index.tsx
@@ -1,22 +1,27 @@
 import { track } from '@amplitude/analytics-browser';
-import { useContext } from 'react';
+import { useContext, useState } from 'react';
 
 import Button from '@components/Button';
 import Callout from '@components/Callout';
 import { RecruitingInfoContext } from '@store/recruitingInfoContext';
 
 import IconCheckmark from './icons/IconCheckmark';
-import { container, icon, mainText, pointBox, pointContainer, subText, surveyBox } from './style.css';
+import { container, icon, mainText, pointBoxVar, pointContainer, subText, surveyBox } from './style.css';
 
 const CompletePage = () => {
   const {
     recruitingInfo: { name, season, group, soptName },
   } = useContext(RecruitingInfoContext);
   const isMakers = soptName?.toLowerCase().includes('makers');
+  const [point, setPoint] = useState(0);
 
   const handleClickMyPage = () => {
     track('click-complete-my');
     window.location.reload();
+  };
+
+  const handleClickPoint = (i: number) => {
+    setPoint(i);
   };
 
   return (
@@ -39,7 +44,10 @@ const CompletePage = () => {
           }}>{`지원서 이용 만족도를 0-10점 중에 선택해주세요.\n의견을 주시면 프로덕트 개선에 도움이 됩니다.`}</span>
         <ul className={pointContainer}>
           {Array.from({ length: 10 }, (_, i) => i + 1).map((v) => (
-            <li key={v} className={pointBox}>
+            <li
+              key={v}
+              className={pointBoxVar[v === point ? 'selected' : 'default']}
+              onClick={() => handleClickPoint(v)}>
               {v}
             </li>
           ))}

--- a/src/views/CompletePage/index.tsx
+++ b/src/views/CompletePage/index.tsx
@@ -5,6 +5,7 @@ import Button from '@components/Button';
 import Callout from '@components/Callout';
 import { RecruitingInfoContext } from '@store/recruitingInfoContext';
 
+import useMutateSatisfaction from './hooks/useMutateSatisfaction';
 import IconCheckmark from './icons/IconCheckmark';
 import {
   container,
@@ -29,7 +30,9 @@ const CompletePage = () => {
     window.location.reload();
   };
 
+  const { mutate } = useMutateSatisfaction();
   const handleClickPoint = (i: number) => {
+    mutate({ satisfaction: i });
     setPoint(i);
     setTimeout(() => {
       setPoint('CHANGED');

--- a/src/views/CompletePage/index.tsx
+++ b/src/views/CompletePage/index.tsx
@@ -1,19 +1,19 @@
 import { track } from '@amplitude/analytics-browser';
-import { useContext, useState } from 'react';
+import { useContext, useEffect, useState } from 'react';
 
 import Button from '@components/Button';
 import Callout from '@components/Callout';
 import { RecruitingInfoContext } from '@store/recruitingInfoContext';
 
 import IconCheckmark from './icons/IconCheckmark';
-import { container, icon, mainText, pointBoxVar, pointContainer, subText, surveyBox } from './style.css';
+import { container, icon, mainText, pointBoxVar, pointContainer, subText, surveyBox, thanksText } from './style.css';
 
 const CompletePage = () => {
   const {
     recruitingInfo: { name, season, group, soptName },
   } = useContext(RecruitingInfoContext);
   const isMakers = soptName?.toLowerCase().includes('makers');
-  const [point, setPoint] = useState(0);
+  const [point, setPoint] = useState<number | 'CHANGED'>(-1);
 
   const handleClickMyPage = () => {
     track('click-complete-my');
@@ -22,6 +22,9 @@ const CompletePage = () => {
 
   const handleClickPoint = (i: number) => {
     setPoint(i);
+    setTimeout(() => {
+      setPoint('CHANGED');
+    }, 1000);
   };
 
   return (
@@ -42,16 +45,20 @@ const CompletePage = () => {
             textAlign: 'center',
             whiteSpace: 'pre-line',
           }}>{`지원서 이용 만족도를 0-10점 중에 선택해주세요.\n의견을 주시면 프로덕트 개선에 도움이 됩니다.`}</span>
-        <ul className={pointContainer}>
-          {Array.from({ length: 10 }, (_, i) => i + 1).map((v) => (
-            <li
-              key={v}
-              className={pointBoxVar[v === point ? 'selected' : 'default']}
-              onClick={() => handleClickPoint(v)}>
-              <span>{v}</span>
-            </li>
-          ))}
-        </ul>
+        {point === 'CHANGED' ? (
+          <span className={thanksText}>소중한 의견 감사합니다 :&#41;</span>
+        ) : (
+          <ul className={pointContainer}>
+            {Array.from({ length: 11 }, (_, i) => i).map((v) => (
+              <li
+                key={v}
+                className={pointBoxVar[v === point ? 'selected' : 'default']}
+                onClick={() => handleClickPoint(v)}>
+                <span style={{ paddingTop: 5 }}>{v}</span>
+              </li>
+            ))}
+          </ul>
+        )}
       </div>
     </section>
   );

--- a/src/views/CompletePage/index.tsx
+++ b/src/views/CompletePage/index.tsx
@@ -48,7 +48,7 @@ const CompletePage = () => {
               key={v}
               className={pointBoxVar[v === point ? 'selected' : 'default']}
               onClick={() => handleClickPoint(v)}>
-              {v}
+              <span>{v}</span>
             </li>
           ))}
         </ul>

--- a/src/views/CompletePage/index.tsx
+++ b/src/views/CompletePage/index.tsx
@@ -6,7 +6,7 @@ import Callout from '@components/Callout';
 import { RecruitingInfoContext } from '@store/recruitingInfoContext';
 
 import IconCheckmark from './icons/IconCheckmark';
-import { container, icon, mainText, subText } from './style.css';
+import { container, icon, mainText, pointBox, pointContainer, subText, surveyBox } from './style.css';
 
 const CompletePage = () => {
   const {
@@ -31,6 +31,20 @@ const CompletePage = () => {
           marginBottom: 50,
         }}>{`이메일 도착 시점에 차이가 있을 수 있습니다.\n이메일이 오지 않으면 스팸 메일함을 확인해주세요.`}</Callout>
       <Button onClick={handleClickMyPage}>마이페이지로 이동하기</Button>
+      <div className={surveyBox}>
+        <span
+          style={{
+            textAlign: 'center',
+            whiteSpace: 'pre-line',
+          }}>{`지원서 이용 만족도를 0-10점 중에 선택해주세요.\n의견을 주시면 프로덕트 개선에 도움이 됩니다.`}</span>
+        <ul className={pointContainer}>
+          {Array.from({ length: 10 }, (_, i) => i + 1).map((v) => (
+            <li key={v} className={pointBox}>
+              {v}
+            </li>
+          ))}
+        </ul>
+      </div>
     </section>
   );
 };

--- a/src/views/CompletePage/index.tsx
+++ b/src/views/CompletePage/index.tsx
@@ -1,45 +1,23 @@
 import { track } from '@amplitude/analytics-browser';
-import { useContext, useState } from 'react';
+import { useContext } from 'react';
 
 import Button from '@components/Button';
 import Callout from '@components/Callout';
 import { RecruitingInfoContext } from '@store/recruitingInfoContext';
 
-import useMutateSatisfaction from './hooks/useMutateSatisfaction';
+import Survey from './components/Survey';
 import IconCheckmark from './icons/IconCheckmark';
-import {
-  container,
-  icon,
-  mainText,
-  pointBoxVar,
-  pointContainerVar,
-  subText,
-  surveyBox,
-  thanksTextVar,
-} from './style.css';
+import { container, icon, mainText, subText } from './style.css';
 
 const CompletePage = () => {
   const {
     recruitingInfo: { name, season, group, soptName },
   } = useContext(RecruitingInfoContext);
   const isMakers = soptName?.toLowerCase().includes('makers');
-  const [point, setPoint] = useState<number | 'CHANGED'>(-1);
 
   const handleClickMyPage = () => {
     track('click-complete-my');
     window.location.reload();
-  };
-
-  const { mutate } = useMutateSatisfaction();
-  const handleClickPoint = (i: number) => {
-    mutate({ satisfaction: i });
-    setPoint(i);
-    setTimeout(() => {
-      setPoint('CHANGED');
-    }, 500);
-    setTimeout(() => {
-      setPoint(-1);
-    }, 2500);
   };
 
   return (
@@ -51,29 +29,10 @@ const CompletePage = () => {
       <p className={subText}>이메일로 지원 접수 완료 알림이 발송되었습니다.</p>
       <Callout
         style={{
-          marginBottom: 50,
+          marginBottom: 35,
         }}>{`이메일 도착 시점에 차이가 있을 수 있습니다.\n이메일이 오지 않으면 스팸 메일함을 확인해주세요.`}</Callout>
       <Button onClick={handleClickMyPage}>마이페이지로 이동하기</Button>
-      <div className={surveyBox}>
-        <span
-          style={{
-            textAlign: 'center',
-            whiteSpace: 'pre-line',
-          }}>{`지원서 이용 만족도를 0-10점 중에 선택해주세요.\n의견을 주시면 프로덕트 개선에 도움이 됩니다.`}</span>
-        <div style={{ position: 'relative', width: 348, height: 36 }}>
-          <span className={thanksTextVar[point === 'CHANGED' ? 'default' : 'out']}>소중한 의견 감사합니다 :&#41;</span>
-          <ul className={pointContainerVar[point !== 'CHANGED' ? 'default' : 'out']}>
-            {Array.from({ length: 11 }, (_, i) => i).map((v) => (
-              <li
-                key={v}
-                className={pointBoxVar[v === point ? 'selected' : 'default']}
-                onClick={() => handleClickPoint(v)}>
-                <span style={{ paddingTop: 5 }}>{v}</span>
-              </li>
-            ))}
-          </ul>
-        </div>
-      </div>
+      <Survey />
     </section>
   );
 };

--- a/src/views/CompletePage/style.css.ts
+++ b/src/views/CompletePage/style.css.ts
@@ -8,7 +8,7 @@ export const container = style({
   flexDirection: 'column',
   alignItems: 'center',
   justifyContent: 'center',
-  width: 466,
+  width: 550,
   height: calc.subtract('100vh', '74px'),
   minHeight: 700,
 
@@ -53,7 +53,7 @@ export const surveyBox = style({
   gap: 12,
   width: 466,
   padding: '22px 0px',
-  marginTop: 50,
+  marginTop: 35,
   color: theme.color.lightestText,
   ...theme.font.BODY_2_16_M,
   border: `1px solid ${theme.color.border}`,
@@ -72,7 +72,7 @@ export const pointContainer = style({
 });
 
 export const pointContainerVar = styleVariants({
-  default: [
+  in: [
     pointContainer,
     {
       opacity: 1,
@@ -112,6 +112,12 @@ export const pointBoxVar = styleVariants({
       color: theme.color.white,
     },
   ],
+  changed: [
+    pointBox,
+    {
+      cursor: 'default',
+    },
+  ],
 });
 
 export const thanksText = style({
@@ -130,7 +136,7 @@ export const thanksText = style({
 });
 
 export const thanksTextVar = styleVariants({
-  default: [
+  in: [
     thanksText,
     {
       opacity: 1,

--- a/src/views/CompletePage/style.css.ts
+++ b/src/views/CompletePage/style.css.ts
@@ -1,4 +1,4 @@
-import { style } from '@vanilla-extract/css';
+import { style, styleVariants } from '@vanilla-extract/css';
 import { calc } from '@vanilla-extract/css-utils';
 
 import { theme } from 'styles/theme.css';
@@ -64,9 +64,30 @@ export const pointContainer = style({
   gap: 4,
 });
 
-export const pointBox = style({
-  padding: '7px 12.5px',
+const pointBox = style({
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+  width: 32,
+  height: 40,
   borderRadius: 8,
-  backgroundColor: theme.color.subBackground,
-  color: theme.color.baseText,
+  transition: 'all 0.3s ease',
+  cursor: 'pointer',
+});
+
+export const pointBoxVar = styleVariants({
+  default: [
+    pointBox,
+    {
+      backgroundColor: theme.color.subBackground,
+      color: theme.color.baseText,
+    },
+  ],
+  selected: [
+    pointBox,
+    {
+      backgroundColor: theme.color.primary,
+      color: theme.color.white,
+    },
+  ],
 });

--- a/src/views/CompletePage/style.css.ts
+++ b/src/views/CompletePage/style.css.ts
@@ -23,7 +23,7 @@ export const icon = style({
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',
-  marginBottom: '32px',
+  marginBottom: 20,
   width: 66,
   height: 66,
   borderRadius: '50%',
@@ -31,7 +31,7 @@ export const icon = style({
 });
 
 export const mainText = style({
-  marginBottom: 24,
+  marginBottom: 8,
   color: theme.color.baseText,
   textAlign: 'center',
   whiteSpace: 'pre-line',
@@ -39,7 +39,7 @@ export const mainText = style({
 });
 
 export const subText = style({
-  marginBottom: 50,
+  marginBottom: 30,
   color: theme.color.baseText,
   textAlign: 'center',
   ...theme.font.BODY_1_18_M,
@@ -50,9 +50,9 @@ export const surveyBox = style({
   flexDirection: 'column',
   justifyContent: 'center',
   alignItems: 'center',
-  gap: 16,
-  padding: '30px 55px',
-  marginTop: 90,
+  gap: 12,
+  padding: '22px 75px',
+  marginTop: 50,
   color: theme.color.lightestText,
   ...theme.font.BODY_2_16_M,
   border: `1px solid ${theme.color.border}`,
@@ -68,9 +68,9 @@ const pointBox = style({
   display: 'flex',
   justifyContent: 'center',
   alignItems: 'center',
-  width: 32,
-  height: 40,
-  borderRadius: 8,
+  width: 28,
+  height: 36,
+  borderRadius: 6,
   transition: 'all 0.3s ease',
   cursor: 'pointer',
 });

--- a/src/views/CompletePage/style.css.ts
+++ b/src/views/CompletePage/style.css.ts
@@ -57,6 +57,7 @@ export const surveyBox = style({
   ...theme.font.BODY_2_16_M,
   border: `1px solid ${theme.color.border}`,
   borderRadius: 15,
+  transition: 'all 0.3s ease',
 });
 
 export const pointContainer = style({
@@ -90,4 +91,13 @@ export const pointBoxVar = styleVariants({
       color: theme.color.white,
     },
   ],
+});
+
+export const thanksText = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  height: 36,
+  ...theme.font.TITLE_6_16_SB,
+  color: theme.color.lighterText,
 });

--- a/src/views/CompletePage/style.css.ts
+++ b/src/views/CompletePage/style.css.ts
@@ -44,3 +44,29 @@ export const subText = style({
   textAlign: 'center',
   ...theme.font.BODY_1_18_M,
 });
+
+export const surveyBox = style({
+  display: 'flex',
+  flexDirection: 'column',
+  justifyContent: 'center',
+  alignItems: 'center',
+  gap: 16,
+  padding: '30px 55px',
+  marginTop: 90,
+  color: theme.color.lightestText,
+  ...theme.font.BODY_2_16_M,
+  border: `1px solid ${theme.color.border}`,
+  borderRadius: 15,
+});
+
+export const pointContainer = style({
+  display: 'flex',
+  gap: 4,
+});
+
+export const pointBox = style({
+  padding: '7px 12.5px',
+  borderRadius: 8,
+  backgroundColor: theme.color.subBackground,
+  color: theme.color.baseText,
+});

--- a/src/views/CompletePage/style.css.ts
+++ b/src/views/CompletePage/style.css.ts
@@ -51,18 +51,39 @@ export const surveyBox = style({
   justifyContent: 'center',
   alignItems: 'center',
   gap: 12,
-  padding: '22px 75px',
+  width: 466,
+  padding: '22px 0px',
   marginTop: 50,
   color: theme.color.lightestText,
   ...theme.font.BODY_2_16_M,
   border: `1px solid ${theme.color.border}`,
   borderRadius: 15,
-  transition: 'all 0.3s ease',
 });
 
 export const pointContainer = style({
+  position: 'absolute',
+  top: 0,
+  left: 0,
+  width: '100%',
+  height: '100%',
   display: 'flex',
   gap: 4,
+  transition: 'all 0.3s ease',
+});
+
+export const pointContainerVar = styleVariants({
+  default: [
+    pointContainer,
+    {
+      opacity: 1,
+    },
+  ],
+  out: [
+    pointContainer,
+    {
+      opacity: 0,
+    },
+  ],
 });
 
 const pointBox = style({
@@ -94,10 +115,31 @@ export const pointBoxVar = styleVariants({
 });
 
 export const thanksText = style({
+  position: 'absolute',
+  top: 0,
+  left: 0,
+  width: '100%',
+  height: '100%',
+  paddingTop: 5,
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',
-  height: 36,
   ...theme.font.TITLE_6_16_SB,
   color: theme.color.lighterText,
+  transition: 'all 0.3s ease',
+});
+
+export const thanksTextVar = styleVariants({
+  default: [
+    thanksText,
+    {
+      opacity: 1,
+    },
+  ],
+  out: [
+    thanksText,
+    {
+      opacity: 0,
+    },
+  ],
 });

--- a/src/views/CompletePage/types.ts
+++ b/src/views/CompletePage/types.ts
@@ -1,0 +1,8 @@
+export interface postSatisfactionRequest {
+  satisfaction: number;
+}
+
+export interface postSatisfactionResponse {
+  err: boolean;
+  userMessage: string;
+}

--- a/src/views/CompletePage/types.ts
+++ b/src/views/CompletePage/types.ts
@@ -1,8 +1,8 @@
-export interface postSatisfactionRequest {
+export interface PostSatisfactionRequest {
   satisfaction: number;
 }
 
-export interface postSatisfactionResponse {
+export interface PostSatisfactionResponse {
   err: boolean;
   userMessage: string;
 }

--- a/src/views/SignedInPage/index.tsx
+++ b/src/views/SignedInPage/index.tsx
@@ -31,9 +31,9 @@ const SignedInPage = () => {
 
   return (
     <>
-      {isComplete && <CompletePage />}
-      {!isComplete && submit && <MyPage part={part} applicationPass={applicationPass} />}
-      {!isComplete && !submit && <ApplyPage onSetComplete={handleSetComplete} />}
+      {!isComplete && <CompletePage />}
+      {/* {!isComplete && submit && <MyPage part={part} applicationPass={applicationPass} />}
+      {!isComplete && !submit && <ApplyPage onSetComplete={handleSetComplete} />} */}
     </>
   );
 };

--- a/src/views/SignedInPage/index.tsx
+++ b/src/views/SignedInPage/index.tsx
@@ -31,9 +31,9 @@ const SignedInPage = () => {
 
   return (
     <>
-      {!isComplete && <CompletePage />}
-      {/* {!isComplete && submit && <MyPage part={part} applicationPass={applicationPass} />}
-      {!isComplete && !submit && <ApplyPage onSetComplete={handleSetComplete} />} */}
+      {isComplete && <CompletePage />}
+      {!isComplete && submit && <MyPage part={part} applicationPass={applicationPass} />}
+      {!isComplete && !submit && <ApplyPage onSetComplete={handleSetComplete} />}
     </>
   );
 };


### PR DESCRIPTION
**Related Issue :** Closes #341 

---

## 🧑‍🎤 Summary
Complete Page에 사용자 만족도 조사를 추가합니다 

## 🧑‍🎤 Screenshot

https://github.com/user-attachments/assets/326fa28b-bb1b-42c7-9452-d864caa80924



## 🧑‍🎤 Comment
- 만족도 조사 추가되면서 레이아웃 전반적으로 좁아져서 수정사항 반영했어요

**🚀 조건부 렌더링되는 컴포넌트에 애니메이션 넣기** 

일반적으로 조건부 렌더링은 JSX에서 조건부로 다른 컴포넌트 리턴시켜주는 식으로 구현되는데요, 
이번에 `점수선택부분` 과 `소중한의견감사드려요` 텍스트는 transition 효과가 들어가야 했어요. 
근데 일반적인 방법대로 조건부렌더링 해주면 fade-out 애니메이션이 보여지기도 전에 컴포넌트가 언마운트 돼서 애니메이션 효과가 적용이 안됩니다. (아마 언석님도 겪어보셨을 이슈일거예요) 
따라서 
- 두 컴포넌트를 감싸는 div를 하나더 만들어서 `position: relative`를 주고 
- 각 컴포넌트에 `position: absolute` 를 줘서 위치를 겹쳐준 다음 
- styleVariant를 통해 **opacity 값을 조건부 스타일링** 해주었습니다. 

이런 케이스에, 언석님이 사용하시는 다른 해결책이 있다면 그것도 궁금해요!! 검색해봐도 다 별로 내키지 않더라구요.. 

> 참고로 큰 역할 안하는 태그에는 그냥 인라인 스타일링 해주었는데, 혹시 인라인 스타일 모두 스타일파일에 분리시켜주길 원하시면 말씀해주세요!! 반영하겠습니다 

**🚀 텍스트 세로 정렬 대체 어떻게 해결하시나요** 
텍스트 세로 중앙 정렬.... 
이것도 항상 겪었던 이슈인데 명쾌한 해답이 없는걸까요 
늘  그래왔던 것처럼 이번에도 텍스트를 감싸는 span 태그에 어림잡아 `paddingTop: 5px` 만 줬는데, 
이것도 언석님만의 해결책이 있는지 궁금합니다 
검색하면 항상 line-height 같은거 추천해주는데 하나도 도움 안되더라고요 ㅜ


참고로 API 연결은 내일 찬기오빠가 작업해주면 이후에 붙여야 하는데, 
어차피 API 코드는 복잡하지 않고 똑같을 것 같아서 일단 퍼블리싱 먼저 코리 받고, 
API 코드 추가로 작업하면 확인차 태그 한번 드릴게요 ! 