### PR TITLE
[Fix] 지원 완료 이메일 템플릿 깨짐 해결 

### DIFF
--- a/src/views/email/complete.html
+++ b/src/views/email/complete.html
@@ -173,9 +173,12 @@
       </tr>
       <tr>
         <td>
-          <table align="center" border="0" cellpadding="0" cellspacing="0" width="600px" class="content">
+          <table
+            class="content"
+            style="border: 0; border-spacing: 0; width: 600px; margin-inline-start: auto; margin-inline-end: auto"
+            cellpadding="0">
             <tr>
-              <td style="font-size: 0; line-height: 0" width="22" class="horizontal-blank">&nbsp;</td>
+              <td style="font-size: 0; line-height: 0; width: 22px" class="horizontal-blank">&nbsp;</td>
               <td
                 style="
                   color: #66666d;
@@ -190,7 +193,7 @@
               </td>
             </tr>
             <tr>
-              <td style="font-size: 0; line-height: 0" width="22" class="horizontal-blank">&nbsp;</td>
+              <td style="font-size: 0; line-height: 0; width: 22px" class="horizontal-blank">&nbsp;</td>
               <td
                 style="
                   color: #66666d;
@@ -209,8 +212,9 @@
         </td>
       </tr>
       <tr>
-        <td style="font-size: 0; line-height: 0" height="30">&nbsp;</td>
+        <td style="font-size: 0; line-height: 0; height: 30px">&nbsp;</td>
       </tr>
+      a
     </table>
   </body>
 </html>

--- a/src/views/email/complete.html
+++ b/src/views/email/complete.html
@@ -214,7 +214,6 @@
       <tr>
         <td style="font-size: 0; line-height: 0; height: 30px">&nbsp;</td>
       </tr>
-      a
     </table>
   </body>
 </html>


### PR DESCRIPTION
**Related Issue :** Closes #330 

---

## 🧑‍🎤 Summary
본 메일 ~ 그부분 중앙정렬이 되지 않아서 해결해주었습니다! 

## 🧑‍🎤 Screenshot
(as-is)
![image](https://github.com/user-attachments/assets/745d30ef-a941-44a7-9bdd-fa9b0992bf4d)


## 🧑‍🎤 Comment
로고 이미지 관련은 네트워크 이슈인 것으로 추측돼서 
우선 하단 메시지 중앙 정렬만 개선해두었습니다! 
인증 메일 PR에서 설명드렸던 레거시 attributes가 안먹는 이슈였어서 
얘네들도 마저 inline style로 바꿔주었습니다~~