### PR TITLE
[Fix] 23:59에 지원서 마감되는 에러 해결

### DIFF
--- a/src/views/ApplyPage/components/ApplyInfo/index.tsx
+++ b/src/views/ApplyPage/components/ApplyInfo/index.tsx
@@ -1,4 +1,4 @@
-import { format } from 'date-fns';
+import { format, subMinutes } from 'date-fns';
 import { ko } from 'date-fns/locale';
 import { memo, useContext } from 'react';
 
@@ -34,7 +34,9 @@ const ApplyInfo = memo(({ isReview }: { isReview: boolean }) => {
   const formattedApplicationStart = format(new Date(applicationStart || ''), 'M월 dd일 (E) aaa HH시 mm분', {
     locale: ko,
   });
-  const formattedApplicationEnd = format(new Date(applicationEnd || ''), 'M월 dd일 (E) aaa HH시 mm분', { locale: ko });
+  const formattedApplicationEnd = format(subMinutes(new Date(applicationEnd || ''), 1), 'M월 dd일 (E) aaa HH시 mm분', {
+    locale: ko,
+  });
   const formattedApplicationConfirmStart = format(
     new Date(applicationPassConfirmStart || ''),
     'M월 dd일 (E) aaa HH시 mm분',


### PR DESCRIPTION
**Related Issue :** Closes #359 

---

## 🧑‍🎤 Summary
- [x] 23시 59분 59초까지 지원서 받기

## 🧑‍🎤 Screenshot
<img width="593" alt="스크린샷 2024-08-08 오전 2 43 03" src="https://github.com/user-attachments/assets/a1a93f38-8377-4d52-8ea1-6d38fef2421f">


## 🧑‍🎤 Comment
admin에 마감 시간을 00:00로 입력하게 하고
화면에 보여지는 건 거기서 1분 뺀 23:59이 보여지도록 했어요
(아직 admin 수정 안해서 23:58로 보입니다)

코드 딴에서 00시로 설정하면 59분으로 설정합니다
<img width="557" alt="스크린샷 2024-08-08 오전 2 45 19" src="https://github.com/user-attachments/assets/11753578-279f-48b7-b2a1-98d774cafa23">

