### PR TITLE
[Feat] session replay masking 추가

### DIFF
--- a/src/common/components/Select/index.tsx
+++ b/src/common/components/Select/index.tsx
@@ -16,8 +16,6 @@ import {
 import { SelectBoxProps } from './type';
 
 const SelectBox = ({ label, name, options, size = 'sm', required, ...inputElementProps }: SelectBoxProps) => {
-  const ampUnmask = name === 'part' || name === 'knownPath';
-
   const { register, formState, clearErrors, getValues, setValue, setError } = useFormContext();
   const { errors } = formState;
 
@@ -43,7 +41,7 @@ const SelectBox = ({ label, name, options, size = 'sm', required, ...inputElemen
         <input
           id={name}
           type="text"
-          className={`${ampUnmask ? 'amp-unmask' : ''} ${selectVariant[errors?.[name] ? 'error' : 'selected']}`}
+          className={selectVariant[errors?.[name] ? 'error' : 'selected']}
           role="combobox"
           readOnly
           {...inputElementProps}

--- a/src/common/components/Textarea/components/Input/index.tsx
+++ b/src/common/components/Textarea/components/Input/index.tsx
@@ -45,7 +45,7 @@ const Input = <T extends FieldValues>({
   return (
     <div className={container}>
       <textarea
-        className={`amp-unmask ${textareaStyle[state]} ${textareaHeight[textareaSize]}`}
+        className={`${textareaStyle[state]} ${textareaHeight[textareaSize]}`}
         {...register(name, {
           ...(required && { required: '필수 입력 항목이에요.' }),
           maxLength: {

--- a/src/common/hooks/useDevice.ts
+++ b/src/common/hooks/useDevice.ts
@@ -23,9 +23,9 @@ export function useIsMobile(maxWidth = '431px') {
   return isMobile;
 }
 
-export function useDevice(): 'TAB' | 'MOB' | 'DESK' {
-  const isTablet = useIsTablet();
-  const isMobile = useIsMobile();
+export function useDevice({ mobMax, tabMax }: { mobMax?: string; tabMax?: string }): 'TAB' | 'MOB' | 'DESK' {
+  const isTablet = useIsTablet(mobMax, tabMax);
+  const isMobile = useIsMobile(mobMax);
 
   return isTablet ? 'TAB' : isMobile ? 'MOB' : 'DESK';
 }

--- a/src/common/hooks/useDevice.ts
+++ b/src/common/hooks/useDevice.ts
@@ -23,9 +23,9 @@ export function useIsMobile(maxWidth = '431px') {
   return isMobile;
 }
 
-export function useDevice({ mobMax, tabMax }: { mobMax?: string; tabMax?: string }): 'TAB' | 'MOB' | 'DESK' {
-  const isTablet = useIsTablet(mobMax, tabMax);
-  const isMobile = useIsMobile(mobMax);
+export function useDevice(): 'TAB' | 'MOB' | 'DESK' {
+  const isTablet = useIsTablet();
+  const isMobile = useIsMobile();
 
   return isTablet ? 'TAB' : isMobile ? 'MOB' : 'DESK';
 }

--- a/src/views/ApplyPage/components/FileInput/index.tsx
+++ b/src/views/ApplyPage/components/FileInput/index.tsx
@@ -163,7 +163,7 @@ const FileInput = ({ section, id, isReview, disabled, defaultFile }: FileInputPr
         {...register(`file${id}`)}
         onChange={(e) => handleFileChange(e, id)}
         ref={inputRef}
-        className={`amp-unmask ${fileInput}`}
+        className={fileInput}
         disabled={disabledStatus}
       />
       <label

--- a/src/views/ApplyPage/components/FileInput/index.tsx
+++ b/src/views/ApplyPage/components/FileInput/index.tsx
@@ -168,7 +168,7 @@ const FileInput = ({ section, id, isReview, disabled, defaultFile }: FileInputPr
       />
       <label
         htmlFor={`file-${id}`}
-        className={fileLabelVar[errors[`file${id}`] ? 'error' : fileName === '' ? 'default' : 'selected']}>
+        className={`amp-mask ${fileLabelVar[errors[`file${id}`] ? 'error' : fileName === '' ? 'default' : 'selected']}`}>
         <div className={textWrapper}>
           <span>파일</span>
           <span className={fileNameVar[getFileNameClass()]}>{getDisplayText()}</span>

--- a/src/views/ApplyPage/components/FileInput/index.tsx
+++ b/src/views/ApplyPage/components/FileInput/index.tsx
@@ -168,10 +168,10 @@ const FileInput = ({ section, id, isReview, disabled, defaultFile }: FileInputPr
       />
       <label
         htmlFor={`file-${id}`}
-        className={`amp-mask ${fileLabelVar[errors[`file${id}`] ? 'error' : fileName === '' ? 'default' : 'selected']}`}>
+        className={fileLabelVar[errors[`file${id}`] ? 'error' : fileName === '' ? 'default' : 'selected']}>
         <div className={textWrapper}>
           <span>파일</span>
-          <span className={fileNameVar[getFileNameClass()]}>{getDisplayText()}</span>
+          <span className={`amp-mask ${fileNameVar[getFileNameClass()]}`}>{getDisplayText()}</span>
         </div>
         <IconPlusButton
           isSelected={fileName !== 'delete-file' && fileValue}

--- a/src/views/MyPage/index.tsx
+++ b/src/views/MyPage/index.tsx
@@ -21,12 +21,14 @@ import {
 } from './style.css';
 
 const MyInfoItem = ({ label, value }: { label: string; value?: string | number | boolean }) => {
+  const isMasking = label !== '지원서';
+
   const DEVICE_TYPE = useDevice();
 
   return (
     <li className={itemWrapper}>
       <span className={infoLabelVar[DEVICE_TYPE]}>{label}</span>
-      <span className={infoValueVar[DEVICE_TYPE]}>{value}</span>
+      <span className={`${isMasking ? 'amp-block' : ''} ${infoValueVar[DEVICE_TYPE]}`}>{value}</span>
     </li>
   );
 };

--- a/src/views/MyPage/index.tsx
+++ b/src/views/MyPage/index.tsx
@@ -28,7 +28,7 @@ const MyInfoItem = ({ label, value }: { label: string; value?: string | number |
   return (
     <li className={itemWrapper}>
       <span className={infoLabelVar[DEVICE_TYPE]}>{label}</span>
-      <span className={`${isMasking ? 'amp-block' : ''} ${infoValueVar[DEVICE_TYPE]}`}>{value}</span>
+      <span className={`${isMasking ? 'amp-mask' : ''} ${infoValueVar[DEVICE_TYPE]}`}>{value}</span>
     </li>
   );
 };

--- a/src/views/ResultPage/components/FinalResult.tsx
+++ b/src/views/ResultPage/components/FinalResult.tsx
@@ -1,3 +1,4 @@
+import { track } from '@amplitude/analytics-browser';
 import { format } from 'date-fns';
 import { ko } from 'date-fns/locale';
 import { useContext, useEffect } from 'react';
@@ -59,7 +60,8 @@ const Content = ({ pass }: { pass?: boolean }) => {
             className={link}
             href={`https://${import.meta.env.VITE_FINAL_PASS_LINK}`}
             target="_blank"
-            rel="noreferrer noopener">
+            rel="noreferrer noopener"
+            onClick={() => track('click-final-google_form')}>
             {`https://${DEVICE_TYPE !== 'DESK' ? '\n' : ''}${import.meta.env.VITE_FINAL_PASS_LINK}`}
           </a>
           <span>{` )\n`}</span>

--- a/src/views/ResultPage/components/FinalResult.tsx
+++ b/src/views/ResultPage/components/FinalResult.tsx
@@ -43,7 +43,7 @@ const Content = ({ pass }: { pass?: boolean }) => {
         <p className={contentVar[DEVICE_TYPE]}>
           <span>{`안녕하세요. ${SOPT_NAME}입니다.\n\n`}</span>
           <strong className={strongText[isMakers ? 'makers' : 'sopt']}>{`축하드립니다!`}</strong>
-          <span>
+          <span className="amp-block">
             {`
               ${name}님은 ${season}기 ${SOPT_NAME} ${!isMakers ? group : ''} 신입회원 모집에 최종 합격하셨습니다.
   
@@ -76,7 +76,7 @@ const Content = ({ pass }: { pass?: boolean }) => {
           </span>
         </p>
       ) : (
-        <p className={contentVar[DEVICE_TYPE]}>
+        <p className={`amp-block ${contentVar[DEVICE_TYPE]}`}>
           {`안녕하세요, ${SOPT_NAME}입니다.
           
           ${SOPT_NAME}에 관심을 갖고 지원해 주셔서 감사드립니다.

--- a/src/views/ResultPage/components/FinalResult.tsx
+++ b/src/views/ResultPage/components/FinalResult.tsx
@@ -44,7 +44,7 @@ const Content = ({ pass }: { pass?: boolean }) => {
         <p className={contentVar[DEVICE_TYPE]}>
           <span>{`안녕하세요. ${SOPT_NAME}입니다.\n\n`}</span>
           <strong className={strongText[isMakers ? 'makers' : 'sopt']}>{`축하드립니다!`}</strong>
-          <span className="amp-block">
+          <span className="amp-mask">
             {`
               ${name}님은 ${season}기 ${SOPT_NAME} ${!isMakers ? group : ''} 신입회원 모집에 최종 합격하셨습니다.
   
@@ -78,7 +78,7 @@ const Content = ({ pass }: { pass?: boolean }) => {
           </span>
         </p>
       ) : (
-        <p className={`amp-block ${contentVar[DEVICE_TYPE]}`}>
+        <p className={`amp-mask ${contentVar[DEVICE_TYPE]}`}>
           {`안녕하세요, ${SOPT_NAME}입니다.
           
           ${SOPT_NAME}에 관심을 갖고 지원해 주셔서 감사드립니다.

--- a/src/views/ResultPage/components/ScreeningResult.tsx
+++ b/src/views/ResultPage/components/ScreeningResult.tsx
@@ -1,3 +1,4 @@
+import { track } from '@amplitude/analytics-browser';
 import { format } from 'date-fns';
 import { ko } from 'date-fns/locale';
 import { useContext, useEffect } from 'react';
@@ -66,7 +67,8 @@ const Content = ({ pass }: { pass?: boolean }) => {
             className={link}
             href={`https://${import.meta.env.VITE_SCREENING_PASS_LINK}`}
             target="_blank"
-            rel="noreferrer noopener">
+            rel="noreferrer noopener"
+            onClick={() => track('click-screening-google_form')}>
             {`https://${DEVICE_TYPE !== 'DESK' ? '\n' : ''}${import.meta.env.VITE_SCREENING_PASS_LINK}`}
           </a>
           <span>{` )\n`}</span>

--- a/src/views/ResultPage/components/ScreeningResult.tsx
+++ b/src/views/ResultPage/components/ScreeningResult.tsx
@@ -52,7 +52,7 @@ const Content = ({ pass }: { pass?: boolean }) => {
         <p className={contentVar[DEVICE_TYPE]}>
           <span>{`안녕하세요. ${SOPT_NAME} 입니다.\n\n`}</span>
           <strong className={strongText[isMakers ? 'makers' : 'sopt']}>{`축하드립니다!`}</strong>
-          <span className="amp-block">
+          <span className="amp-mask">
             {`
               서류 검토 결과, ${name}님은 인터뷰 대상자로 선정되셨습니다.
 
@@ -88,7 +88,7 @@ const Content = ({ pass }: { pass?: boolean }) => {
           </span>
         </p>
       ) : (
-        <p className={`amp-block ${contentVar[DEVICE_TYPE]}`}>
+        <p className={`amp-mask ${contentVar[DEVICE_TYPE]}`}>
           {`안녕하세요, ${SOPT_NAME}입니다.
           
           ${SOPT_NAME}에 관심을 갖고 지원해 주셔서 감사드립니다.

--- a/src/views/ResultPage/components/ScreeningResult.tsx
+++ b/src/views/ResultPage/components/ScreeningResult.tsx
@@ -51,7 +51,7 @@ const Content = ({ pass }: { pass?: boolean }) => {
         <p className={contentVar[DEVICE_TYPE]}>
           <span>{`안녕하세요. ${SOPT_NAME} 입니다.\n\n`}</span>
           <strong className={strongText[isMakers ? 'makers' : 'sopt']}>{`축하드립니다!`}</strong>
-          <span>
+          <span className="amp-block">
             {`
               서류 검토 결과, ${name}님은 인터뷰 대상자로 선정되셨습니다.
 
@@ -86,7 +86,7 @@ const Content = ({ pass }: { pass?: boolean }) => {
           </span>
         </p>
       ) : (
-        <p className={contentVar[DEVICE_TYPE]}>
+        <p className={`amp-block ${contentVar[DEVICE_TYPE]}`}>
           {`안녕하세요, ${SOPT_NAME}입니다.
           
           ${SOPT_NAME}에 관심을 갖고 지원해 주셔서 감사드립니다.


### PR DESCRIPTION
**Related Issue :** Closes #395 

---

## 🧑‍🎤 Summary
- [x] 답변 부분 masking 처리
- [x] 결과 확인 및 마이 페이지 masking 처리
- [x] 구글폼 클릭 이벤트 추가

## 🧑‍🎤 Comment
### 🏋🏻 답변 부분 masking 처리
기존에는 뚫어놨었던 지원자 답변과 파트 선택 여부를 다시 masking 처리 했어요
<br />

### 🏋🏻 결과 확인 및 마이 페이지 masking 처리
마이 페이지에서 기수, 이름, 지원 파트, 합불 여부에 대한 정보를 마스킹 처리 했어요
<br />

### 🏋🏻 구글폼 클릭 이벤트 추가
합격 페이지에서 구글폼 클릭 시 이벤트가 트래킹 되도록 구현했어요
이벤트 이름은 `click-final-google_form` / `click-screening-google_form` 으로 해줬습니다
<br />