### PR TITLE
[Design] Mobile ver. - Dialog 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,7 +12,6 @@ import Layout from '@components/Layout';
 import { RecruitingInfoContext, RecruitingInfoType } from '@store/recruitingInfoContext';
 import { ModeType, ThemeContext } from '@store/themeContext';
 import { dark, light } from 'styles/theme.css';
-import SessionExpiredDialog from 'views/dialogs/SessionExpiredDialog';
 import ErrorPage from 'views/ErrorPage';
 import MainPage from 'views/MainPage';
 import PasswordPage from 'views/PasswordPage';
@@ -21,6 +20,7 @@ import ReviewPage from 'views/ReviewPage';
 import SignupPage from 'views/SignupPage';
 
 import 'styles/reset.css';
+import { SessionExpiredDialog } from 'views/dialogs';
 
 const router = createBrowserRouter([
   {

--- a/src/common/components/Dialog/index.tsx
+++ b/src/common/components/Dialog/index.tsx
@@ -1,15 +1,19 @@
 import { forwardRef, type DialogHTMLAttributes, type ReactNode } from 'react';
 import { createPortal } from 'react-dom';
 
-import { container } from './style.css';
+import { useDevice } from '@hooks/useDevice';
+
+import { containerVar } from './style.css';
 
 interface DialogProps extends DialogHTMLAttributes<HTMLDialogElement> {
   children?: ReactNode;
 }
 
 const Dialog = forwardRef<HTMLDialogElement, DialogProps>(({ children, ...dialogElementProps }: DialogProps, ref) => {
+  const DEVICE_TYPE = useDevice();
+
   return createPortal(
-    <dialog ref={ref} className={container} {...dialogElementProps}>
+    <dialog ref={ref} className={containerVar[DEVICE_TYPE]} {...dialogElementProps}>
       {children}
     </dialog>,
     document.getElementById('modal')!,

--- a/src/common/components/Dialog/style.css.ts
+++ b/src/common/components/Dialog/style.css.ts
@@ -1,8 +1,7 @@
 import { colors } from '@sopt-makers/colors';
-import { style } from '@vanilla-extract/css';
+import { style, styleVariants } from '@vanilla-extract/css';
 
-export const container = style({
-  width: 400,
+const container = style({
   padding: 24,
   backgroundColor: colors.white, // subBackground
   borderRadius: 14,
@@ -11,4 +10,25 @@ export const container = style({
   '::backdrop': {
     backgroundColor: colors.grayAlpha500, // backgroundDimmed
   },
+});
+
+export const containerVar = styleVariants({
+  DESK: [
+    container,
+    {
+      width: 400,
+    },
+  ],
+  TAB: [
+    container,
+    {
+      width: 400,
+    },
+  ],
+  MOB: [
+    container,
+    {
+      width: 313,
+    },
+  ],
 });

--- a/src/views/ApplyPage/index.tsx
+++ b/src/views/ApplyPage/index.tsx
@@ -7,8 +7,7 @@ import Button from '@components/Button';
 import useCheckBrowser from '@hooks/useCheckBrowser';
 import useDate from '@hooks/useDate';
 import useScrollToHash from '@hooks/useScrollToHash';
-import { DraftDialog, SubmitDialog } from 'views/dialogs';
-import PreventApplyDialog from 'views/dialogs/PreventApplyDialog';
+import { DraftDialog, PreventApplyDialog, SubmitDialog } from 'views/dialogs';
 import NoMore from 'views/ErrorPage/components/NoMore';
 import BigLoading from 'views/loadings/BigLoding';
 

--- a/src/views/ReviewPage/index.tsx
+++ b/src/views/ReviewPage/index.tsx
@@ -14,7 +14,7 @@ import PartSection from 'views/ApplyPage/components/PartSection';
 import useGetDraft from 'views/ApplyPage/hooks/useGetDraft';
 import useGetQuestions from 'views/ApplyPage/hooks/useGetQuestions';
 import { container, formContainer } from 'views/ApplyPage/style.css';
-import PreventReviewDialog from 'views/dialogs/PreventReviewDialog';
+import { PreventReviewDialog } from 'views/dialogs';
 import NoMore from 'views/ErrorPage/components/NoMore';
 import BigLoading from 'views/loadings/BigLoding';
 

--- a/src/views/SignupPage/components/SignupForm/index.tsx
+++ b/src/views/SignupPage/components/SignupForm/index.tsx
@@ -11,7 +11,7 @@ import { PRIVACY_POLICY } from '@constants/policy';
 import { VALIDATION_CHECK } from '@constants/validationCheck';
 import useVerificationStatus from '@hooks/useVerificationStatus';
 import { RecruitingInfoContext } from '@store/recruitingInfoContext';
-import ExistingApplicantDialog from 'views/dialogs/ExistingApplicantDialog';
+import { ExistingApplicantDialog } from 'views/dialogs';
 import useMutateSignUp from 'views/SignupPage/hooks/useMutateSignUp';
 
 import { formWrapper } from './style.css';

--- a/src/views/dialogs/CompleteDialog/index.tsx
+++ b/src/views/dialogs/CompleteDialog/index.tsx
@@ -2,15 +2,18 @@ import { forwardRef } from 'react';
 import { Link } from 'react-router-dom';
 
 import Dialog from '@components/Dialog';
+import { useDevice } from '@hooks/useDevice';
 
-import { buttonInside, buttonOutside, buttonWrapper, mainText, subText } from '../style.css';
+import { buttonInside, buttonOutside, buttonWrapperVar, mainTextVar, subTextVar } from '../style.css';
 
 const CompleteDialog = forwardRef<HTMLDialogElement>((_, ref) => {
+  const DEVICE_TYPE = useDevice();
+
   return (
     <Dialog ref={ref}>
-      <p className={mainText}>비밀번호 재설정이 완료되었어요.</p>
-      <p className={subText}>&apos;로그인&apos; 페이지로 이동할게요.</p>
-      <form method="dialog" className={`${buttonWrapper} ${buttonOutside.solid}`}>
+      <p className={mainTextVar[DEVICE_TYPE]}>비밀번호 재설정이 완료되었어요.</p>
+      <p className={subTextVar[DEVICE_TYPE]}>&apos;로그인&apos; 페이지로 이동할게요.</p>
+      <form method="dialog" className={`${buttonWrapperVar[DEVICE_TYPE]} ${buttonOutside.solid}`}>
         <Link to="/" className={buttonInside.solid}>
           확인
         </Link>

--- a/src/views/dialogs/CompleteDialog/index.tsx
+++ b/src/views/dialogs/CompleteDialog/index.tsx
@@ -4,7 +4,7 @@ import { Link } from 'react-router-dom';
 import Dialog from '@components/Dialog';
 import { useDevice } from '@hooks/useDevice';
 
-import { buttonInside, buttonOutside, buttonWrapperVar, mainTextVar, subTextVar } from '../style.css';
+import { buttonInside, buttonOutside, buttonOutsideVar, buttonWrapperVar, mainTextVar, subTextVar } from '../style.css';
 
 const CompleteDialog = forwardRef<HTMLDialogElement>((_, ref) => {
   const DEVICE_TYPE = useDevice();
@@ -13,7 +13,9 @@ const CompleteDialog = forwardRef<HTMLDialogElement>((_, ref) => {
     <Dialog ref={ref}>
       <p className={mainTextVar[DEVICE_TYPE]}>비밀번호 재설정이 완료되었어요.</p>
       <p className={subTextVar[DEVICE_TYPE]}>&apos;로그인&apos; 페이지로 이동할게요.</p>
-      <form method="dialog" className={`${buttonWrapperVar[DEVICE_TYPE]} ${buttonOutside.solid}`}>
+      <form
+        method="dialog"
+        className={`${buttonWrapperVar[DEVICE_TYPE]} ${buttonOutside.solid} ${buttonOutsideVar[DEVICE_TYPE]}`}>
         <Link to="/" className={buttonInside.solid}>
           확인
         </Link>

--- a/src/views/dialogs/DraftDialog/index.tsx
+++ b/src/views/dialogs/DraftDialog/index.tsx
@@ -3,7 +3,7 @@ import { forwardRef } from 'react';
 import Dialog from '@components/Dialog';
 import { useDevice } from '@hooks/useDevice';
 
-import { buttonInside, buttonOutside, buttonWrapperVar, mainTextVar } from '../style.css';
+import { buttonInside, buttonOutside, buttonOutsideVar, buttonWrapperVar, mainTextVar } from '../style.css';
 
 const DraftDialog = forwardRef<HTMLDialogElement>((_, ref) => {
   const DEVICE_TYPE = useDevice();
@@ -11,7 +11,9 @@ const DraftDialog = forwardRef<HTMLDialogElement>((_, ref) => {
   return (
     <Dialog ref={ref}>
       <p className={mainTextVar[DEVICE_TYPE]}>임시 저장이 완료되었어요.</p>
-      <form method="dialog" className={`${buttonWrapperVar[DEVICE_TYPE]} ${buttonOutside.solid}`}>
+      <form
+        method="dialog"
+        className={`${buttonWrapperVar[DEVICE_TYPE]} ${buttonOutside.solid} ${buttonOutsideVar[DEVICE_TYPE]}`}>
         <button className={buttonInside.solid}>확인</button>
       </form>
     </Dialog>

--- a/src/views/dialogs/DraftDialog/index.tsx
+++ b/src/views/dialogs/DraftDialog/index.tsx
@@ -1,14 +1,17 @@
 import { forwardRef } from 'react';
 
 import Dialog from '@components/Dialog';
+import { useDevice } from '@hooks/useDevice';
 
-import { buttonInside, buttonOutside, buttonWrapper, mainText } from '../style.css';
+import { buttonInside, buttonOutside, buttonWrapperVar, mainTextVar } from '../style.css';
 
 const DraftDialog = forwardRef<HTMLDialogElement>((_, ref) => {
+  const DEVICE_TYPE = useDevice();
+
   return (
     <Dialog ref={ref}>
-      <p className={mainText}>임시 저장이 완료되었어요.</p>
-      <form method="dialog" className={`${buttonWrapper} ${buttonOutside.solid}`}>
+      <p className={mainTextVar[DEVICE_TYPE]}>임시 저장이 완료되었어요.</p>
+      <form method="dialog" className={`${buttonWrapperVar[DEVICE_TYPE]} ${buttonOutside.solid}`}>
         <button className={buttonInside.solid}>확인</button>
       </form>
     </Dialog>

--- a/src/views/dialogs/ExistingApplicantDialog/index.tsx
+++ b/src/views/dialogs/ExistingApplicantDialog/index.tsx
@@ -4,7 +4,7 @@ import { Link } from 'react-router-dom';
 import Dialog from '@components/Dialog';
 import { useDevice } from '@hooks/useDevice';
 
-import { buttonInside, buttonOutside, buttonWrapperVar, mainTextVar } from '../style.css';
+import { buttonInside, buttonOutside, buttonOutsideVar, buttonWrapperVar, mainTextVar } from '../style.css';
 
 const ExistingApplicantDialog = forwardRef<HTMLDialogElement>((_, ref) => {
   const DEVICE_TYPE = useDevice();
@@ -13,7 +13,7 @@ const ExistingApplicantDialog = forwardRef<HTMLDialogElement>((_, ref) => {
     <Dialog ref={ref}>
       <p className={mainTextVar[DEVICE_TYPE]}>이미 가입된 계정이 있어요.</p>
       <div className={buttonWrapperVar[DEVICE_TYPE]}>
-        <form method="dialog" className={buttonOutside.line}>
+        <form method="dialog" className={`${buttonOutside.line} ${buttonOutsideVar[DEVICE_TYPE]}`}>
           <button className={buttonInside.line}>다시 입력하기</button>
         </form>
         <div className={buttonOutside.solid}>

--- a/src/views/dialogs/ExistingApplicantDialog/index.tsx
+++ b/src/views/dialogs/ExistingApplicantDialog/index.tsx
@@ -2,14 +2,17 @@ import { forwardRef } from 'react';
 import { Link } from 'react-router-dom';
 
 import Dialog from '@components/Dialog';
+import { useDevice } from '@hooks/useDevice';
 
-import { buttonInside, buttonOutside, buttonWrapper, mainText } from '../style.css';
+import { buttonInside, buttonOutside, buttonWrapperVar, mainTextVar } from '../style.css';
 
 const ExistingApplicantDialog = forwardRef<HTMLDialogElement>((_, ref) => {
+  const DEVICE_TYPE = useDevice();
+
   return (
     <Dialog ref={ref}>
-      <p className={mainText}>이미 가입된 계정이 있어요.</p>
-      <div className={buttonWrapper}>
+      <p className={mainTextVar[DEVICE_TYPE]}>이미 가입된 계정이 있어요.</p>
+      <div className={buttonWrapperVar[DEVICE_TYPE]}>
         <form method="dialog" className={buttonOutside.line}>
           <button className={buttonInside.line}>다시 입력하기</button>
         </form>

--- a/src/views/dialogs/ExitDialog/index.tsx
+++ b/src/views/dialogs/ExitDialog/index.tsx
@@ -3,7 +3,7 @@ import { forwardRef } from 'react';
 import Dialog from '@components/Dialog';
 import { useDevice } from '@hooks/useDevice';
 
-import { buttonInside, buttonOutside, buttonWrapperVar, mainTextVar, subTextVar } from '../style.css';
+import { buttonInside, buttonOutside, buttonOutsideVar, buttonWrapperVar, mainTextVar, subTextVar } from '../style.css';
 
 const ExitDialog = forwardRef<HTMLDialogElement>((_, ref) => {
   const DEVICE_TYPE = useDevice();
@@ -13,10 +13,10 @@ const ExitDialog = forwardRef<HTMLDialogElement>((_, ref) => {
       <p className={mainTextVar[DEVICE_TYPE]}>이대로 나가시겠어요?</p>
       <p className={subTextVar[DEVICE_TYPE]}>변경사항이 있는 경우 임시저장을 해주세요.</p>
       <div className={buttonWrapperVar[DEVICE_TYPE]}>
-        <form method="dialog" className={buttonOutside.line}>
+        <form method="dialog" className={`${buttonOutside.line} ${buttonOutsideVar[DEVICE_TYPE]}`}>
           <button className={buttonInside.line}>머물기</button>
         </form>
-        <div className={buttonOutside.solid}>
+        <div className={`${buttonOutside.solid} ${buttonOutsideVar[DEVICE_TYPE]}`}>
           <button className={buttonInside.solid}>나가기</button>
         </div>
       </div>

--- a/src/views/dialogs/ExitDialog/index.tsx
+++ b/src/views/dialogs/ExitDialog/index.tsx
@@ -1,15 +1,18 @@
 import { forwardRef } from 'react';
 
 import Dialog from '@components/Dialog';
+import { useDevice } from '@hooks/useDevice';
 
-import { buttonInside, buttonOutside, buttonWrapper, mainText, subText } from '../style.css';
+import { buttonInside, buttonOutside, buttonWrapperVar, mainTextVar, subTextVar } from '../style.css';
 
 const ExitDialog = forwardRef<HTMLDialogElement>((_, ref) => {
+  const DEVICE_TYPE = useDevice();
+
   return (
     <Dialog ref={ref}>
-      <p className={mainText}>이대로 나가시겠어요?</p>
-      <p className={subText}>변경사항이 있는 경우 임시저장을 해주세요.</p>
-      <div className={buttonWrapper}>
+      <p className={mainTextVar[DEVICE_TYPE]}>이대로 나가시겠어요?</p>
+      <p className={subTextVar[DEVICE_TYPE]}>변경사항이 있는 경우 임시저장을 해주세요.</p>
+      <div className={buttonWrapperVar[DEVICE_TYPE]}>
         <form method="dialog" className={buttonOutside.line}>
           <button className={buttonInside.line}>머물기</button>
         </form>

--- a/src/views/dialogs/PreventApplyDialog/index.tsx
+++ b/src/views/dialogs/PreventApplyDialog/index.tsx
@@ -1,18 +1,21 @@
 import { forwardRef, type KeyboardEvent } from 'react';
 
 import Dialog from '@components/Dialog';
+import { useDevice } from '@hooks/useDevice';
 
-import { buttonInside, buttonOutside, buttonWrapper, mainText } from '../style.css';
+import { buttonInside, buttonOutside, buttonWrapperVar, mainTextVar } from '../style.css';
 
 const PreventApplyDialog = forwardRef<HTMLDialogElement>((_, ref) => {
+  const DEVICE_TYPE = useDevice();
+
   const handlePreventESCKeyPress = (e: KeyboardEvent<HTMLDialogElement>) => {
     if (e.key === 'Escape') e.preventDefault();
   };
 
   return (
     <Dialog ref={ref} onKeyDown={handlePreventESCKeyPress}>
-      <p className={mainText}>지원서 제출 기한이 지났어요.</p>
-      <form method="dialog" className={`${buttonWrapper} ${buttonOutside.solid}`}>
+      <p className={mainTextVar[DEVICE_TYPE]}>지원서 제출 기한이 지났어요.</p>
+      <form method="dialog" className={`${buttonWrapperVar[DEVICE_TYPE]} ${buttonOutside.solid}`}>
         <button className={buttonInside.solid}>확인</button>
       </form>
     </Dialog>

--- a/src/views/dialogs/PreventApplyDialog/index.tsx
+++ b/src/views/dialogs/PreventApplyDialog/index.tsx
@@ -3,7 +3,7 @@ import { forwardRef, type KeyboardEvent } from 'react';
 import Dialog from '@components/Dialog';
 import { useDevice } from '@hooks/useDevice';
 
-import { buttonInside, buttonOutside, buttonWrapperVar, mainTextVar } from '../style.css';
+import { buttonInside, buttonOutside, buttonOutsideVar, buttonWrapperVar, mainTextVar } from '../style.css';
 
 const PreventApplyDialog = forwardRef<HTMLDialogElement>((_, ref) => {
   const DEVICE_TYPE = useDevice();
@@ -15,7 +15,9 @@ const PreventApplyDialog = forwardRef<HTMLDialogElement>((_, ref) => {
   return (
     <Dialog ref={ref} onKeyDown={handlePreventESCKeyPress}>
       <p className={mainTextVar[DEVICE_TYPE]}>지원서 제출 기한이 지났어요.</p>
-      <form method="dialog" className={`${buttonWrapperVar[DEVICE_TYPE]} ${buttonOutside.solid}`}>
+      <form
+        method="dialog"
+        className={`${buttonWrapperVar[DEVICE_TYPE]} ${buttonOutside.solid} ${buttonOutsideVar[DEVICE_TYPE]}`}>
         <button className={buttonInside.solid}>확인</button>
       </form>
     </Dialog>

--- a/src/views/dialogs/PreventReviewDialog/index.tsx
+++ b/src/views/dialogs/PreventReviewDialog/index.tsx
@@ -4,7 +4,7 @@ import { Link } from 'react-router-dom';
 import Dialog from '@components/Dialog';
 import { useDevice } from '@hooks/useDevice';
 
-import { buttonInside, buttonOutside, buttonWrapperVar, mainTextVar, subTextVar } from '../style.css';
+import { buttonInside, buttonOutside, buttonOutsideVar, buttonWrapperVar, mainTextVar, subTextVar } from '../style.css';
 
 const PreventReviewDialog = forwardRef<HTMLDialogElement>((_, ref) => {
   const DEVICE_TYPE = useDevice();
@@ -17,7 +17,9 @@ const PreventReviewDialog = forwardRef<HTMLDialogElement>((_, ref) => {
     <Dialog ref={ref} onKeyDown={handlePreventESCKeyPress}>
       <p className={mainTextVar[DEVICE_TYPE]}>지원서 제출을 먼저 해주세요.</p>
       <p className={subTextVar[DEVICE_TYPE]}>&apos;지원서&apos; 페이지로 이동할게요.</p>
-      <form method="dialog" className={`${buttonWrapperVar[DEVICE_TYPE]} ${buttonOutside.solid}`}>
+      <form
+        method="dialog"
+        className={`${buttonWrapperVar[DEVICE_TYPE]} ${buttonOutside.solid} ${buttonOutsideVar[DEVICE_TYPE]}`}>
         <Link to="/" className={buttonInside.solid}>
           확인
         </Link>

--- a/src/views/dialogs/PreventReviewDialog/index.tsx
+++ b/src/views/dialogs/PreventReviewDialog/index.tsx
@@ -2,19 +2,22 @@ import { forwardRef, type KeyboardEvent } from 'react';
 import { Link } from 'react-router-dom';
 
 import Dialog from '@components/Dialog';
+import { useDevice } from '@hooks/useDevice';
 
-import { buttonInside, buttonOutside, buttonWrapper, mainText, subText } from '../style.css';
+import { buttonInside, buttonOutside, buttonWrapperVar, mainTextVar, subTextVar } from '../style.css';
 
 const PreventReviewDialog = forwardRef<HTMLDialogElement>((_, ref) => {
+  const DEVICE_TYPE = useDevice();
+
   const handlePreventESCKeyPress = (e: KeyboardEvent<HTMLDialogElement>) => {
     if (e.key === 'Escape') e.preventDefault();
   };
 
   return (
     <Dialog ref={ref} onKeyDown={handlePreventESCKeyPress}>
-      <p className={mainText}>지원서 제출을 먼저 해주세요.</p>
-      <p className={subText}>&apos;지원서&apos; 페이지로 이동할게요.</p>
-      <form method="dialog" className={`${buttonWrapper} ${buttonOutside.solid}`}>
+      <p className={mainTextVar[DEVICE_TYPE]}>지원서 제출을 먼저 해주세요.</p>
+      <p className={subTextVar[DEVICE_TYPE]}>&apos;지원서&apos; 페이지로 이동할게요.</p>
+      <form method="dialog" className={`${buttonWrapperVar[DEVICE_TYPE]} ${buttonOutside.solid}`}>
         <Link to="/" className={buttonInside.solid}>
           확인
         </Link>

--- a/src/views/dialogs/SessionExpiredDialog/index.tsx
+++ b/src/views/dialogs/SessionExpiredDialog/index.tsx
@@ -4,7 +4,7 @@ import { forwardRef, type KeyboardEvent } from 'react';
 import Dialog from '@components/Dialog';
 import { useDevice } from '@hooks/useDevice';
 
-import { buttonInside, buttonOutside, buttonWrapperVar, mainTextVar, subTextVar } from '../style.css';
+import { buttonInside, buttonOutside, buttonOutsideVar, buttonWrapperVar, mainTextVar, subTextVar } from '../style.css';
 
 const SessionExpiredDialog = forwardRef<HTMLDialogElement>((_, ref) => {
   const DEVICE_TYPE = useDevice();
@@ -28,7 +28,9 @@ const SessionExpiredDialog = forwardRef<HTMLDialogElement>((_, ref) => {
     <Dialog ref={ref} onKeyDown={handlePreventESCKeyPress}>
       <p className={mainTextVar[DEVICE_TYPE]}>로그인을 다시 해주세요.</p>
       <p className={subTextVar[DEVICE_TYPE]}>세션이 만료되었거나 비정상적인 로그인이에요.</p>
-      <form method="dialog" className={`${buttonWrapperVar[DEVICE_TYPE]} ${buttonOutside.solid}`}>
+      <form
+        method="dialog"
+        className={`${buttonWrapperVar[DEVICE_TYPE]} ${buttonOutside.solid} ${buttonOutsideVar[DEVICE_TYPE]}`}>
         <button className={buttonInside.solid} onClick={handleLogout}>
           확인
         </button>

--- a/src/views/dialogs/SessionExpiredDialog/index.tsx
+++ b/src/views/dialogs/SessionExpiredDialog/index.tsx
@@ -2,10 +2,13 @@ import { track } from '@amplitude/analytics-browser';
 import { forwardRef, type KeyboardEvent } from 'react';
 
 import Dialog from '@components/Dialog';
+import { useDevice } from '@hooks/useDevice';
 
-import { buttonInside, buttonOutside, buttonWrapper, mainText, subText } from '../style.css';
+import { buttonInside, buttonOutside, buttonWrapperVar, mainTextVar, subTextVar } from '../style.css';
 
 const SessionExpiredDialog = forwardRef<HTMLDialogElement>((_, ref) => {
+  const DEVICE_TYPE = useDevice();
+
   const handlePreventESCKeyPress = (e: KeyboardEvent<HTMLDialogElement>) => {
     if (e.key === 'Escape') e.preventDefault();
   };
@@ -23,9 +26,9 @@ const SessionExpiredDialog = forwardRef<HTMLDialogElement>((_, ref) => {
 
   return (
     <Dialog ref={ref} onKeyDown={handlePreventESCKeyPress}>
-      <p className={mainText}>로그인을 다시 해주세요.</p>
-      <p className={subText}>세션이 만료되었거나 비정상적인 로그인이에요.</p>
-      <form method="dialog" className={`${buttonWrapper} ${buttonOutside.solid}`}>
+      <p className={mainTextVar[DEVICE_TYPE]}>로그인을 다시 해주세요.</p>
+      <p className={subTextVar[DEVICE_TYPE]}>세션이 만료되었거나 비정상적인 로그인이에요.</p>
+      <form method="dialog" className={`${buttonWrapperVar[DEVICE_TYPE]} ${buttonOutside.solid}`}>
         <button className={buttonInside.solid} onClick={handleLogout}>
           확인
         </button>

--- a/src/views/dialogs/SubmitDialog/index.tsx
+++ b/src/views/dialogs/SubmitDialog/index.tsx
@@ -2,6 +2,7 @@ import { track } from '@amplitude/analytics-browser';
 import { type ChangeEvent, forwardRef, useState } from 'react';
 
 import Dialog from '@components/Dialog';
+import { useDevice } from '@hooks/useDevice';
 import ButtonLoading from 'views/loadings/ButtonLoading';
 
 import {
@@ -9,18 +10,26 @@ import {
   checkboxWrapper,
   checkmark,
   hiddenCheckbox,
-  infoContainer,
-  infoLabel,
-  infoValue,
-  infoWrapper,
+  infoContainerVar,
+  infoLabelVar,
+  infoValueVar,
+  infoWrapperVar,
 } from './style.css';
-import { buttonInside, buttonOutside, buttonWrapper, mainText, subText } from '../style.css';
+import { buttonInside, buttonOutside, buttonWrapperVar, mainTextVar, subTextVar } from '../style.css';
 
-const MyInfoItem = ({ label, value }: { label: string; value: string }) => {
+const MyInfoItem = ({
+  DEVICE_TYPE,
+  label,
+  value,
+}: {
+  DEVICE_TYPE: 'MOB' | 'TAB' | 'DESK';
+  label: string;
+  value: string;
+}) => {
   return (
-    <li className={infoWrapper}>
-      <label className={infoLabel}>{label}</label>
-      <span className={infoValue}>{value}</span>
+    <li className={infoWrapperVar[DEVICE_TYPE]}>
+      <label className={infoLabelVar[DEVICE_TYPE]}>{label}</label>
+      <span className={infoValueVar[DEVICE_TYPE]}>{value}</span>
     </li>
   );
 };
@@ -40,19 +49,21 @@ const SubmitDialog = forwardRef<HTMLDialogElement, SubmitDialogProps>(
   ({ userInfo: { name, email, phone, part }, dataIsPending, onSendData }, ref) => {
     const [isChecked, setIsChecked] = useState(false);
 
+    const DEVICE_TYPE = useDevice();
+
     const handleCheck = (e: ChangeEvent<HTMLInputElement>) => {
       setIsChecked(e.target.checked);
     };
 
     return (
       <Dialog ref={ref}>
-        <p className={mainText}>이대로 제출하시겠어요?</p>
-        <p className={subText}>제출 완료하신 지원서는 수정하실 수 없어요.</p>
-        <ol className={infoContainer}>
-          <MyInfoItem label="이름" value={name} />
-          <MyInfoItem label="이메일" value={email} />
-          <MyInfoItem label="전화번호" value={phone} />
-          <MyInfoItem label="지원파트" value={part} />
+        <p className={mainTextVar[DEVICE_TYPE]}>이대로 제출하시겠어요?</p>
+        <p className={subTextVar[DEVICE_TYPE]}>제출 완료하신 지원서는 수정하실 수 없어요.</p>
+        <ol className={infoContainerVar[DEVICE_TYPE]}>
+          <MyInfoItem DEVICE_TYPE={DEVICE_TYPE} label="이름" value={name} />
+          <MyInfoItem DEVICE_TYPE={DEVICE_TYPE} label="이메일" value={email} />
+          <MyInfoItem DEVICE_TYPE={DEVICE_TYPE} label="전화번호" value={phone} />
+          <MyInfoItem DEVICE_TYPE={DEVICE_TYPE} label="지원파트" value={part} />
         </ol>
         <div className={checkboxContainer}>
           <label className={checkboxWrapper}>
@@ -66,7 +77,7 @@ const SubmitDialog = forwardRef<HTMLDialogElement, SubmitDialogProps>(
             <span>확인했습니다.</span>
           </label>
         </div>
-        <div className={buttonWrapper}>
+        <div className={buttonWrapperVar[DEVICE_TYPE]}>
           <form
             method="dialog"
             className={dataIsPending ? buttonOutside.disabled : buttonOutside.line}

--- a/src/views/dialogs/SubmitDialog/index.tsx
+++ b/src/views/dialogs/SubmitDialog/index.tsx
@@ -15,7 +15,7 @@ import {
   infoValueVar,
   infoWrapperVar,
 } from './style.css';
-import { buttonInside, buttonOutside, buttonWrapperVar, mainTextVar, subTextVar } from '../style.css';
+import { buttonInside, buttonOutside, buttonOutsideVar, buttonWrapperVar, mainTextVar, subTextVar } from '../style.css';
 
 const MyInfoItem = ({
   DEVICE_TYPE,
@@ -80,13 +80,13 @@ const SubmitDialog = forwardRef<HTMLDialogElement, SubmitDialogProps>(
         <div className={buttonWrapperVar[DEVICE_TYPE]}>
           <form
             method="dialog"
-            className={dataIsPending ? buttonOutside.disabled : buttonOutside.line}
+            className={`${dataIsPending ? buttonOutside.disabled : buttonOutside.line} ${buttonOutsideVar[DEVICE_TYPE]}`}
             onSubmit={() => setIsChecked(false)}>
             <button className={buttonInside.line} disabled={dataIsPending} onClick={() => track('click-apply-cancel')}>
               {dataIsPending ? <ButtonLoading width={48} height={18} /> : '검토하기'}
             </button>
           </form>
-          <div className={buttonOutside[!isChecked ? 'disabled' : 'solid']}>
+          <div className={`${buttonOutside[!isChecked ? 'disabled' : 'solid']} ${buttonOutsideVar[DEVICE_TYPE]}`}>
             <button className={buttonInside.solid} onClick={onSendData} disabled={!isChecked || dataIsPending}>
               {dataIsPending ? <ButtonLoading width={48} height={18} /> : '제출하기'}
             </button>

--- a/src/views/dialogs/SubmitDialog/style.css.ts
+++ b/src/views/dialogs/SubmitDialog/style.css.ts
@@ -1,19 +1,45 @@
 import { colors } from '@sopt-makers/colors';
-import { style } from '@vanilla-extract/css';
+import { style, styleVariants } from '@vanilla-extract/css';
 
 import { theme } from 'styles/theme.css';
 
-export const infoContainer = style({
+const infoContainer = style({
   display: 'flex',
   flexDirection: 'column',
   justifyContent: 'space-between',
-  width: 352,
-  height: 252,
-  marginTop: 20,
-  padding: '33px 44px',
   // FIXME: gray20으로 수정해야 함.
   backgroundColor: colors.gray30,
   borderRadius: 10,
+});
+
+export const infoContainerVar = styleVariants({
+  DESK: [
+    infoContainer,
+    {
+      width: 352,
+      height: 252,
+      marginTop: 20,
+      padding: '33px 44px',
+    },
+  ],
+  TAB: [
+    infoContainer,
+    {
+      width: 352,
+      height: 252,
+      marginTop: 20,
+      padding: '33px 44px',
+    },
+  ],
+  MOB: [
+    infoContainer,
+    {
+      width: 265,
+      height: 245,
+      marginTop: 14,
+      padding: '35px 30px',
+    },
+  ],
 });
 
 export const infoWrapper = style({
@@ -22,17 +48,80 @@ export const infoWrapper = style({
   alignItems: 'center',
 });
 
-export const infoLabel = style({
+export const infoWrapperVar = styleVariants({
+  DESK: [
+    infoWrapper,
+    {
+      gap: 48,
+    },
+  ],
+  TAB: [
+    infoWrapper,
+    {
+      gap: 48,
+    },
+  ],
+  MOB: [
+    infoWrapper,
+    {
+      gap: 39,
+    },
+  ],
+});
+
+const infoLabel = style({
   width: 56,
   minWidth: 56,
   color: colors.gray300,
   ...theme.font.BODY_2_16_R,
 });
 
-export const infoValue = style({
+export const infoLabelVar = styleVariants({
+  DESK: [
+    infoLabel,
+    {
+      ...theme.font.BODY_2_16_R,
+    },
+  ],
+  TAB: [
+    infoLabel,
+    {
+      ...theme.font.BODY_2_16_R,
+    },
+  ],
+  MOB: [
+    infoLabel,
+    {
+      ...theme.font.BODY_3_14_R,
+    },
+  ],
+});
+
+const infoValue = style({
   color: colors.gray950,
   wordBreak: 'break-all',
   ...theme.font.BODY_2_16_M,
+});
+
+export const infoValueVar = styleVariants({
+  DESK: [
+    infoValue,
+    {
+      ...theme.font.BODY_2_16_M,
+    },
+  ],
+  TAB: [
+    infoValue,
+    {
+      ...theme.font.BODY_2_16_M,
+    },
+  ],
+  MOB: [
+    infoValue,
+    {
+      ...theme.font.BODY_3_14_M,
+    },
+  ],
 });
 
 export const checkboxContainer = style({

--- a/src/views/dialogs/index.tsx
+++ b/src/views/dialogs/index.tsx
@@ -1,4 +1,8 @@
 export { default as CompleteDialog } from './CompleteDialog';
 export { default as DraftDialog } from './DraftDialog';
+export { default as ExistingApplicantDialog } from './ExistingApplicantDialog';
 export { default as ExitDialog } from './ExitDialog';
+export { default as PreventApplyDialog } from './PreventApplyDialog';
+export { default as PreventReviewDialog } from './PreventReviewDialog';
+export { default as SessionExpiredDialog } from './SessionExpiredDialog';
 export { default as SubmitDialog } from './SubmitDialog';

--- a/src/views/dialogs/style.css.ts
+++ b/src/views/dialogs/style.css.ts
@@ -3,24 +3,86 @@ import { style, styleVariants } from '@vanilla-extract/css';
 
 import { theme } from 'styles/theme.css';
 
-export const mainText = style({
+const mainText = style({
   color: colors.gray950,
-  ...theme.font.HEADING_5_20_B,
 });
 
-export const subText = style({
+export const mainTextVar = styleVariants({
+  DESK: [
+    mainText,
+    {
+      ...theme.font.HEADING_5_20_B,
+    },
+  ],
+  TAB: [
+    mainText,
+    {
+      ...theme.font.HEADING_5_20_B,
+    },
+  ],
+  MOB: [
+    mainText,
+    {
+      ...theme.font.HEADING_7_16_B,
+    },
+  ],
+});
+
+const subText = style({
   marginTop: 2,
   color: colors.gray300,
   ...theme.font.BODY_2_16_M,
 });
 
-export const buttonWrapper = style({
+export const subTextVar = styleVariants({
+  DESK: [
+    subText,
+    {
+      ...theme.font.BODY_2_16_M,
+    },
+  ],
+  TAB: [
+    subText,
+    {
+      ...theme.font.BODY_2_16_M,
+    },
+  ],
+  MOB: [
+    subText,
+    {
+      ...theme.font.BODY_3_14_M,
+    },
+  ],
+});
+
+const buttonWrapper = style({
   display: 'flex',
-  gap: 12,
+
   alignItems: 'center',
   justifyContent: 'flex-end',
   marginLeft: 'auto',
   marginTop: 20,
+});
+
+export const buttonWrapperVar = styleVariants({
+  DESK: [
+    buttonWrapper,
+    {
+      gap: 12,
+    },
+  ],
+  TAB: [
+    buttonWrapper,
+    {
+      gap: 12,
+    },
+  ],
+  MOB: [
+    buttonWrapper,
+    {
+      gap: 8,
+    },
+  ],
 });
 
 const buttonOutsideBase = style({

--- a/src/views/dialogs/style.css.ts
+++ b/src/views/dialogs/style.css.ts
@@ -116,6 +116,12 @@ export const buttonOutside = styleVariants({
   ],
 });
 
+export const buttonOutsideVar = styleVariants({
+  DESK: { ...theme.font.LABEL_3_14_SB },
+  TAB: { ...theme.font.LABEL_3_14_SB },
+  MOB: { ...theme.font.LABEL_4_12_SB },
+});
+
 const buttonInsideBase = style({
   display: 'flex',
   alignItems: 'center',
@@ -124,7 +130,6 @@ const buttonInsideBase = style({
   padding: '13px 20px',
   borderRadius: 12,
   transition: 'background-color 0.3s ease-out',
-  ...theme.font.LABEL_3_14_SB,
 
   ':active': {
     margin: '0 auto',


### PR DESCRIPTION
**Related Issue :** Closes #377 

---

## 🧑‍🎤 Summary
- [x] dialog들 반응형으로 구현
- [x] dialog들 import 방식 통일

## 🧑‍🎤 Screenshot
### ExitDialog
![스크린샷 2024-08-13 오후 5 58 34](https://github.com/user-attachments/assets/2d5721b9-fecd-460b-b9f4-2ead7980e399)

### SubmitDialog
![스크린샷 2024-08-13 오후 5 56 42](https://github.com/user-attachments/assets/19d90303-f414-49dd-a98a-6c3a8c477715)

### SessionExpiredDialog
![스크린샷 2024-08-13 오후 5 55 06](https://github.com/user-attachments/assets/5c9aabc7-013b-4625-840f-2cd4de50201f)

### PreventReviewDialog
![스크린샷 2024-08-13 오후 5 54 53](https://github.com/user-attachments/assets/a8a3c321-f807-4761-8449-328caf3c0834)

### PreventApplyDialog
![스크린샷 2024-08-13 오후 5 54 34](https://github.com/user-attachments/assets/572893de-de6f-4c01-a7d0-dbcea41932b5)

### ExistingApplicantDialog
![스크린샷 2024-08-13 오후 5 53 44](https://github.com/user-attachments/assets/3ab35c4b-f82e-4c68-aaab-5ea2ec164da7)

### DraftDialog
![스크린샷 2024-08-13 오후 5 53 36](https://github.com/user-attachments/assets/2b6e8182-6639-4141-89af-257c339aeb61)

### CompleteDialog
![스크린샷 2024-08-13 오후 5 53 29](https://github.com/user-attachments/assets/e41e6904-2721-4dd2-95b0-b6d412936d6e)

## 🧑‍🎤 Comment
### dialog들 import 방식 통일
몇 개는 해당 컴포넌트에서 import 되고 있어서
기존 방식인 index.tsx에서 한 번에 import 해주는 방식으로 통일했어요
```tsx
export { default as CompleteDialog } from './CompleteDialog';
export { default as DraftDialog } from './DraftDialog';
export { default as ExistingApplicantDialog } from './ExistingApplicantDialog';
export { default as ExitDialog } from './ExitDialog';
export { default as PreventApplyDialog } from './PreventApplyDialog';
export { default as PreventReviewDialog } from './PreventReviewDialog';
export { default as SessionExpiredDialog } from './SessionExpiredDialog';
export { default as SubmitDialog } from './SubmitDialog';
```