### PR TITLE
[Design] Mobile ver. - 로그인, 비밀번호 페이지 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "react-dom": "^18.2.0",
     "react-helmet-async": "^2.0.5",
     "react-hook-form": "^7.51.5",
+    "react-responsive": "^10.0.0",
     "react-router-dom": "^6.23.1"
   },
   "devDependencies": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -44,13 +44,13 @@ const router = createBrowserRouter([
 ]);
 
 const App = () => {
-  useEffect(() => {
-    const isMobile = /Mobi/i.test(window.navigator.userAgent);
-    if (isMobile) {
-      alert('PC로 지원해주세요.');
-      window.location.href = 'https://makers.sopt.org/recruit';
-    }
-  }, []);
+  // useEffect(() => {
+  //   const isMobile = /Mobi/i.test(window.navigator.userAgent);
+  //   if (isMobile) {
+  //     alert('PC로 지원해주세요.');
+  //     window.location.href = 'https://makers.sopt.org/recruit';
+  //   }
+  // }, []);
 
   const sessionRef = useRef<HTMLDialogElement>(null);
 

--- a/src/common/components/Button/index.tsx
+++ b/src/common/components/Button/index.tsx
@@ -1,9 +1,10 @@
 import { useId, type ButtonHTMLAttributes, type ReactNode } from 'react';
 import { Link, To } from 'react-router-dom';
 
+import { useDevice } from '@hooks/useDevice';
 import ButtonLoading from 'views/loadings/ButtonLoading';
 
-import { container, outsideBox, paddings } from './style.css';
+import { buttonFontVar, container, outsideBox, paddings } from './style.css';
 
 interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement | HTMLAnchorElement> {
   children?: ReactNode;
@@ -25,6 +26,7 @@ const Button = ({
   isLink = false,
   ...buttonElementProps
 }: ButtonProps) => {
+  const DEVICE_TYPE = useDevice();
   const { disabled, type = 'button' } = buttonElementProps;
   const Tag = isLink ? Link : 'button';
 
@@ -44,7 +46,7 @@ const Button = ({
       disabled={isLoading || disabled}
       {...buttonElementProps}>
       <div
-        className={`${container[isLoading || disabled ? 'disabled' : buttonStyle]} ${paddings[padding]} ${className}`}>
+        className={`${container[isLoading || disabled ? 'disabled' : buttonStyle]} ${paddings[padding]} ${buttonFontVar[DEVICE_TYPE]} ${className}`}>
         {isLoading ? <ButtonLoading width={loadingWidth} /> : children}
       </div>
     </Tag>

--- a/src/common/components/Button/style.css.ts
+++ b/src/common/components/Button/style.css.ts
@@ -39,7 +39,6 @@ const containerBase = style({
   width: 'fit-content',
   borderRadius: 12,
   transition: 'background-color 0.3s ease-out',
-  ...theme.font.TITLE_5_18_SB,
 
   selectors: {
     '&:disabled, &:disabled:hover': {
@@ -121,4 +120,16 @@ export const container = styleVariants({
       pointerEvents: 'none',
     },
   ],
+});
+
+export const buttonFontVar = styleVariants({
+  DESK: {
+    ...theme.font.TITLE_5_18_SB,
+  },
+  TAB: {
+    ...theme.font.TITLE_5_18_SB,
+  },
+  MOB: {
+    ...theme.font.TITLE_6_16_SB,
+  },
 });

--- a/src/common/components/Callout/index.tsx
+++ b/src/common/components/Callout/index.tsx
@@ -3,7 +3,7 @@ import { IconAlertCircle } from '@sopt-makers/icons';
 
 import { useDevice } from '@hooks/useDevice';
 
-import { button, container, warningWrapperVar } from './style.css';
+import { buttonVar, container, warningWrapperVar } from './style.css';
 
 import type { HTMLAttributes, ReactNode } from 'react';
 
@@ -30,7 +30,7 @@ const Callout = ({ children, size = 'sm', Button, ...calloutElementProps }: Call
         />
         {children}
       </div>
-      {Button && <div className={button}>{Button}</div>}
+      {Button && <div className={buttonVar[DEVICE_TYPE]}>{Button}</div>}
     </article>
   );
 };

--- a/src/common/components/Callout/index.tsx
+++ b/src/common/components/Callout/index.tsx
@@ -1,7 +1,9 @@
 import { colors } from '@sopt-makers/colors';
 import { IconAlertCircle } from '@sopt-makers/icons';
 
-import { button, container, warningWrapper } from './style.css';
+import { useDevice } from '@hooks/useDevice';
+
+import { button, container, warningWrapperVar } from './style.css';
 
 import type { HTMLAttributes, ReactNode } from 'react';
 
@@ -12,9 +14,10 @@ interface CalloutProps extends HTMLAttributes<HTMLElement> {
 }
 
 const Callout = ({ children, size = 'sm', Button, ...calloutElementProps }: CalloutProps) => {
+  const DEVICE_TYPE = useDevice();
   return (
-    <article className={container[size]} {...calloutElementProps}>
-      <div className={warningWrapper}>
+    <article className={container[DEVICE_TYPE === 'DESK' ? size : DEVICE_TYPE]} {...calloutElementProps}>
+      <div className={warningWrapperVar[DEVICE_TYPE]}>
         <IconAlertCircle
           style={{
             width: 32,

--- a/src/common/components/Callout/style.css.ts
+++ b/src/common/components/Callout/style.css.ts
@@ -18,12 +18,44 @@ const containerBase = style({
 export const container = styleVariants({
   sm: [containerBase, { width: 466 }],
   lg: [containerBase, { width: 720 }],
+  TAB: [
+    containerBase,
+    {
+      width: 367,
+      padding: '28px 16px',
+      ...theme.font.HEADING_7_16_B,
+    },
+  ],
+  MOB: [
+    containerBase,
+    {
+      width: 312,
+      padding: '28px 16px',
+      ...theme.font.TITLE_7_14_SB,
+    },
+  ],
 });
 
-export const warningWrapper = style({
+const warningWrapper = style({
   display: 'flex',
   gap: 22,
   alignItems: 'center',
+});
+
+export const warningWrapperVar = styleVariants({
+  DESK: [warningWrapper],
+  TAB: [
+    warningWrapper,
+    {
+      gap: 8,
+    },
+  ],
+  MOB: [
+    warningWrapper,
+    {
+      gap: 8,
+    },
+  ],
 });
 
 export const button = style({

--- a/src/common/components/Callout/style.css.ts
+++ b/src/common/components/Callout/style.css.ts
@@ -9,7 +9,7 @@ const containerBase = style({
   padding: '28px 28px',
   borderRadius: 15,
   backgroundColor: theme.color.subBackground,
-  whiteSpace: 'pre-line',
+  whiteSpace: 'pre-wrap',
   ...theme.font.HEADING_6_18_B,
   letterSpacing: -0.36,
 });

--- a/src/common/components/Callout/style.css.ts
+++ b/src/common/components/Callout/style.css.ts
@@ -6,7 +6,6 @@ const containerBase = style({
   display: 'flex',
   flexDirection: 'column',
 
-  wordBreak: 'keep-all',
   padding: '28px 28px',
   borderRadius: 15,
   backgroundColor: theme.color.subBackground,
@@ -24,6 +23,7 @@ export const container = styleVariants({
       width: 367,
       padding: '28px 16px',
       ...theme.font.HEADING_7_16_B,
+      letterSpacing: '-0.24px',
     },
   ],
   MOB: [
@@ -32,6 +32,7 @@ export const container = styleVariants({
       width: 312,
       padding: '28px 16px',
       ...theme.font.TITLE_7_14_SB,
+      letterSpacing: '-0.21px',
     },
   ],
 });
@@ -61,4 +62,20 @@ export const warningWrapperVar = styleVariants({
 export const button = style({
   marginTop: 8,
   marginLeft: 'auto',
+});
+
+export const buttonVar = styleVariants({
+  DESK: [button],
+  TAB: [
+    button,
+    {
+      marginTop: 20,
+    },
+  ],
+  MOB: [
+    button,
+    {
+      marginTop: 12,
+    },
+  ],
 });

--- a/src/common/components/Input/components/Description/index.tsx
+++ b/src/common/components/Input/components/Description/index.tsx
@@ -1,10 +1,13 @@
 import { TextBoxProps } from '@components/Input/types';
+import { useDevice } from '@hooks/useDevice';
 
-import { descriptionVar } from './style.css';
+import { descriptionFontVar, descriptionVar } from './style.css';
 
 // TextBox 내부 Input 하단의 부가텍스트
-const Description = ({ children, styleType = 'default' }: Pick<TextBoxProps, 'children' | 'styleType'>) => (
-  <div className={descriptionVar[styleType]}>{children}</div>
-);
+const Description = ({ children, styleType = 'default' }: Pick<TextBoxProps, 'children' | 'styleType'>) => {
+  const DEVICE_TYPE = useDevice();
+
+  return <div className={`${descriptionVar[styleType]} ${descriptionFontVar[DEVICE_TYPE]}`}>{children}</div>;
+};
 
 export default Description;

--- a/src/common/components/Input/components/Description/style.css.ts
+++ b/src/common/components/Input/components/Description/style.css.ts
@@ -7,7 +7,6 @@ const description = style({
   gap: 10,
 
   color: theme.color.lightestText,
-  ...theme.font.LABEL_2_16_SB,
 });
 
 export const descriptionVar = styleVariants(
@@ -22,3 +21,9 @@ export const descriptionVar = styleVariants(
     },
   ],
 );
+
+export const descriptionFontVar = styleVariants({
+  DESK: { ...theme.font.LABEL_2_16_SB },
+  TAB: { ...theme.font.LABEL_2_16_SB },
+  MOB: { ...theme.font.LABEL_3_14_SB },
+});

--- a/src/common/components/Input/components/InputButton/index.tsx
+++ b/src/common/components/Input/components/InputButton/index.tsx
@@ -1,12 +1,14 @@
 import Button from '@components/Button';
+import { useDevice } from '@hooks/useDevice';
 
-import { textWidth } from './style.css';
+import { buttonVar } from './style.css';
 import { InputButtonProps } from './types';
 
 // TextBox 내부 InputLine 우측 버튼
 const InputButton = ({ isLoading, text, ...props }: InputButtonProps) => {
+  const DEVICE_TYPE = useDevice();
   return (
-    <Button isLoading={isLoading} className={textWidth} {...props}>
+    <Button isLoading={isLoading} className={buttonVar[DEVICE_TYPE]} {...props}>
       {text}
     </Button>
   );

--- a/src/common/components/Input/components/InputButton/style.css.ts
+++ b/src/common/components/Input/components/InputButton/style.css.ts
@@ -1,5 +1,26 @@
-import { style } from '@vanilla-extract/css';
+import { style, styleVariants } from '@vanilla-extract/css';
 
-export const textWidth = style({
-  width: 148,
+export const button = style({
+  paddingLeft: 0,
+  paddingRight: 0,
+});
+export const buttonVar = styleVariants({
+  DESK: [
+    button,
+    {
+      width: 148,
+    },
+  ],
+  TAB: [
+    button,
+    {
+      width: 116,
+    },
+  ],
+  MOB: [
+    button,
+    {
+      width: 99,
+    },
+  ],
 });

--- a/src/common/components/Input/components/InputLine/index.tsx
+++ b/src/common/components/Input/components/InputLine/index.tsx
@@ -1,7 +1,9 @@
 import { ChangeEvent, useContext } from 'react';
 import { useFormContext } from 'react-hook-form';
 
-import { inputLine, inputVar } from './style.css';
+import { useDevice } from '@hooks/useDevice';
+
+import { inputFontVar, inputLineVar, inputVar } from './style.css';
 import { formatBirthdate } from './utils/formatBirthdate';
 import { formatPhoneNumber } from './utils/formatPhoneNumber';
 import { TextBoxProps } from '../../types';
@@ -17,6 +19,7 @@ const InputLine = ({
   children,
   ...inputElementProps
 }: Omit<TextBoxProps, 'label' | 'size'>) => {
+  const DEVICE_TYPE = useDevice();
   const {
     register,
     formState: { errors },
@@ -43,11 +46,11 @@ const InputLine = ({
 
   return (
     <>
-      <div className={inputLine}>
+      <div className={inputLineVar[DEVICE_TYPE]}>
         <input
           id={name}
           defaultValue={defaultValue}
-          className={inputVar[errors[name] ? 'error' : 'default']}
+          className={`${inputVar[errors[name] ? 'error' : 'default']} ${inputFontVar[DEVICE_TYPE]}`}
           {...inputElementProps}
           {...register(name, {
             required: required && '필수 입력 항목이에요.',

--- a/src/common/components/Input/components/InputLine/style.css.ts
+++ b/src/common/components/Input/components/InputLine/style.css.ts
@@ -3,11 +3,27 @@ import { style, styleVariants } from '@vanilla-extract/css';
 import { formColors } from '@constants/styleValues';
 import { theme } from 'styles/theme.css';
 
-export const inputLine = style({
+const inputLine = style({
   display: 'flex',
   gap: 10,
 
   position: 'relative',
+});
+
+export const inputLineVar = styleVariants({
+  DESK: [inputLine],
+  TAB: [
+    inputLine,
+    {
+      gap: 5,
+    },
+  ],
+  MOB: [
+    inputLine,
+    {
+      gap: 5,
+    },
+  ],
 });
 
 const input = style({
@@ -16,14 +32,6 @@ const input = style({
   padding: 16,
   backgroundColor: theme.color.white,
   borderRadius: 12,
-
-  color: theme.color.baseText,
-  ...theme.font.BODY_2_16_R,
-
-  '::placeholder': {
-    color: theme.color.placeholder,
-    ...theme.font.BODY_2_16_R,
-  },
 
   ':focus': {
     boxShadow: `0 0 0 1px ${theme.color.primary} inset`,
@@ -55,3 +63,22 @@ export const inputVar = styleVariants(formColors, ({ boxShadow, focusShadow }) =
     },
   },
 ]);
+
+export const inputFontVar = styleVariants(
+  {
+    DESK: theme.font.BODY_2_16_R,
+    TAB: theme.font.BODY_2_16_R,
+    MOB: theme.font.BODY_4_13_R,
+  },
+  (font) => [
+    {
+      color: theme.color.baseText,
+      ...font,
+
+      '::placeholder': {
+        color: theme.color.placeholder,
+        ...font,
+      },
+    },
+  ],
+);

--- a/src/common/components/Input/components/InputTheme/index.tsx
+++ b/src/common/components/Input/components/InputTheme/index.tsx
@@ -8,9 +8,10 @@ import useMutateCheckCode from '@components/Input/hooks/useMutateCheckCode';
 import useMutateCheckUser from '@components/Input/hooks/useMutateCheckUser';
 import useMutateSendCode from '@components/Input/hooks/useMutateSendCode';
 import { VALIDATION_CHECK } from '@constants/validationCheck';
+import { useDevice } from '@hooks/useDevice';
 import useScrollToHash from '@hooks/useScrollToHash';
 
-import { success } from '../../style.css';
+import { successVar } from './style.css';
 import InputLine from '../InputLine';
 
 export const TextBox이름 = () => {
@@ -39,6 +40,7 @@ export const TextBox이메일 = ({
   isVerified,
   onChangeVerification,
 }: TextBox이메일Props) => {
+  const DEVICE_TYPE = useDevice();
   const location = useLocation();
   const navigate = useNavigate();
 
@@ -171,18 +173,20 @@ export const TextBox이메일 = ({
       </InputLine>
       {isActive && (
         <>
-          <p className={success}>이메일이 전송되었어요. 약 1분 정도 소요될 수 있어요.</p>
-          <p className={success} style={{ marginTop: '-8px' }}>
+          <p className={successVar[DEVICE_TYPE]}>이메일이 전송되었어요. 약 1분 정도 소요될 수 있어요.</p>
+          <p className={successVar[DEVICE_TYPE]} style={{ marginTop: '-8px' }}>
             메일이 오지 않는다면 스팸 메일함을 확인해주세요.
           </p>
         </>
       )}
-      {isVerified && <p className={success}>인증에 성공했어요.</p>}
+      {isVerified && <p className={successVar[DEVICE_TYPE]}>인증에 성공했어요.</p>}
     </TextBox>
   );
 };
 
 export const TextBox비밀번호 = () => {
+  const DEVICE_TYPE = useDevice();
+
   const location = useLocation();
   const textVar = location.pathname === '/password' ? '새 비밀번호' : '비밀번호';
   const name = location.pathname === '/password' ? 'newPassword' : 'password';
@@ -215,7 +219,9 @@ export const TextBox비밀번호 = () => {
         errorText={VALIDATION_CHECK.passwordConfirm.errorText}
         validate={VALIDATION_CHECK.passwordConfirm.validate(watch, name)}
       />
-      {passwordConfirm && password === passwordConfirm && <p className={success}>비밀번호가 일치해요.</p>}
+      {passwordConfirm && password === passwordConfirm && (
+        <p className={successVar[DEVICE_TYPE]}>비밀번호가 일치해요.</p>
+      )}
     </TextBox>
   );
 };

--- a/src/common/components/Input/components/InputTheme/style.css.ts
+++ b/src/common/components/Input/components/InputTheme/style.css.ts
@@ -1,0 +1,9 @@
+import { styleVariants } from '@vanilla-extract/css';
+
+import { theme } from 'styles/theme.css';
+
+export const successVar = styleVariants({
+  DESK: { color: theme.color.primary, ...theme.font.LABEL_2_16_SB },
+  TAB: { color: theme.color.primary, ...theme.font.LABEL_2_16_SB },
+  MOB: { color: theme.color.primary, ...theme.font.LABEL_3_14_SB },
+});

--- a/src/common/components/Input/components/TextBox/index.tsx
+++ b/src/common/components/Input/components/TextBox/index.tsx
@@ -1,8 +1,9 @@
 import { createContext } from 'react';
 
 import { TextBoxProps } from '@components/Input/types';
+import { useDevice } from '@hooks/useDevice';
 
-import { circle, containerVar, title } from './style.css';
+import { circle, containerVar, titleVar } from './style.css';
 
 export const FormContext = createContext({} as Pick<TextBoxProps, 'required'>);
 
@@ -14,10 +15,12 @@ export const TextBox = ({
   size = 'md',
   required,
 }: Pick<TextBoxProps, 'children' | 'label' | 'name' | 'size' | 'required'>) => {
+  const DEVICE_TYPE = useDevice();
+
   return (
     <FormContext.Provider value={{ required }}>
-      <div className={containerVar[size]}>
-        <label className={title} htmlFor={name}>
+      <div className={containerVar[DEVICE_TYPE === 'DESK' ? size : DEVICE_TYPE]}>
+        <label className={titleVar[DEVICE_TYPE]} htmlFor={name}>
           <span>{label}</span>
           {required && <i className={circle} />}
         </label>

--- a/src/common/components/Input/components/TextBox/style.css.ts
+++ b/src/common/components/Input/components/TextBox/style.css.ts
@@ -13,7 +13,7 @@ export const container = style({
 
 export const containerVar = styleVariants(containerSize, (size) => [container, { width: size }]);
 
-export const title = style({
+const title = style({
   display: 'flex',
   alignItems: 'center',
   gap: 6,
@@ -21,9 +21,14 @@ export const title = style({
   width: 'fit-content',
 
   color: theme.color.baseText,
-  ...theme.font.TITLE_5_18_SB,
 
   cursor: 'pointer',
+});
+
+export const titleVar = styleVariants({
+  DESK: [title, { ...theme.font.TITLE_5_18_SB }],
+  TAB: [title, { ...theme.font.TITLE_5_18_SB }],
+  MOB: [title, { ...theme.font.TITLE_6_16_SB }],
 });
 
 export const circle = style({

--- a/src/common/components/Input/components/Timer/index.tsx
+++ b/src/common/components/Input/components/Timer/index.tsx
@@ -1,7 +1,9 @@
 import { differenceInSeconds } from 'date-fns';
 import { useEffect, useState } from 'react';
 
-import { timer } from './style.css';
+import { useDevice } from '@hooks/useDevice';
+
+import { timerVar } from './style.css';
 import { TimerProps } from './types';
 import formatTimer from './utils/formatTimer';
 
@@ -9,6 +11,7 @@ const INITIAL_TIME = 300;
 
 // TextBox 내부 타이머
 const Timer = ({ isActive, onResetTimer }: TimerProps) => {
+  const DEVICE_TYPE = useDevice();
   const [seconds, setSeconds] = useState(INITIAL_TIME - 1);
 
   useEffect(() => {
@@ -43,7 +46,7 @@ const Timer = ({ isActive, onResetTimer }: TimerProps) => {
     };
   }, [isActive, onResetTimer]);
 
-  return <span className={timer}>{isActive && formatTimer(seconds)}</span>;
+  return <span className={timerVar[DEVICE_TYPE]}>{isActive && formatTimer(seconds)}</span>;
 };
 
 export default Timer;

--- a/src/common/components/Input/components/Timer/style.css.ts
+++ b/src/common/components/Input/components/Timer/style.css.ts
@@ -1,13 +1,36 @@
-import { style } from '@vanilla-extract/css';
+import { style, styleVariants } from '@vanilla-extract/css';
 
 import { theme } from 'styles/theme.css';
 
-export const timer = style({
+const timer = style({
   position: 'absolute',
-  right: 172,
   top: '50%',
   transform: 'translateY(-50%)',
   color: theme.color.lighterText,
-  ...theme.font.BODY_2_16_R,
+
   lineHeight: 'inherit',
+});
+
+export const timerVar = styleVariants({
+  DESK: [
+    timer,
+    {
+      right: 172,
+      ...theme.font.BODY_2_16_R,
+    },
+  ],
+  TAB: [
+    timer,
+    {
+      right: 137,
+      ...theme.font.BODY_2_16_R,
+    },
+  ],
+  MOB: [
+    timer,
+    {
+      right: 122,
+      ...theme.font.BODY_4_13_R,
+    },
+  ],
 });

--- a/src/common/components/Input/constants.ts
+++ b/src/common/components/Input/constants.ts
@@ -4,4 +4,6 @@ export const containerSize: Record<SizeType, number> = {
   sm: 356,
   md: 466,
   lg: 720,
+  TAB: 367,
+  MOB: 312,
 };

--- a/src/common/components/Input/style.css.ts
+++ b/src/common/components/Input/style.css.ts
@@ -1,8 +1,0 @@
-import { style } from '@vanilla-extract/css';
-
-import { theme } from 'styles/theme.css';
-
-export const success = style({
-  color: theme.color.primary,
-  ...theme.font.LABEL_2_16_SB,
-});

--- a/src/common/components/Input/types.ts
+++ b/src/common/components/Input/types.ts
@@ -1,7 +1,7 @@
 import { InputHTMLAttributes, ReactNode } from 'react';
 import { FieldValues, Validate } from 'react-hook-form';
 
-export type SizeType = 'sm' | 'md' | 'lg';
+export type SizeType = 'sm' | 'md' | 'lg' | 'TAB' | 'MOB';
 export interface TextBoxProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'size' | 'pattern'> {
   label: string;
   name: string;

--- a/src/common/components/Layout/components/Header/style.css.ts
+++ b/src/common/components/Layout/components/Header/style.css.ts
@@ -12,7 +12,6 @@ export const container = style({
   top: 0,
   maxWidth: 1440,
   width: '100%',
-  minWidth: 1000,
   margin: '0 auto',
   padding: '22px 156px 22px 150px',
 

--- a/src/common/components/Layout/style.css.ts
+++ b/src/common/components/Layout/style.css.ts
@@ -6,7 +6,6 @@ export const container = style({
   display: 'flex',
   flexDirection: 'column',
   alignItems: 'center',
-  minWidth: 1000,
   backgroundColor: theme.color.background,
 });
 

--- a/src/common/components/Title/index.tsx
+++ b/src/common/components/Title/index.tsx
@@ -1,12 +1,15 @@
 import { ReactNode } from 'react';
 
-import { heading } from './style.css';
+import { useDevice } from '@hooks/useDevice';
+
+import { headingVar } from './style.css';
 
 interface TitleProps {
   children: ReactNode;
 }
 const Title = ({ children }: TitleProps) => {
-  return <h1 className={heading}>{children}</h1>;
+  const DEVICE_TYPE = useDevice();
+  return <h1 className={headingVar[DEVICE_TYPE]}>{children}</h1>;
 };
 
 export default Title;

--- a/src/common/components/Title/style.css.ts
+++ b/src/common/components/Title/style.css.ts
@@ -1,12 +1,25 @@
-import { style } from '@vanilla-extract/css';
+import { styleVariants } from '@vanilla-extract/css';
 
 import { theme } from 'styles/theme.css';
 
-export const heading = style({
-  /* Heading/40_B */
-  ...theme.font.HEADING_1_48_B,
-  fontSize: 40,
-  lineHeight: '60px',
-  letterSpacing: -0.8,
-  color: theme.color.baseText,
+export const headingVar = styleVariants({
+  DESK: {
+    /* Heading/40_B */
+    ...theme.font.HEADING_1_48_B,
+    fontSize: 40,
+    lineHeight: '60px',
+    letterSpacing: -0.8,
+    color: theme.color.baseText,
+  },
+  TAB: {
+    /* Heading/40_B */
+    ...theme.font.HEADING_1_48_B,
+    fontSize: 40,
+    lineHeight: '60px',
+    letterSpacing: -0.8,
+    color: theme.color.baseText,
+  },
+  MOB: {
+    ...theme.font.HEADING_4_24_B,
+  },
 });

--- a/src/common/hooks/useDevice.ts
+++ b/src/common/hooks/useDevice.ts
@@ -1,0 +1,31 @@
+import { useEffect, useState } from 'react';
+import { useMediaQuery } from 'react-responsive';
+
+export function useIsTablet(minWidth = '429px', maxWidth = '768px') {
+  const [isTablet, setIsTablet] = useState(false);
+  const tablet = useMediaQuery({
+    query: `(min-width: ${minWidth}) and (max-width: ${maxWidth})`,
+  });
+  useEffect(() => {
+    setIsTablet(tablet);
+  }, [tablet]);
+  return isTablet;
+}
+
+export function useIsMobile(maxWidth = '428.999px') {
+  const [isMobile, setIsMobile] = useState(false);
+  const mobile = useMediaQuery({
+    query: `(max-width:${maxWidth})`,
+  });
+  useEffect(() => {
+    setIsMobile(mobile);
+  }, [mobile]);
+  return isMobile;
+}
+
+export function useDevice() {
+  const isTablet = useIsTablet();
+  const isMobile = useIsMobile();
+
+  return isTablet ? 'tablet' : isMobile ? 'mobile' : 'desktop';
+}

--- a/src/common/hooks/useDevice.ts
+++ b/src/common/hooks/useDevice.ts
@@ -23,9 +23,9 @@ export function useIsMobile(maxWidth = '428.999px') {
   return isMobile;
 }
 
-export function useDevice() {
+export function useDevice(): 'TAB' | 'MOB' | 'DESK' {
   const isTablet = useIsTablet();
   const isMobile = useIsMobile();
 
-  return isTablet ? 'tablet' : isMobile ? 'mobile' : 'desktop';
+  return isTablet ? 'TAB' : isMobile ? 'MOB' : 'DESK';
 }

--- a/src/views/PasswordPage/index.tsx
+++ b/src/views/PasswordPage/index.tsx
@@ -1,19 +1,21 @@
 import Title from '@components/Title';
 import useDate from '@hooks/useDate';
+import { useDevice } from '@hooks/useDevice';
 import NoMore from 'views/ErrorPage/components/NoMore';
 import BigLoading from 'views/loadings/BigLoding';
 
 import PasswordForm from './components/PasswordForm';
-import { container } from './style.css';
+import { containerVar } from './style.css';
 
 const PasswordPage = () => {
+  const DEVICE_TYPE = useDevice();
   const { NoMoreRecruit, isLoading, isMakers } = useDate();
 
   if (isLoading) return <BigLoading />;
   if (NoMoreRecruit) return <NoMore isMakers={isMakers} content="모집 기간이 아니에요" />;
 
   return (
-    <div className={container}>
+    <div className={containerVar[DEVICE_TYPE]}>
       <Title>비밀번호 재설정하기</Title>
       <PasswordForm />
     </div>

--- a/src/views/PasswordPage/style.css.ts
+++ b/src/views/PasswordPage/style.css.ts
@@ -1,10 +1,33 @@
-import { style } from '@vanilla-extract/css';
+import { style, styleVariants } from '@vanilla-extract/css';
 
-export const container = style({
+const container = style({
   display: 'flex',
   flexDirection: 'column',
-  gap: 50,
+});
 
-  margin: '90px auto 144px',
-  width: 466,
+export const containerVar = styleVariants({
+  DESK: [
+    container,
+    {
+      gap: 50,
+      margin: '90px 0 144px 0',
+      width: 466,
+    },
+  ],
+  TAB: [
+    container,
+    {
+      gap: 50,
+      margin: '75px 0 129px 0',
+      width: 367,
+    },
+  ],
+  MOB: [
+    container,
+    {
+      gap: 30,
+      margin: '43px 0 75px 0',
+      width: 312,
+    },
+  ],
 });

--- a/src/views/SignInPage/components/SignInInfo/index.tsx
+++ b/src/views/SignInPage/components/SignInInfo/index.tsx
@@ -7,7 +7,7 @@ import Title from '@components/Title';
 import { useDevice } from '@hooks/useDevice';
 import { RecruitingInfoContext } from '@store/recruitingInfoContext';
 
-import { calloutButtonVar, strongText } from './style.css';
+import { calloutButtonVar } from './style.css';
 
 const SignInInfo = () => {
   const DEVICE_TYPE = useDevice();
@@ -27,9 +27,8 @@ const SignInInfo = () => {
           </Link>
         }>
         <p>
-          {season}기 {isMakers ? '' : group} 지원서 작성이 처음이라면 ‘새 지원서 작성하기’를 진행해주세요.{' '}
-          <strong className={strongText}>이전에 지원서 </strong>를 제출한 적이 있더라도{' '}
-          <strong className={strongText}>반드시</strong> 새 지원서를 작성해야 해요.
+          {season}기 {isMakers ? '' : group} 지원서 작성이 처음이라면 ‘새 지원서 작성하기’를 진행해주세요. 이전에
+          지원서를 제출한 적이 있더라도 새 지원서를 작성해야 해요.
         </p>
       </Callout>
     </>

--- a/src/views/SignInPage/components/SignInInfo/index.tsx
+++ b/src/views/SignInPage/components/SignInInfo/index.tsx
@@ -4,11 +4,13 @@ import { Link } from 'react-router-dom';
 
 import Callout from '@components/Callout';
 import Title from '@components/Title';
+import { useDevice } from '@hooks/useDevice';
 import { RecruitingInfoContext } from '@store/recruitingInfoContext';
 
-import { calloutButton, strongText } from './style.css';
+import { calloutButtonVar, strongText } from './style.css';
 
 const SignInInfo = () => {
+  const DEVICE_TYPE = useDevice();
   const {
     recruitingInfo: { soptName, isMakers, season, group },
   } = useContext(RecruitingInfoContext);
@@ -20,12 +22,12 @@ const SignInInfo = () => {
       </Title>
       <Callout
         Button={
-          <Link to="/sign-up" className={calloutButton} onClick={() => track('click-signin-signup')}>
+          <Link to="/sign-up" className={calloutButtonVar[DEVICE_TYPE]} onClick={() => track('click-signin-signup')}>
             새 지원서 작성하기
           </Link>
         }>
         <p>
-          {season}기 {soptName} {isMakers ? '' : group} 지원서 작성이 처음이라면 ‘새 지원서 작성하기’를 진행해주세요.{' '}
+          {season}기 {isMakers ? '' : group} 지원서 작성이 처음이라면 ‘새 지원서 작성하기’를 진행해주세요.{' '}
           <strong className={strongText}>이전에 지원서 </strong>를 제출한 적이 있더라도{' '}
           <strong className={strongText}>반드시</strong> 새 지원서를 작성해야 해요.
         </p>

--- a/src/views/SignInPage/components/SignInInfo/style.css.ts
+++ b/src/views/SignInPage/components/SignInInfo/style.css.ts
@@ -1,12 +1,17 @@
-import { style } from '@vanilla-extract/css';
+import { style, styleVariants } from '@vanilla-extract/css';
 
 import { theme } from 'styles/theme.css';
 
-export const calloutButton = style({
+const calloutButton = style({
   marginRight: 18,
   borderBottom: '1px solid currentColor',
   color: theme.color.lighterText,
-  ...theme.font.TITLE_5_18_SB,
+});
+
+export const calloutButtonVar = styleVariants({
+  DESK: [calloutButton, { ...theme.font.TITLE_5_18_SB }],
+  TAB: [calloutButton, { ...theme.font.TITLE_6_16_SB, border: 'none' }],
+  MOB: [calloutButton, { ...theme.font.TITLE_7_14_SB, border: 'none' }],
 });
 
 export const strongText = style({

--- a/src/views/SignInPage/index.tsx
+++ b/src/views/SignInPage/index.tsx
@@ -1,19 +1,21 @@
 import useDate from '@hooks/useDate';
+import { useDevice } from '@hooks/useDevice';
 import NoMore from 'views/ErrorPage/components/NoMore';
 import BigLoading from 'views/loadings/BigLoding';
 
 import SignInForm from './components/SignInForm';
 import SignInInfo from './components/SignInInfo';
-import { container } from './style.css';
+import { containerVar } from './style.css';
 
 const SignInPage = () => {
+  const DEVICE_TYPE = useDevice();
   const { isLoading, NoMoreRecruit, isMakers } = useDate();
 
   if (isLoading) return <BigLoading />;
   if (NoMoreRecruit) return <NoMore isMakers={isMakers} content="모집 기간이 아니에요" />;
 
   return (
-    <div className={container}>
+    <div className={containerVar[DEVICE_TYPE]}>
       <SignInInfo />
       <SignInForm />
     </div>

--- a/src/views/SignInPage/style.css.ts
+++ b/src/views/SignInPage/style.css.ts
@@ -1,10 +1,33 @@
-import { style } from '@vanilla-extract/css';
+import { style, styleVariants } from '@vanilla-extract/css';
 
 export const container = style({
   display: 'flex',
   flexDirection: 'column',
-  gap: 50,
+});
 
-  margin: '90px 0 168px 0',
-  width: 466,
+export const containerVar = styleVariants({
+  DESK: [
+    container,
+    {
+      gap: 50,
+      margin: '90px 0 168px 0',
+      width: 466,
+    },
+  ],
+  TAB: [
+    container,
+    {
+      gap: 50,
+      margin: '90px 0 172px 0',
+      width: 367,
+    },
+  ],
+  MOB: [
+    container,
+    {
+      gap: 30,
+      margin: '43px 0 115px 0',
+      width: 312,
+    },
+  ],
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1896,6 +1896,11 @@ cross-spawn@^7.0.2:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
+css-mediaquery@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/css-mediaquery/-/css-mediaquery-0.1.2.tgz#6a2c37344928618631c54bd33cedd301da18bea0"
+  integrity sha512-COtn4EROW5dBGlE/4PiKnh6rZpAPxDeFLaEEwt4i10jpDMFt2EhQGS79QmmrO+iKCHv0PU/HrOWEhijFd1x99Q==
+
 css-what@^6.1.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/css-what/-/css-what-6.1.0.tgz#fb5effcf76f1ddea2c81bdfaa4de44e79bac70f4"
@@ -2758,6 +2763,11 @@ http-parser-js@>=0.5.1:
   resolved "https://registry.yarnpkg.com/http-parser-js/-/http-parser-js-0.5.8.tgz#af23090d9ac4e24573de6f6aecc9d84a48bf20e3"
   integrity sha512-SGeBX54F94Wgu5RH3X5jsDtf4eHyRogWX1XGT3b4HuW3tQPM4AaBzoUji/4AAJNXCEOWZ5O0DgZmJw1947gD5Q==
 
+hyphenate-style-name@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/hyphenate-style-name/-/hyphenate-style-name-1.1.0.tgz#1797bf50369588b47b72ca6d5e65374607cf4436"
+  integrity sha512-WDC/ui2VVRrz3jOVi+XtjqkDjiVjTtFaAGiW37k6b+ohyQ5wYDOGkvCZa8+H0nx3gyvv0+BST9xuOgIyGQ00gw==
+
 idb-keyval@^6.2.1:
   version "6.2.1"
   resolved "https://registry.yarnpkg.com/idb-keyval/-/idb-keyval-6.2.1.tgz#94516d625346d16f56f3b33855da11bfded2db33"
@@ -3138,6 +3148,13 @@ lru-cache@^5.1.1:
   dependencies:
     yallist "^3.0.2"
 
+matchmediaquery@^0.4.2:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/matchmediaquery/-/matchmediaquery-0.4.2.tgz#22582bd4ae63ad9f54c53001bba80cbed0f7eafa"
+  integrity sha512-wrZpoT50ehYOudhDjt/YvUJc6eUzcdFPdmbizfgvswCKNHD1/OBOHYJpHie+HXpu6bSkEGieFMYk6VuutaiRfA==
+  dependencies:
+    css-mediaquery "^0.1.2"
+
 media-query-parser@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/media-query-parser/-/media-query-parser-2.0.2.tgz#ff79e56cee92615a304a1c2fa4f2bd056c0a1d29"
@@ -3437,7 +3454,7 @@ prettier@^3.2.5:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.2.5.tgz#e52bc3090586e824964a8813b09aba6233b28368"
   integrity sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==
 
-prop-types@^15.8.1:
+prop-types@^15.6.1, prop-types@^15.8.1:
   version "15.8.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
   integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
@@ -3520,6 +3537,16 @@ react-refresh@^0.14.0:
   version "0.14.2"
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.14.2.tgz#3833da01ce32da470f1f936b9d477da5c7028bf9"
   integrity sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==
+
+react-responsive@^10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/react-responsive/-/react-responsive-10.0.0.tgz#657c7a90823cd565f43aa5918bd8eb0cd2c91c91"
+  integrity sha512-N6/UiRLGQyGUqrarhBZmrSmHi2FXSD++N5VbSKsBBvWfG0ZV7asvUBluSv5lSzdMyEVjzZ6Y8DL4OHABiztDOg==
+  dependencies:
+    hyphenate-style-name "^1.0.0"
+    matchmediaquery "^0.4.2"
+    prop-types "^15.6.1"
+    shallow-equal "^3.1.0"
 
 react-router-dom@^6.23.1:
   version "6.23.1"
@@ -3720,6 +3747,11 @@ set-function-name@^2.0.1, set-function-name@^2.0.2:
     es-errors "^1.3.0"
     functions-have-names "^1.2.3"
     has-property-descriptors "^1.0.2"
+
+shallow-equal@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/shallow-equal/-/shallow-equal-3.1.0.tgz#e7a54bac629c7f248eff6c2f5b63122ba4320bec"
+  integrity sha512-pfVOw8QZIXpMbhBWvzBISicvToTiM5WBF1EeAUZDDSb5Dt29yl4AYbyywbJFSEsRUMr7gJaxqCdr4L3tQf9wVg==
 
 shallowequal@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
**Related Issue :** Closes #351

---

## 🧑‍🎤 Summary
- SignInPage Tab, Mob 반응형 구현
- PasswordPage Tab, Mob 반응형 구현
- 그 외 피그마 데탑뷰와 디자인 살짝 다른 부분들 수정

## 🧑‍🎤 Screenshot
### SignInPage 
> 아직 header는 구현하지 않아서, 레이아웃 꺠지게 하는 nav는 주석처리해놓고 녹화했습니다! 

https://github.com/user-attachments/assets/81fb6c7b-e877-4f72-99d7-5e9e5dfc59fe

### PasswordPage


https://github.com/user-attachments/assets/0ce3c2dd-5d0c-42c7-a9df-40dcc09701cb



## 🧑‍🎤 Comment
### 🚀 breakPoint 기준 
지원서 서비스의 breakPoint는 
- w ~769
- w768~429
- w428~375

이렇게 범위가 나뉘게 됩니다. 
편의상 `desktop`, `tablet`, `mobile` 이라고 분류하였어요 

### 🚀 react-responsive 패키지
> 공홈 프로젝트에서 사용 중인 방식을 차용했어요 

반응형 웹을 구현하기 위해 `react-responsive` 패키지를 추가했어요. 
의존성 추가 이유는 다음과 같아요 
- 조건부 스타일링 뿐만 아니라 반응형에 따라 조건부 렌더링도 필요해서 media query로 부족함
- resize 이벤트핸들러를 만들어 이모저모 구현해줄 수 있겠지만, 해당 방식은 성능 최적화를 필요로 하고 지금은 그렇게까지 구현할 여유가 없는 상황이라고 판단하여 우선 라이브러리로 편리하게 개발함. 만약 라이브러리를 지양하고자 할 경우, 추후 걷어내고 리팩 가능

### 🚀 useDevice 공통 hook 추가 
> 공홈 프로젝트에서 사용 중인 방식을 차용했어요. 

`react-responsive`를 통해 동적으로 창크기를 측정하여 mobile인지, tablet인지를 판단하는 공통 hook을 추가했어요. 
[commit 보러 가기 1](https://github.com/sopt-makers/sopt-recruiting-frontend/commit/2ab80576ff4eaf2d4822e575ba9d4a1b407ee8f2)
[commit 보러 가기 2](https://github.com/sopt-makers/sopt-recruiting-frontend/commit/77e8182b07d72516e2f7b3727222538d56eb854e)

공홈에서는 단순히 isMobile, isTablet과 같은 boolean값을 반환받아 사용하고 있지만, 
저희는 vanilla extract 특성상 style variants로 대부분의 반응형을 구현하고 있기 때문에 저희가 사용하기 더 편리하도록 type을 반환시켜주는 useDevice 함수를 추가했어요. 
```ts
export function useDevice(): 'TAB' | 'MOB' | 'DESK' {
  const isTablet = useIsTablet();
  const isMobile = useIsMobile();

  return isTablet ? 'TAB' : isMobile ? 'MOB' : 'DESK';
}
```
앞서 말했듯, 반응형의 기준은 breakpoint 범위에 따라 
- DESK : 데스크탑 
- TAB : 태블릿 
- MOB : 모바일

로 나뉩니다. 

### 🚀 SignInPage, PasswordPage 반응형 작업 
로그인 페이지와 비밀번호 페이지 등 대부분이 공통 컴포넌트로만 이루어져있기 때문에, 대부분의 작업이 공통 컴포에 styleVary를 추가해주는 방식이었어요. 
작업 사이즈가 커지게 되어 컴포넌트별로 커밋을 쪼개며 작업했어요. 
아래는 제가 작업하기 전에 피그마 보고 정리한 반응형 요소들이고, 각 제목에 **commit 링크** 걸어두었으니 필요 시 참고해주세요! 

1️⃣ **[Callout 반응형 작업](https://github.com/sopt-makers/sopt-recruiting-frontend/commit/f681a2f3a8307e8de93f361cd3609e97c3e5f319)** 
이미 styleVariant로 sm, lg에 따라 크기를 다르게 부여해주고 있어서, 
DESKTOP일 때는 sm, lg에 따라, TAB/MOB일 때는 반응형 사이즈로 보여지게 추가했어요 
> width, padding, font, gap
- 데탑 : 466, '28px 28px', heading 18, 22
- 탭 : 367, '28px 16px', heading 16, 8
- 모바일 : 312, '28px 16px', title 14, 8
    
2️⃣ **[TextBox 반응형](https://github.com/sopt-makers/sopt-recruiting-frontend/commit/71b64ee24b20bebb77a6384c739dada261df5cb1)** 
- 너비
  - 데탑 : 466
  - 탭 : 367
  - 모바일 : 312
- 라벨
  - 데탑 : title 18
  - 탭 : title 18
  - 모바일 : title 16


3️⃣ **[InputLine 반응형](https://github.com/sopt-makers/sopt-recruiting-frontend/commit/1101ba96235bb2121204a8be1b579c7587387df9)** 
- inputLine gap
  - 데탑 : 10
  - 탭, 모바일 : 5
- input 내부 font size
  > `inputFontVar` : inputVar처럼 variant와 중첩해주고 싶은 순간들이 참많았는데.. 이걸 하려면 또 새로운 vanilla 패키지 하나를 추가로 다운받아야 하더라고요? 그래서 그냥 classList로 처리해줬어요
  - 데탑 : body 16r
  - 탭 : body 16r
  - 모바일 : body 13r


4️⃣ **[InputButton 반응형](https://github.com/sopt-makers/sopt-recruiting-frontend/commit/56968c85143ff336d8ba4514c96ef0d94350aa70)**  
> fontSize는 Button공컴에서 주고 있길래 공컴에 작업! 
    
> 얘도 buttonFontSize classList로 추가!

> padding은 어제 건영오빠 제보 이슈로 제거! -> 근데 언석오빠가 어제 이슈 해결한거 pull 안땡겨서 ㅠㅠ 직접 추가해둠!

- 데탑 : title 18, ~~padding 15 32~~, width 146
- 탭 : title 18, ~~padding 15 17,~~ width 116
- 모바일 : title 16, ~~padding 14 13~~, width 99


5️⃣ **[Description 반응형](https://github.com/sopt-makers/sopt-recruiting-frontend/commit/06e00bdbd5702a2a74d484e3b9beb25bbd271c01)** 
- 데탑 : Label 16
- 탭 : label 16
- 모바일 : label 14


6️⃣ **[Timer 반응형](https://github.com/sopt-makers/sopt-recruiting-frontend/commit/f14dde6fbecea00f7df9797a77a4394ec50d6934)**
- input 내부 fontsize와 동일
- right 값
  - 데탑 : 172
  - 탭: 21 + 116 = 137
  - 모바일 : 23 + 99 = 122


7️⃣ **[InpuTheme → 이메일 인증번호 전송 메시지](https://github.com/sopt-makers/sopt-recruiting-frontend/commit/4bdecc909362d15b9b66e4933e95d8f1761a31a8)** 
- 데탑 : label 16
- 탭 : label 16
- 모바일 : label 14


8️⃣ **[Heading (Title) 반응형](https://github.com/sopt-makers/sopt-recruiting-frontend/commit/e9ebec36b06596755e7069eeda027edb979d9bc7)** 
- 데탑, 탭 : heading 40 (mds 없음)
- 모바일 : heading 24


9️⃣ **[SignInPage 반응형](https://github.com/sopt-makers/sopt-recruiting-frontend/commit/adf4745a6d454037e36bd7d82c2750e48ba36de0)** 
- 데탑
  - gap 50
  - margin 90px 0 168px 0
  - width 466
- 탭
  - gap 50
  - margin 90px 0 172px 0
  - width 367
- 모바일
  - gap 30
  - margin 43px 0 115px 0
  - width 312


🔟 **[PasswordPage 반응형](https://github.com/sopt-makers/sopt-recruiting-frontend/commit/9c2e5b82c6d9c960f96d92dce12267de20451111)** 
- SignInPage와 동일
