### PR TITLE
[Design] Mobile ver. - MyPage 구현

### DIFF
--- a/src/views/MyPage/index.tsx
+++ b/src/views/MyPage/index.tsx
@@ -5,29 +5,49 @@ import Button from '@components/Button';
 import Callout from '@components/Callout';
 import Title from '@components/Title';
 import useDate from '@hooks/useDate';
+import { useDevice } from '@hooks/useDevice';
 import { RecruitingInfoContext } from '@store/recruitingInfoContext';
 import NoMore from 'views/ErrorPage/components/NoMore';
 import BigLoading from 'views/loadings/BigLoding';
 
-import { buttonWidth, container, infoContainer, infoLabel, infoValue, itemWrapper, buttonValue } from './style.css';
+import {
+  itemWrapper,
+  buttonValue,
+  containerVar,
+  infoContainerVar,
+  infoLabelVar,
+  infoValueVar,
+  buttonWidthVar,
+} from './style.css';
 
 const MyInfoItem = ({ label, value }: { label: string; value?: string | number | boolean }) => {
+  const DEVICE_TYPE = useDevice();
+
   return (
     <li className={itemWrapper}>
-      <span className={infoLabel}>{label}</span>
-      <span className={infoValue}>{value}</span>
+      <span className={infoLabelVar[DEVICE_TYPE]}>{label}</span>
+      <span className={infoValueVar[DEVICE_TYPE]}>{value}</span>
     </li>
   );
 };
 
-const StatusButton = ({ label, to, trackingEvent }: { label: string; to: string; trackingEvent: string }) => (
-  <li className={buttonValue}>
-    <span className={infoLabel}>{label}</span>
-    <Button isLink to={to} className={buttonWidth} onClick={() => track(trackingEvent)} padding="15x25">
-      {label === '지원서' ? '지원서 확인' : '결과 확인'}
-    </Button>
-  </li>
-);
+const StatusButton = ({ label, to, trackingEvent }: { label: string; to: string; trackingEvent: string }) => {
+  const DEVICE_TYPE = useDevice();
+
+  return (
+    <li className={buttonValue}>
+      <span className={infoLabelVar[DEVICE_TYPE]}>{label}</span>
+      <Button
+        isLink
+        to={to}
+        className={buttonWidthVar[DEVICE_TYPE]}
+        onClick={() => track(trackingEvent)}
+        padding="15x25">
+        {label === '지원서' ? '지원서 확인' : '결과 확인'}
+      </Button>
+    </li>
+  );
+};
 
 interface MyPageProps {
   part?: string;
@@ -35,6 +55,7 @@ interface MyPageProps {
 }
 
 const MyPage = ({ part, applicationPass }: MyPageProps) => {
+  const DEVICE_TYPE = useDevice();
   const {
     recruitingInfo: { name, season },
   } = useContext(RecruitingInfoContext);
@@ -44,10 +65,10 @@ const MyPage = ({ part, applicationPass }: MyPageProps) => {
   if (NoMoreRecruit) return <NoMore isMakers={isMakers} content="모집 기간이 아니에요" />;
 
   return (
-    <section className={container}>
+    <section className={containerVar[DEVICE_TYPE]}>
       <Title>지원 현황</Title>
       <Callout>{`지원서는 면접 이후부터 열람이 불가하오니\n백업해두시길 바랍니다.`}</Callout>
-      <ol className={infoContainer}>
+      <ol className={infoContainerVar[DEVICE_TYPE]}>
         <MyInfoItem label="기수" value={season} />
         <MyInfoItem label="이름" value={name} />
         <MyInfoItem label="지원파트" value={part} />

--- a/src/views/MyPage/index.tsx
+++ b/src/views/MyPage/index.tsx
@@ -1,5 +1,5 @@
 import { track } from '@amplitude/analytics-browser';
-import { useContext } from 'react';
+import { MouseEvent, useContext } from 'react';
 
 import Button from '@components/Button';
 import Callout from '@components/Callout';
@@ -34,15 +34,25 @@ const MyInfoItem = ({ label, value }: { label: string; value?: string | number |
 const StatusButton = ({ label, to, trackingEvent }: { label: string; to: string; trackingEvent: string }) => {
   const DEVICE_TYPE = useDevice();
 
+  const handlePreventMobile = (e: MouseEvent<HTMLButtonElement>) => {
+    track(trackingEvent);
+
+    const isMobile = /Mobi/i.test(window.navigator.userAgent);
+    if (isMobile) {
+      alert('PC로 이용해주세요.');
+      e.preventDefault();
+      return;
+    }
+    if (DEVICE_TYPE !== 'DESK') {
+      alert('전체화면 이용을 권장드려요.');
+      return;
+    }
+  };
+
   return (
     <li className={buttonValue}>
       <span className={infoLabelVar[DEVICE_TYPE]}>{label}</span>
-      <Button
-        isLink
-        to={to}
-        className={buttonWidthVar[DEVICE_TYPE]}
-        onClick={() => track(trackingEvent)}
-        padding="15x25">
+      <Button isLink to={to} className={buttonWidthVar[DEVICE_TYPE]} onClick={handlePreventMobile} padding="15x25">
         {label === '지원서' ? '지원서 확인' : '결과 확인'}
       </Button>
     </li>

--- a/src/views/MyPage/style.css.ts
+++ b/src/views/MyPage/style.css.ts
@@ -1,24 +1,68 @@
-import { style } from '@vanilla-extract/css';
+import { style, styleVariants } from '@vanilla-extract/css';
 
 import { theme } from 'styles/theme.css';
 
-export const container = style({
+const container = style({
   display: 'flex',
   flexDirection: 'column',
-  gap: 50,
   justifyContent: 'center',
-  margin: 95,
 });
 
-export const infoContainer = style({
+export const containerVar = styleVariants({
+  DESK: [
+    container,
+    {
+      gap: 50,
+      marginTop: 90,
+    },
+  ],
+  TAB: [
+    container,
+    {
+      gap: 50,
+      marginTop: 90,
+    },
+  ],
+  MOB: [
+    container,
+    {
+      gap: 30,
+      marginTop: 23,
+    },
+  ],
+});
+
+const infoContainer = style({
   display: 'flex',
   flexDirection: 'column',
   justifyContent: 'space-between',
-  width: 467,
   height: 455,
-  padding: '38px 80px',
   border: `1px solid ${theme.color.border}`,
   borderRadius: 18,
+});
+
+export const infoContainerVar = styleVariants({
+  DESK: [
+    infoContainer,
+    {
+      width: 467,
+      padding: '38px 80px',
+    },
+  ],
+  TAB: [
+    infoContainer,
+    {
+      width: 367,
+      padding: '38px 50px',
+    },
+  ],
+  MOB: [
+    infoContainer,
+    {
+      width: 312,
+      padding: '38px 34px',
+    },
+  ],
 });
 
 export const itemWrapper = style({
@@ -27,17 +71,53 @@ export const itemWrapper = style({
   justifyContent: 'space-between',
 });
 
-export const infoLabel = style({
-  width: 63,
-  color: theme.color.lighterText,
-  ...theme.font.BODY_1_18_M,
+export const infoLabelVar = styleVariants({
+  DESK: {
+    width: 63,
+    color: theme.color.lighterText,
+    ...theme.font.BODY_1_18_M,
+  },
+  TAB: {
+    width: 63,
+    color: theme.color.lighterText,
+    ...theme.font.BODY_1_18_M,
+  },
+  MOB: {
+    width: 56,
+    color: theme.color.lighterText,
+    ...theme.font.BODY_2_16_M,
+  },
 });
 
-export const infoValue = style({
+const infoValue = style({
   width: 132,
   color: theme.color.baseText,
   textAlign: 'center',
   ...theme.font.TITLE_5_18_SB,
+});
+
+export const infoValueVar = styleVariants({
+  DESK: [
+    infoValue,
+    {
+      width: 132,
+      ...theme.font.TITLE_5_18_SB,
+    },
+  ],
+  TAB: [
+    infoValue,
+    {
+      width: 132,
+      ...theme.font.TITLE_5_18_SB,
+    },
+  ],
+  MOB: [
+    infoValue,
+    {
+      width: 111,
+      ...theme.font.TITLE_6_16_SB,
+    },
+  ],
 });
 
 export const buttonValue = style([
@@ -47,6 +127,17 @@ export const buttonValue = style([
   },
 ]);
 
-export const buttonWidth = style({
-  width: 133,
+export const buttonWidthVar = styleVariants({
+  DESK: {
+    width: 132,
+    letterSpacing: '-0.36px',
+  },
+  TAB: {
+    width: 132,
+    letterSpacing: '-0.36px',
+  },
+  MOB: {
+    width: 111,
+    letterSpacing: '-0.24px',
+  },
 });

--- a/src/views/MyPage/style.css.ts
+++ b/src/views/MyPage/style.css.ts
@@ -13,21 +13,21 @@ export const containerVar = styleVariants({
     container,
     {
       gap: 50,
-      marginTop: 90,
+      margin: '90px 0 70px',
     },
   ],
   TAB: [
     container,
     {
       gap: 50,
-      marginTop: 90,
+      margin: '90px 0 191px',
     },
   ],
   MOB: [
     container,
     {
       gap: 30,
-      marginTop: 23,
+      margin: '23px 0 74px',
     },
   ],
 });

--- a/src/views/MyPage/style.css.ts
+++ b/src/views/MyPage/style.css.ts
@@ -127,17 +127,31 @@ export const buttonValue = style([
   },
 ]);
 
+const buttonWidth = style({
+  paddingLeft: 0,
+  paddingRight: 0,
+});
+
 export const buttonWidthVar = styleVariants({
-  DESK: {
-    width: 132,
-    letterSpacing: '-0.36px',
-  },
-  TAB: {
-    width: 132,
-    letterSpacing: '-0.36px',
-  },
-  MOB: {
-    width: 111,
-    letterSpacing: '-0.24px',
-  },
+  DESK: [
+    buttonWidth,
+    {
+      width: 132,
+      letterSpacing: '-0.36px',
+    },
+  ],
+  TAB: [
+    buttonWidth,
+    {
+      width: 132,
+      letterSpacing: '-0.36px',
+    },
+  ],
+  MOB: [
+    buttonWidth,
+    {
+      width: 111,
+      letterSpacing: '-0.24px',
+    },
+  ],
 });

--- a/src/views/SignedInPage/index.tsx
+++ b/src/views/SignedInPage/index.tsx
@@ -33,9 +33,10 @@ const SignedInPage = () => {
 
   return (
     <>
-      {isComplete && <CompletePage />}
+      <MyPage part={part} applicationPass={applicationPass} />
+      {/* {isComplete && <CompletePage />}
       {!isComplete && submit && <MyPage part={part} applicationPass={applicationPass} />}
-      {!isComplete && !submit && <ApplyPage onSetComplete={handleSetComplete} />}
+      {!isComplete && !submit && <ApplyPage onSetComplete={handleSetComplete} />} */}
     </>
   );
 };

--- a/src/views/SignedInPage/index.tsx
+++ b/src/views/SignedInPage/index.tsx
@@ -34,9 +34,9 @@ const SignedInPage = () => {
   return (
     <>
       <MyPage part={part} applicationPass={applicationPass} />
-      {/* {isComplete && <CompletePage />}
+      {isComplete && <CompletePage />}
       {!isComplete && submit && <MyPage part={part} applicationPass={applicationPass} />}
-      {!isComplete && !submit && <ApplyPage onSetComplete={handleSetComplete} />} */}
+      {!isComplete && !submit && <ApplyPage onSetComplete={handleSetComplete} />}
     </>
   );
 };


### PR DESCRIPTION
**Related Issue :** Closes #372 

---

## 🧑‍🎤 Summary
반응형 마이페이지를 구현했습니다 

## 🧑‍🎤 Screenshot
> 반응형 

https://github.com/user-attachments/assets/3e9d6731-8cc7-40c8-9aaf-9ac0b0fcea25

> 모바일, 작은창 접속 막기 

https://github.com/user-attachments/assets/13dce1fd-6ccd-4c53-a808-01ca4471fcc7



https://github.com/user-attachments/assets/de4fc89a-efe4-43ae-97b9-b11a549ca601



## 🧑‍🎤 Comment

🚀 **마이페이지 반응형 작업** 
다 styleVary만 쳐주면 되는거라 무리없이 작업했습니다 
([반응형 요소들 정리한 노션](https://lydiacho.notion.site/MAKERS-mob-0823bc9402ee47f5a24cc6af3768e993?pvs=4))

🚀 **ReviewPage 접속 제한** 
전에 이야기했던 대로 ReviewPage는 우선 반응형 작업 미루고, 따라서 `지원서 확인` 클릭 시 사용자 상태를 체크해서 접속 제한 처리를 해줬는데요, 
두가지 케이스가 있어요 
- 모바일로 접속 : userAgent를 통해 사용자 디바이스 환경을 체크
- 작은 창으로 접속 : useDevice 훅 사용해서 창 크기가 768이하인지 체크 

이때 모바일로 접속하면 무조건 'PC로 접속하라'는 alert 띄우고 **이동을 막으면** 되는데, 
PC에서 작은 창으로 접속할 경우에도 PC로 접속하라는 alert을 띄우는게 부적절하다고 생각해서 '전체화면 이용을 권장드려요' 라고 alert 문구를 바꿔줬는데요, 
이와 동시에 이렇게 권장드린다는 말을 하고나서 이동까지 아예 막아버리는 것보다, 그냥 사용자가 알아서 창 크기 키우겠거니 하고 페이지 이동은 정상적으로 진행시키는게 낫다는 생각이 들었어요. 

그래서 정리하자면 
- 모바일로 접속 : 'PC로 이용해주세요' alert + navigate 막기 
- 작은 창으로 접속 : '전체화면 이용을 권장드려요' alert + navigate 진행 

이렇게 일단 구현해주었습니다. 
제가 임의로 정한거라, 이견 있으시면 반영할게요!! 

🚀 **Button padding left, right 0 처리** 
깨지고 있는 letterSpacing까지 제대로 다시 넣어줬는데도 모바일 화면에서 줄바꿈이 발생하길래 왜지 했는데 
피그마 상에서 padding 영역이 이렇더라고요? 
![image](https://github.com/user-attachments/assets/20cbc059-9232-4974-bc8d-940086364ce0)

영역을 제대로 안보고 padding을 15, 25로 주니까 깨졌던 거였고, 
이메일 버튼 깨짐 이슈 때처럼 padding left, right 0으로 줘서 해결했어요 

