### PR TITLE
[Fix] 사진과 체크박스의 필수 여부 체크할 때 발생되는 에러 해결

### DIFF
--- a/src/common/components/Checkbox/index.tsx
+++ b/src/common/components/Checkbox/index.tsx
@@ -18,6 +18,7 @@ const Checkbox = <T extends FieldValues>({
 }: CheckboxProps<T>) => {
   const {
     register,
+    trigger,
     formState: { errors },
   } = useFormContext();
 
@@ -28,6 +29,7 @@ const Checkbox = <T extends FieldValues>({
           <input
             {...register(name, {
               ...(required && { required: '필수 동의 항목이에요.' }),
+              onChange: () => trigger(name),
             })}
             type="checkbox"
             className={`amp-unmask ${hiddenCheckbox}`}

--- a/src/views/ApplyPage/index.tsx
+++ b/src/views/ApplyPage/index.tsx
@@ -158,7 +158,10 @@ const ApplyPage = ({ onSetComplete }: ApplyPageProps) => {
 
   useEffect(() => {
     if (errors.attendance || errors.personalInformation) {
-      if (Object.keys(errors).length === 1 && (errors.attendance || errors.personalInformation))
+      if (
+        (Object.keys(errors).length === 2 && errors.attendance && errors.personalInformation) ||
+        (Object.keys(errors).length === 1 && (errors.attendance || errors.personalInformation))
+      )
         navigate('#check-necessary');
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/views/ApplyPage/index.tsx
+++ b/src/views/ApplyPage/index.tsx
@@ -157,13 +157,11 @@ const ApplyPage = ({ onSetComplete }: ApplyPageProps) => {
   }, [errors.picture]);
 
   useEffect(() => {
-    if (errors.attendance || errors.personalInformation) {
-      if (
-        (Object.keys(errors).length === 2 && errors.attendance && errors.personalInformation) ||
-        (Object.keys(errors).length === 1 && (errors.attendance || errors.personalInformation))
-      )
-        navigate('#check-necessary');
-    }
+    if (
+      (Object.keys(errors).length === 2 && errors.attendance && errors.personalInformation) ||
+      (Object.keys(errors).length === 1 && (errors.attendance || errors.personalInformation))
+    )
+      navigate('#check-necessary');
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [errors.attendance, errors.personalInformation]);
 

--- a/src/views/ApplyPage/index.tsx
+++ b/src/views/ApplyPage/index.tsx
@@ -153,12 +153,16 @@ const ApplyPage = ({ onSetComplete }: ApplyPageProps) => {
       return;
     }
 
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [errors.picture]);
+
+  useEffect(() => {
     if (errors.attendance || errors.personalInformation) {
-      if (Object.keys(errors).length > 2) return;
-      navigate('#check-necessary');
+      if (Object.keys(errors).length === 1 && (errors.attendance || errors.personalInformation))
+        navigate('#check-necessary');
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [errors.picture, errors.attendance, errors.personalInformation]);
+  }, [errors.attendance, errors.personalInformation]);
 
   useEffect(() => {
     if (isReview) return;


### PR DESCRIPTION
**Related Issue :** Closes #367 

---

## 🧑‍🎤 Summary
- [x] 사진과 체크박스 동시에 에러 있을 때, 체크박스 클릭 시 사진으로 focus 가는 에러 해결
- [x] 체크박스 바로바로 에러 체크 안 되는 이슈 해결

## 🧑‍🎤 Comment

### 🥕 사진과 체크박스 동시에 에러 있을 때, 체크박스 클릭 시 사진으로 focus 가는 에러 해결
https://github.com/user-attachments/assets/01ac0f02-9f73-4424-9b50-7bc4ecf3fe26

같은 useEffect 안에 사진 에러 로직과 체크박스 에러 로직을 넣어놔서
체크박스 에러가 변경이 될 때 사진 에러에 대한 로직이 적용되어서 그랬던 거 였습니다

일단 둘을 분리함으로써 해결해줄 수 있었어요

#### navigate를 해준 이유
사진 같은 경우 input을 안 보이게 설정하고 div와 label 태그를 이용해서 사진을 렌더링 해주고 있는데요
이 때문에 최종 제출 버튼 클릭 시 빈칸임에도 불구하고 자동 focus가 되지 않더라고요 (setFocus도 안 되어요ㅜ)

체크박스가 현재 화면에 보이지 않을 때 자동 포커스가 되는데 아래 사진처럼 헤더에 가려져있을 때는 안 되더라고요
아마 현재 화면에 표시되고 있는데 헤더에 가려져서 안 보이는 것처럼 보일 뿐이라 그런 거 같아요
<img width="342" alt="스크린샷 2024-08-08 오후 11 48 42" src="https://github.com/user-attachments/assets/ca6ee9b8-01fb-49c8-b44d-7986f9287bbf">

위와 같은 이유로 navigate를 써주기로 했어요

#### 체크박스 로직
```tsx
if (
  (Object.keys(errors).length === 2 && errors.attendance && errors.personalInformation) ||
  (Object.keys(errors).length === 1 && (errors.attendance || errors.personalInformation))
)
```
체크박스가 포커스 되어야 할 경우는 오로지 체크박스에만 에러가 발생했을 경우예요
그 외의 경우는 모두 다른 에러 쪽으로 포커스가 가야 하거든요
그래서 위와 같이 길게 작성해주었습니다

<br />

### 🥕 체크박스 바로바로 에러 체크 안 되는 이슈 해결
react-hook-form의 mode가 onBlur로 되어 있어서 체크박스 클릭 후 다른 곳을 클릭해야 에러 체크를 하고 있었어요
그래서 onChange 될 때마다 에러 체크 바로 할 수 있게 trigger를 요청했습니다

#### 전
https://github.com/user-attachments/assets/5ef5282d-eac2-4bc9-8afe-cd98caafdd70

#### 후
https://github.com/user-attachments/assets/be5de35e-8318-4fce-9505-2fc48295b230

