### PR TITLE
[Feat] amplitude 허수 판독기

### DIFF
--- a/src/views/SignedInPage/index.tsx
+++ b/src/views/SignedInPage/index.tsx
@@ -1,3 +1,4 @@
+import { track } from '@amplitude/analytics-browser';
 import { useContext, useEffect, useState } from 'react';
 
 import { RecruitingInfoContext } from '@store/recruitingInfoContext';
@@ -17,6 +18,7 @@ const SignedInPage = () => {
   const { handleSaveRecruitingInfo } = useContext(RecruitingInfoContext);
 
   const handleSetComplete = () => {
+    track('done-apply-confirm_submit');
     setIsComplete(true);
   };
 

--- a/src/views/SignupPage/hooks/useMutateSignUp.tsx
+++ b/src/views/SignupPage/hooks/useMutateSignUp.tsx
@@ -1,3 +1,4 @@
+import { track } from '@amplitude/analytics-browser';
 import { useMutation } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
 
@@ -21,6 +22,7 @@ const useMutateSignUp = ({ onCheckExistence }: MutateSignUpProps) => {
   >({
     mutationFn: (userInfo: SignUpRequest) => sendSignUp(userInfo),
     onSuccess: () => {
+      track('done-signup-apply');
       navigate('/');
     },
     onError: (error) => {


### PR DESCRIPTION
**Related Issue :** Closes #344 

---

## 🧑‍🎤 Summary
- [x] 회원가입 완료 시, 지원서 제출 완료 시 amplitude event tracking 되도록 구현

## 🧑‍🎤 Comment
tanstack query의 onSuccess 이용해줬어요

sign-up 버튼 클릭 -> click-signup-apply
sign-up 완료 -> done-signup-apply

지원서 최종 제출 버튼 클릭 -> click-apply-confirm_submit
지원서 최종 제출 완료 -> done-apply-confirm_submit