### PR TITLE
[Fix] 이메일 인증 버튼 크기 깨지는 에러 해결

### DIFF
--- a/src/common/components/Input/components/InputButton/style.css.ts
+++ b/src/common/components/Input/components/InputButton/style.css.ts
@@ -2,4 +2,6 @@ import { style } from '@vanilla-extract/css';
 
 export const textWidth = style({
   width: 148,
+  paddingLeft: 0,
+  paddingRight: 0,
 });


### PR DESCRIPTION
**Related Issue :** Closes #349 

---

## 🧑‍🎤 Summary
- [x] window + chrome 환경에서 이메일 인증 버튼 디자인 깨지는 에러 해결


## 🧑‍🎤 Comment
window가 없어서 테스트는 못 해봤어요
하지만 건영님이 테스트 해본 방식을 적용했기에 잘 작동할 것으로 판단이 됩니다

이메일 확인버튼과 인증 확인 버튼은 공통 컴포넌트를 공유하고 있는데
인증 확인 버튼의 크기가 이메일 확인 버튼의 크기와 일치해야 했어요
그렇기에 width를 고정적으로 박아야 해서 width: max-content는 이용할 수가 없었어요

대신 두 번째 추천 방법인 padding을 줄이는 방법을 택했습니다

사파리와 크롬, arc, firefox에서 문제 없는 거 확인했습니다!