### PR TITLE
[Fix] apply page 카테고리 관련 에러 해결

### DIFF
--- a/src/views/ApplyPage/components/ApplyCategory/index.tsx
+++ b/src/views/ApplyPage/components/ApplyCategory/index.tsx
@@ -1,5 +1,5 @@
 import { memo } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 
 import useScrollPosition from '@hooks/useScrollPosition';
 
@@ -10,7 +10,9 @@ interface ApplyCategoryProps {
   minIndex: number;
 }
 const ApplyCategory = memo(({ minIndex }: ApplyCategoryProps) => {
-  const { isScrollingDown, isScrollTop } = useScrollPosition(950);
+  const { pathname } = useLocation();
+
+  const { isScrollingDown, isScrollTop } = useScrollPosition(pathname === '/review' ? 380 : 950);
 
   return (
     <nav className={container[minIndex !== -1 && isScrollingDown && !isScrollTop ? 'scrollDown' : 'scrollUp']}>

--- a/src/views/ApplyPage/components/ApplyCategory/index.tsx
+++ b/src/views/ApplyPage/components/ApplyCategory/index.tsx
@@ -15,7 +15,7 @@ const ApplyCategory = memo(({ minIndex }: ApplyCategoryProps) => {
   const { isScrollingDown, isScrollTop } = useScrollPosition(pathname === '/review' ? 380 : 950);
 
   return (
-    <nav className={container[minIndex !== -1 && isScrollingDown && !isScrollTop ? 'scrollDown' : 'scrollUp']}>
+    <nav className={container[isScrollingDown && !isScrollTop ? 'scrollDown' : 'scrollUp']}>
       <ul className={categoryList}>
         {CATEGORY.map(({ index, text, path }) => (
           <li key={path}>

--- a/src/views/ApplyPage/components/ApplyCategory/index.tsx
+++ b/src/views/ApplyPage/components/ApplyCategory/index.tsx
@@ -1,5 +1,5 @@
 import { memo } from 'react';
-import { Link, useLocation } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 
 import useScrollPosition from '@hooks/useScrollPosition';
 
@@ -7,12 +7,11 @@ import { CATEGORY } from './constant';
 import { activeLinkStyle, categoryLinkStyle, categoryList, container } from './style.css';
 
 interface ApplyCategoryProps {
+  isReview: boolean;
   minIndex: number;
 }
-const ApplyCategory = memo(({ minIndex }: ApplyCategoryProps) => {
-  const { pathname } = useLocation();
-
-  const { isScrollingDown, isScrollTop } = useScrollPosition(pathname === '/review' ? 380 : 950);
+const ApplyCategory = memo(({ isReview, minIndex }: ApplyCategoryProps) => {
+  const { isScrollingDown, isScrollTop } = useScrollPosition(isReview ? 380 : 950);
 
   return (
     <nav className={container[isScrollingDown && !isScrollTop ? 'scrollDown' : 'scrollUp']}>

--- a/src/views/ApplyPage/components/ApplyCategory/style.css.ts
+++ b/src/views/ApplyPage/components/ApplyCategory/style.css.ts
@@ -28,6 +28,8 @@ export const container = styleVariants({
     containerBase,
     {
       opacity: 0,
+      pointerEvents: 'none',
+      cursor: 'default',
       transform: 'translateY(-41px)',
     },
   ],

--- a/src/views/ApplyPage/index.tsx
+++ b/src/views/ApplyPage/index.tsx
@@ -286,7 +286,7 @@ const ApplyPage = ({ onSetComplete }: ApplyPageProps) => {
           onSubmitData={handleSubmit(handleApplySubmit)}
         />
         <ApplyInfo isReview={isReview} />
-        <ApplyCategory minIndex={minIndex} />
+        <ApplyCategory isReview={isReview} minIndex={minIndex} />
         <form id="apply-form" name="apply-form" onSubmit={handleSubmit(handleApplySubmit)} className={formContainer}>
           <DefaultSection
             isMakers={isMakers}

--- a/src/views/ReviewPage/index.tsx
+++ b/src/views/ReviewPage/index.tsx
@@ -109,7 +109,7 @@ const ReviewPage = () => {
         <div className={container}>
           <ApplyHeader isReview={isReview} />
           <ApplyInfo isReview={isReview} />
-          <ApplyCategory minIndex={minIndex} />
+          <ApplyCategory isReview={isReview} minIndex={minIndex} />
           <form id="apply-form" name="apply-form" className={formContainer}>
             <DefaultSection
               isMakers={isMakers}


### PR DESCRIPTION
**Related Issue :** Closes #361 

---

## 🧑‍🎤 Summary
- [x] 리뷰 페이지에서 apply info 줄어든 만큼 category도 더 빨리 사라지도록 수정
- [x] 개인정보 수집 동의 여부까지 스크롤 내리면 다시 카테고리 등장하는 에러 해결
- [x] 카테고리 사라져도 계속 클릭되는 에러 해결

## 🧑‍🎤 Screenshot
### 리뷰 페이지에서 apply info 줄어든 만큼 category도 더 빨리 사라지도록 수정
https://github.com/user-attachments/assets/909178af-41bb-4c88-9fb5-b42ce8bed040

### 개인정보 수집 동의 여부까지 스크롤 내리면 다시 카테고리 등장하는 에러
### 전
![스크린샷 2024-08-08 오후 1 40 35](https://github.com/user-attachments/assets/2f656839-2578-4d99-bf30-dc5cbdb2b8fc)

### 후
![스크린샷 2024-08-08 오후 1 43 08](https://github.com/user-attachments/assets/39ed047e-df45-4f1a-8d42-9dd53c4dfc90)


## 🧑‍🎤 Comment
원래는 scrollY가 950 이상이 되어야 사라지도록 설정이 되어 있었는데
리뷰 페이지는 apply info가 지원서 페이지보다 양이 작아
380 정도에 사라지도록 설정했습니다
