### PR TITLE
[Design] Mobile ver. - ErrorPage 구현

### DIFF
--- a/src/views/CompletePage/style.css.ts
+++ b/src/views/CompletePage/style.css.ts
@@ -9,12 +9,12 @@ export const container = style({
   alignItems: 'center',
   justifyContent: 'center',
   width: 550,
-  height: calc.subtract('100vh', '74px'),
+  height: calc.subtract('100vh', '80px'),
   minHeight: 700,
 
   '@supports': {
     '(height: 100dvh)': {
-      height: calc.subtract('100dvh', '74px'),
+      height: calc.subtract('100dvh', '80px'),
     },
   },
 });

--- a/src/views/ErrorPage/components/ErrorCode/index.tsx
+++ b/src/views/ErrorPage/components/ErrorCode/index.tsx
@@ -1,3 +1,4 @@
+import { useDevice } from '@hooks/useDevice';
 import Icon404Back from 'views/ErrorPage/icons/Icon404Back';
 import Icon404Front from 'views/ErrorPage/icons/Icon404Front';
 import Icon500Back from 'views/ErrorPage/icons/Icon500Back';
@@ -5,34 +6,45 @@ import Icon500Front from 'views/ErrorPage/icons/Icon500Front';
 import IconCone from 'views/ErrorPage/icons/IconCone';
 import IconGhost from 'views/ErrorPage/icons/IconGhost';
 
-import { backText, frontText, iconWrapper, showIcon } from './style.css';
+import { backText, frontText, iconWrapperVar, showIconVar } from './style.css';
 
 export default function ErrorCode({ code }: { code: 404 | 500 }) {
+  const DEVICE_TYPE = useDevice();
+  const isMobile = DEVICE_TYPE === 'MOB';
+
   return (
-    <div className={iconWrapper}>
+    <div className={iconWrapperVar[DEVICE_TYPE]}>
       {code === 404 ? (
         <>
-          <i className={frontText}>
-            <Icon404Front />
-          </i>
-          <i className={showIcon}>
+          {!isMobile && (
+            <i className={frontText}>
+              <Icon404Front />
+            </i>
+          )}
+          <i className={showIconVar[DEVICE_TYPE]}>
             <IconGhost />
           </i>
-          <i className={backText}>
-            <Icon404Back />
-          </i>
+          {!isMobile && (
+            <i className={backText}>
+              <Icon404Back />
+            </i>
+          )}
         </>
       ) : (
         <>
-          <i className={frontText}>
-            <Icon500Front />
-          </i>
-          <i className={showIcon}>
+          {!isMobile && (
+            <i className={frontText}>
+              <Icon500Front />
+            </i>
+          )}
+          <i className={showIconVar[DEVICE_TYPE]}>
             <IconCone />
           </i>
-          <i className={backText}>
-            <Icon500Back />
-          </i>
+          {!isMobile && (
+            <i className={backText}>
+              <Icon500Back />
+            </i>
+          )}
         </>
       )}
     </div>

--- a/src/views/ErrorPage/components/ErrorCode/style.css.ts
+++ b/src/views/ErrorPage/components/ErrorCode/style.css.ts
@@ -1,10 +1,30 @@
-import { style } from '@vanilla-extract/css';
+import { style, styleVariants } from '@vanilla-extract/css';
 
-export const iconWrapper = style({
+const iconWrapper = style({
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',
-  marginBottom: 43,
+});
+
+export const iconWrapperVar = styleVariants({
+  DESK: [
+    iconWrapper,
+    {
+      marginBottom: 43,
+    },
+  ],
+  TAB: [
+    iconWrapper,
+    {
+      marginBottom: 43,
+    },
+  ],
+  MOB: [
+    iconWrapper,
+    {
+      marginBottom: 24,
+    },
+  ],
 });
 
 export const frontText = style({
@@ -18,8 +38,7 @@ export const frontText = style({
   },
 });
 
-export const showIcon = style({
-  opacity: 0,
+const showIcon = style({
   transition: 'all 0.3s ease',
 
   selectors: {
@@ -27,6 +46,27 @@ export const showIcon = style({
       opacity: 1,
     },
   },
+});
+
+export const showIconVar = styleVariants({
+  DESK: [
+    showIcon,
+    {
+      opacity: 0,
+    },
+  ],
+  TAB: [
+    showIcon,
+    {
+      opacity: 0,
+    },
+  ],
+  MOB: [
+    showIcon,
+    {
+      opacity: 1,
+    },
+  ],
 });
 
 export const backText = style({

--- a/src/views/ErrorPage/components/NoMore/index.tsx
+++ b/src/views/ErrorPage/components/NoMore/index.tsx
@@ -1,6 +1,8 @@
 import { track } from '@amplitude/analytics-browser';
 
-import { article, contactButton, container, errorButton, errorText, instruction } from '../../style.css';
+import { useDevice } from '@hooks/useDevice';
+
+import { article, contactButtonVar, container, errorButtonVar, errorText, instructionVar } from '../../style.css';
 
 interface NoMoreProps {
   isMakers?: boolean;
@@ -8,26 +10,28 @@ interface NoMoreProps {
 }
 
 const NoMore = ({ isMakers, content }: NoMoreProps) => {
+  const DEVICE_TYPE = useDevice();
+
   return (
     <section className={container[isMakers == undefined ? 'withoutHeader' : 'withHeader']}>
       <article className={article}>
         <p className={errorText}>{content}</p>
         <a
           href={isMakers ? 'https://makers.sopt.org/' : 'https://www.sopt.org/'}
-          className={errorButton}
+          className={errorButtonVar[DEVICE_TYPE]}
           target="_blank"
           rel="noreferrer noopener"
           onClick={() => track(isMakers ? 'click-nomore-official_makers' : 'click-nomore-official')}>
           공식 홈페이지 가기
         </a>
       </article>
-      <p className={instruction}>{`문의사항이 있다면\n아래 ‘문의하기’를 이용해 주세요`}</p>
+      <p className={instructionVar[DEVICE_TYPE]}>{`문의사항이 있다면\n아래 ‘문의하기’를 이용해 주세요`}</p>
       <a
         id="chat-channel-button"
         href={isMakers ? 'https://pf.kakao.com/_sxaIWG' : 'https://pf.kakao.com/_JdTKd'}
         target="_blank"
         rel="noreferrer noopener"
-        className={contactButton}
+        className={contactButtonVar[DEVICE_TYPE]}
         onClick={() => track(isMakers ? 'click-nomore-ask_makers' : 'click-nomore-ask')}>
         문의하기
       </a>

--- a/src/views/ErrorPage/components/NoMore/index.tsx
+++ b/src/views/ErrorPage/components/NoMore/index.tsx
@@ -13,7 +13,7 @@ const NoMore = ({ isMakers, content }: NoMoreProps) => {
   const DEVICE_TYPE = useDevice();
 
   return (
-    <section className={container[isMakers == undefined ? 'withoutHeader' : 'withHeader']}>
+    <section className={container}>
       <article className={article}>
         <p className={errorText}>{content}</p>
         <a

--- a/src/views/ErrorPage/components/NoMore/index.tsx
+++ b/src/views/ErrorPage/components/NoMore/index.tsx
@@ -2,7 +2,7 @@ import { track } from '@amplitude/analytics-browser';
 
 import { useDevice } from '@hooks/useDevice';
 
-import { article, contactButtonVar, container, errorButtonVar, errorText, instructionVar } from '../../style.css';
+import { article, contactButtonVar, container, errorButtonVar, errorTextVar, instructionVar } from '../../style.css';
 
 interface NoMoreProps {
   isMakers?: boolean;
@@ -15,7 +15,7 @@ const NoMore = ({ isMakers, content }: NoMoreProps) => {
   return (
     <section className={container}>
       <article className={article}>
-        <p className={errorText}>{content}</p>
+        <p className={errorTextVar[DEVICE_TYPE]}>{content}</p>
         <a
           href={isMakers ? 'https://makers.sopt.org/' : 'https://www.sopt.org/'}
           className={errorButtonVar[DEVICE_TYPE]}

--- a/src/views/ErrorPage/index.tsx
+++ b/src/views/ErrorPage/index.tsx
@@ -1,9 +1,7 @@
 import { track } from '@amplitude/analytics-browser';
-import { useContext } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import { useDevice } from '@hooks/useDevice';
-import { RecruitingInfoContext } from '@store/recruitingInfoContext';
 
 import ErrorCode from './components/ErrorCode';
 import { ERROR_MESSAGE } from './constants';
@@ -12,10 +10,6 @@ import { article, contactButtonVar, container, errorButtonVar, errorTextVar, ins
 const ErrorPage = ({ code }: { code: 404 | 500 }) => {
   const DEVICE_TYPE = useDevice();
   const navigate = useNavigate();
-
-  const {
-    recruitingInfo: { isMakers },
-  } = useContext(RecruitingInfoContext);
 
   const handleGoBack = (code: 404 | 500) => {
     const hasPreviousPage = window.history.length > 1;
@@ -35,7 +29,7 @@ const ErrorPage = ({ code }: { code: 404 | 500 }) => {
   const CODE_KEY: 'CODE404' | 'CODE500' = `CODE${code}`;
 
   return (
-    <section className={container[isMakers == undefined ? 'withoutHeader' : 'withHeader']}>
+    <section className={container}>
       <article className={article}>
         <ErrorCode code={code} />
         <p className={errorTextVar[DEVICE_TYPE]}>{ERROR_MESSAGE[CODE_KEY]?.text}</p>

--- a/src/views/ErrorPage/index.tsx
+++ b/src/views/ErrorPage/index.tsx
@@ -2,13 +2,15 @@ import { track } from '@amplitude/analytics-browser';
 import { useContext } from 'react';
 import { useNavigate } from 'react-router-dom';
 
+import { useDevice } from '@hooks/useDevice';
 import { RecruitingInfoContext } from '@store/recruitingInfoContext';
 
 import ErrorCode from './components/ErrorCode';
 import { ERROR_MESSAGE } from './constants';
-import { article, contactButton, container, errorButton, errorText, instruction } from './style.css';
+import { article, contactButtonVar, container, errorButtonVar, errorTextVar, instructionVar } from './style.css';
 
 const ErrorPage = ({ code }: { code: 404 | 500 }) => {
+  const DEVICE_TYPE = useDevice();
   const navigate = useNavigate();
 
   const {
@@ -36,18 +38,21 @@ const ErrorPage = ({ code }: { code: 404 | 500 }) => {
     <section className={container[isMakers == undefined ? 'withoutHeader' : 'withHeader']}>
       <article className={article}>
         <ErrorCode code={code} />
-        <p className={errorText}>{ERROR_MESSAGE[CODE_KEY]?.text}</p>
-        <button className={errorButton} onClick={handleClickErrorButton}>
+        <p className={errorTextVar[DEVICE_TYPE]}>{ERROR_MESSAGE[CODE_KEY]?.text}</p>
+        <button className={errorButtonVar[DEVICE_TYPE]} onClick={handleClickErrorButton}>
           {ERROR_MESSAGE[CODE_KEY]?.button}
         </button>
       </article>
-      <p className={instruction}>{`문제가 지속적으로 발생하거나 문의사항이 있다면\n아래 ‘문의하기’를 이용해 주세요`}</p>
+      <p
+        className={
+          instructionVar[DEVICE_TYPE]
+        }>{`문제가 지속적으로 발생하거나 문의사항이 있다면\n아래 ‘문의하기’를 이용해 주세요`}</p>
       <a
         id="chat-channel-button"
         href="http://pf.kakao.com/_sxaIWG"
         target="_blank"
         rel="noreferrer noopener"
-        className={contactButton}
+        className={contactButtonVar[DEVICE_TYPE]}
         onClick={() => track('click-error-ask')}>
         문의하기
       </a>

--- a/src/views/ErrorPage/style.css.ts
+++ b/src/views/ErrorPage/style.css.ts
@@ -55,38 +55,129 @@ export const article = style({
 });
 
 export const errorText = style({
-  marginBottom: 28,
   color: theme.color.baseText,
-  ...theme.font.TITLE_2_28_SB,
 });
 
-export const errorButton = style({
+export const errorTextVar = styleVariants({
+  DESK: [
+    errorText,
+    {
+      marginBottom: 28,
+      ...theme.font.TITLE_2_28_SB,
+    },
+  ],
+  TAB: [
+    errorText,
+    {
+      marginBottom: 28,
+      ...theme.font.TITLE_2_28_SB,
+    },
+  ],
+  MOB: [
+    errorText,
+    {
+      marginBottom: 24,
+      ...theme.font.TITLE_3_24_SB,
+    },
+  ],
+});
+
+const errorButton = style({
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',
-  width: 231,
-  height: 60,
-  marginBottom: 135,
+
   borderRadius: 99,
   backgroundColor: theme.color.errorButtonBackground,
-  ...theme.font.TITLE_3_24_SB,
 });
 
-export const instruction = style({
-  marginBottom: 20,
+export const errorButtonVar = styleVariants({
+  DESK: [
+    errorButton,
+    {
+      width: 231,
+      height: 60,
+      marginBottom: 135,
+      ...theme.font.TITLE_3_24_SB,
+    },
+  ],
+  TAB: [
+    errorButton,
+    {
+      width: 202,
+      height: 54,
+      marginBottom: 140,
+      ...theme.font.TITLE_4_20_SB,
+    },
+  ],
+  MOB: [
+    errorButton,
+    {
+      width: 175,
+      height: 44,
+      marginBottom: 140,
+      ...theme.font.TITLE_5_18_SB,
+    },
+  ],
+});
+
+const instruction = style({
   color: theme.color.lightestText,
   textAlign: 'center',
   whiteSpace: 'pre-line',
-  ...theme.font.BODY_1_18_M,
 });
 
-export const contactButton = style({
+export const instructionVar = styleVariants({
+  DESK: [
+    instruction,
+    {
+      marginBottom: 20,
+      ...theme.font.BODY_1_18_M,
+    },
+  ],
+  TAB: [
+    instruction,
+    {
+      marginBottom: 24,
+      ...theme.font.BODY_2_16_M,
+    },
+  ],
+  MOB: [
+    instruction,
+    {
+      marginBottom: 24,
+      ...theme.font.BODY_3_14_M,
+    },
+  ],
+});
+
+const contactButton = style({
   display: 'block',
-  fontSize: 24,
-  fontWeight: '600',
-  lineHeight: '150%' /* 36px */,
-  letterSpacing: '-0.48px',
   textDecorationLine: 'underline',
   margin: '0 auto',
   color: theme.color.buttonText,
+});
+
+export const contactButtonVar = styleVariants({
+  DESK: [
+    contactButton,
+    {
+      fontSize: 24,
+      fontWeight: '600',
+      lineHeight: '150%' /* 36px */,
+      letterSpacing: '-0.48px',
+    },
+  ],
+  TAB: [
+    contactButton,
+    {
+      ...theme.font.HEADING_5_20_B,
+    },
+  ],
+  MOB: [
+    contactButton,
+    {
+      ...theme.font.TITLE_5_18_SB,
+    },
+  ],
 });

--- a/src/views/ErrorPage/style.css.ts
+++ b/src/views/ErrorPage/style.css.ts
@@ -22,11 +22,11 @@ export const container = styleVariants({
   withHeader: [
     containerBase,
     {
-      height: calc.subtract('100vh', '74px'),
+      height: calc.subtract('100vh', '80px'),
 
       '@supports': {
         'height: (100dvh)': {
-          height: calc.subtract('100dvh', '74px'),
+          height: calc.subtract('100dvh', '80px'),
         },
       },
     },
@@ -34,11 +34,13 @@ export const container = styleVariants({
   withoutHeader: [
     containerBase,
     {
-      height: '100vh',
+      // height: '100vh',
+      height: calc.subtract('100vh', '80px'),
 
       '@supports': {
         'height: (100dvh)': {
-          height: '100dvh',
+          // height: '100dvh',
+          height: calc.subtract('100dvh', '80px'),
         },
       },
     },

--- a/src/views/ErrorPage/style.css.ts
+++ b/src/views/ErrorPage/style.css.ts
@@ -3,48 +3,20 @@ import { calc } from '@vanilla-extract/css-utils';
 
 import { theme } from 'styles/theme.css';
 
-const containerBase = style({
+export const container = style({
   display: 'flex',
   flexDirection: 'column',
   alignItems: 'center',
   justifyContent: 'center',
   width: '100%',
+  height: calc.subtract('100vh', '80px'),
   minHeight: 700,
 
   '@supports': {
     'height: (100dvh)': {
-      height: '100dvh',
+      height: calc.subtract('100dvh', '80px'),
     },
   },
-});
-
-export const container = styleVariants({
-  withHeader: [
-    containerBase,
-    {
-      height: calc.subtract('100vh', '80px'),
-
-      '@supports': {
-        'height: (100dvh)': {
-          height: calc.subtract('100dvh', '80px'),
-        },
-      },
-    },
-  ],
-  withoutHeader: [
-    containerBase,
-    {
-      // height: '100vh',
-      height: calc.subtract('100vh', '80px'),
-
-      '@supports': {
-        'height: (100dvh)': {
-          // height: '100dvh',
-          height: calc.subtract('100dvh', '80px'),
-        },
-      },
-    },
-  ],
 });
 
 export const article = style({

--- a/src/views/ErrorPage/style.css.ts
+++ b/src/views/ErrorPage/style.css.ts
@@ -26,7 +26,7 @@ export const article = style({
   width: '100%',
 });
 
-export const errorText = style({
+const errorText = style({
   color: theme.color.baseText,
 });
 

--- a/src/views/loadings/BigLoding/style.css.ts
+++ b/src/views/loadings/BigLoding/style.css.ts
@@ -9,11 +9,11 @@ export const container = style({
   alignItems: 'center',
   justifyContent: 'center',
   width: '100%',
-  height: calc.subtract('100vh', '74px'),
+  height: calc.subtract('100vh', '80px'),
 
   '@supports': {
     'height: (100dvh)': {
-      height: calc.subtract('100dvh', '74px'),
+      height: calc.subtract('100dvh', '80px'),
     },
   },
 });


### PR DESCRIPTION
**Related Issue :** Closes #378 

---

## 🧑‍🎤 Summary
- [x] error page 반응형 구현
- [x] no more page 반응형 구현
- [x] 헤더 자리 padding 80px으로 변경됨에 따른 error page 컨텐츠 높이 다시 계산

## 🧑‍🎤 Screenshot
![스크린샷 2024-08-13 오후 3 48 02](https://github.com/user-attachments/assets/7f91a110-bedb-473f-9547-9f0f5b56d840)
![스크린샷 2024-08-13 오후 3 48 53](https://github.com/user-attachments/assets/4cef8e9a-ac80-46b5-873d-d1c66f18c7bb)

## 🧑‍🎤 Comment
단순 작업이라 크게 어려움은 없었어요

header를 sticky에서 fixed로 변경하면서 padding을 80 추가 해준 덕분에 
에러 페이지에서 헤더가 있는지 없는지에 따라 조건부로 height을 계산할 필요가 없어졌어요
헤더 있든 없든 padding 80은 항상 존재하니까요
다만 기존에는 74로 설정이 되어있었기에 이를 다 80으로 수정했어요

no more page는 제가 만든 페이지라 디자인이 없어요 😅
해당 페이지 만들 때 error page를 참고하여 만든 거기 때문에 에러 페이지와 동일하게 적용해줬어요
