### PR TITLE
[Feat] 헤더 스크롤 시 숨김 처리

### DIFF
--- a/src/common/hooks/useScrollPosition.tsx
+++ b/src/common/hooks/useScrollPosition.tsx
@@ -1,0 +1,31 @@
+import { useEffect, useRef, useState } from 'react';
+
+const useScrollPosition = () => {
+  const lastScrollPositionRef = useRef(0);
+  const [isScrollingDown, setIsScrollingDown] = useState(true);
+  const [isScrollTop, setIsScrollTop] = useState(true);
+
+  useEffect(() => {
+    const scrollHandler = () => {
+      const currentScrollPosition = window.scrollY;
+
+      setIsScrollTop(currentScrollPosition < 20);
+      setIsScrollingDown(lastScrollPositionRef.current < currentScrollPosition);
+
+      lastScrollPositionRef.current = currentScrollPosition;
+    };
+
+    window.addEventListener('scroll', scrollHandler);
+
+    return () => {
+      window.removeEventListener('scroll', scrollHandler);
+    };
+  }, []);
+
+  return {
+    isScrollingDown,
+    isScrollTop,
+  };
+};
+
+export default useScrollPosition;

--- a/src/common/hooks/useScrollPosition.tsx
+++ b/src/common/hooks/useScrollPosition.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 
-const useScrollPosition = () => {
+const useScrollPosition = (topYScrollPosition: number = 20) => {
   const lastScrollPositionRef = useRef(0);
   const [isScrollingDown, setIsScrollingDown] = useState(true);
   const [isScrollTop, setIsScrollTop] = useState(true);
@@ -9,7 +9,7 @@ const useScrollPosition = () => {
     const scrollHandler = () => {
       const currentScrollPosition = window.scrollY;
 
-      setIsScrollTop(currentScrollPosition < 20);
+      setIsScrollTop(currentScrollPosition < topYScrollPosition);
       setIsScrollingDown(lastScrollPositionRef.current < currentScrollPosition);
 
       lastScrollPositionRef.current = currentScrollPosition;
@@ -20,7 +20,7 @@ const useScrollPosition = () => {
     return () => {
       window.removeEventListener('scroll', scrollHandler);
     };
-  }, []);
+  }, [topYScrollPosition]);
 
   return {
     isScrollingDown,

--- a/src/views/ApplyPage/components/ApplyCategory/index.tsx
+++ b/src/views/ApplyPage/components/ApplyCategory/index.tsx
@@ -10,7 +10,7 @@ interface ApplyCategoryProps {
   minIndex: number;
 }
 const ApplyCategory = memo(({ minIndex }: ApplyCategoryProps) => {
-  const { isScrollingDown, isScrollTop } = useScrollPosition();
+  const { isScrollingDown, isScrollTop } = useScrollPosition(950);
 
   return (
     <nav className={container[minIndex !== -1 && isScrollingDown && !isScrollTop ? 'down' : 'up']}>

--- a/src/views/ApplyPage/components/ApplyCategory/index.tsx
+++ b/src/views/ApplyPage/components/ApplyCategory/index.tsx
@@ -13,7 +13,7 @@ const ApplyCategory = memo(({ minIndex }: ApplyCategoryProps) => {
   const { isScrollingDown, isScrollTop } = useScrollPosition(950);
 
   return (
-    <nav className={container[minIndex !== -1 && isScrollingDown && !isScrollTop ? 'down' : 'up']}>
+    <nav className={container[minIndex !== -1 && isScrollingDown && !isScrollTop ? 'scrollDown' : 'scrollUp']}>
       <ul className={categoryList}>
         {CATEGORY.map(({ index, text, path }) => (
           <li key={path}>

--- a/src/views/ApplyPage/components/ApplyCategory/index.tsx
+++ b/src/views/ApplyPage/components/ApplyCategory/index.tsx
@@ -1,6 +1,8 @@
 import { memo } from 'react';
 import { Link } from 'react-router-dom';
 
+import useScrollPosition from '@hooks/useScrollPosition';
+
 import { CATEGORY } from './constant';
 import { activeLinkStyle, categoryLinkStyle, categoryList, container } from './style.css';
 
@@ -8,8 +10,10 @@ interface ApplyCategoryProps {
   minIndex: number;
 }
 const ApplyCategory = memo(({ minIndex }: ApplyCategoryProps) => {
+  const { isScrollingDown, isScrollTop } = useScrollPosition();
+
   return (
-    <nav className={container}>
+    <nav className={container[minIndex !== -1 && isScrollingDown && !isScrollTop ? 'down' : 'up']}>
       <ul className={categoryList}>
         {CATEGORY.map(({ index, text, path }) => (
           <li key={path}>

--- a/src/views/ApplyPage/components/ApplyCategory/style.css.ts
+++ b/src/views/ApplyPage/components/ApplyCategory/style.css.ts
@@ -1,9 +1,9 @@
-import { style } from '@vanilla-extract/css';
+import { style, styleVariants } from '@vanilla-extract/css';
 
 import { Z_INDEX } from '@constants/zIndex';
 import { theme } from 'styles/theme.css';
 
-export const container = style({
+export const containerBase = style({
   display: 'flex',
   justifyContent: 'center',
   width: 1440,
@@ -14,6 +14,23 @@ export const container = style({
 
   backgroundColor: theme.color.white,
   zIndex: Z_INDEX.applyCategory,
+  transition: 'all 0.5s ease',
+});
+
+export const container = styleVariants({
+  up: [
+    containerBase,
+    {
+      opacity: 1,
+    },
+  ],
+  down: [
+    containerBase,
+    {
+      opacity: 0,
+      transform: 'translateY(-41px)',
+    },
+  ],
 });
 
 export const categoryList = style({

--- a/src/views/ApplyPage/components/ApplyCategory/style.css.ts
+++ b/src/views/ApplyPage/components/ApplyCategory/style.css.ts
@@ -18,13 +18,13 @@ export const containerBase = style({
 });
 
 export const container = styleVariants({
-  up: [
+  scrollUp: [
     containerBase,
     {
       opacity: 1,
     },
   ],
-  down: [
+  scrollDown: [
     containerBase,
     {
       opacity: 0,

--- a/src/views/ApplyPage/components/CommonSection/style.css.ts
+++ b/src/views/ApplyPage/components/CommonSection/style.css.ts
@@ -6,7 +6,7 @@ export const sectionContainer = style({
   display: 'flex',
   flexDirection: 'column',
   gap: 50,
-  paddingTop: 90,
+  paddingTop: 40,
 });
 
 export const title = style({

--- a/src/views/ApplyPage/components/PartSection/style.css.ts
+++ b/src/views/ApplyPage/components/PartSection/style.css.ts
@@ -6,7 +6,7 @@ export const sectionContainer = style({
   display: 'flex',
   flexDirection: 'column',
   gap: 50,
-  paddingTop: 90,
+  paddingTop: 40,
 });
 
 export const title = style({

--- a/src/views/ApplyPage/style.css.ts
+++ b/src/views/ApplyPage/style.css.ts
@@ -11,7 +11,7 @@ export const container = style({
 export const formContainer = style({
   display: 'flex',
   flexDirection: 'column',
-  gap: 50,
+  gap: 100,
 
   marginBottom: 362,
   width: 720,


### PR DESCRIPTION
**Related Issue :** Closes #345 

---

## 🧑‍🎤 Summary
- [x] apply page category 부분 아래로 스크롤 시 사라지게 만들기


## 🧑‍🎤 Screenshot
https://github.com/user-attachments/assets/209eb4cc-9944-4e26-973a-9f2e6e8d159e


## 🧑‍🎤 Comment
### scroll 여부 파악하는 custom hook(useScrollPosition) 제작
공홈 거 가져왔어요!

다만 조금 더 확장을 했는데요

기존에는 상단 페이지인 경우 스크롤의 상관 없이 항상 보여지도록 구현을 했어요
이때 상단 페이지인지 구분하기 위해 window.scrollY이 20보다 작은지를 기준으로 삼고 있었어요
하지만 저희는 category가 header랑 딱 붙기 전까진 계속 보여져야 했으므로 window.scrollY이 950보다 작아야 했어요
그래서 이를 동적으로 설정할 수 있도록 해줬어요
기본값은 20입니다
```tsx
const useScrollPosition = (topYScrollPosition: number = 20) => {
  // ...

  useEffect(() => {
    const scrollHandler = () => {
      const currentScrollPosition = window.scrollY;

      setIsScrollTop(currentScrollPosition < topYScrollPosition);
    // ...
```

### gap 수정
gap을 100으로 늘려줬어요
왜냐면 category 클릭 시 아래 사진과 같이 윗 부분 section도 살짝 보이게 되더라고요
<img width="780" alt="스크린샷 2024-08-06 오후 10 42 57" src="https://github.com/user-attachments/assets/cfd7243d-7b7c-42f9-8453-06146a686c95">
대신 section의 padding top을 줄여주어 디자인적으로는 변함이 없도록 했어요