### PR TITLE
[Fix] meta tag && 연산자 삭제

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,8 +17,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta property="og:type" content="website" />
     <meta property="og:locale" content="ko_KR" />
-    <meta property="og:url" content="https://recruiting.sopt.org" />
-    <meta property="twitter:site" content="https://recruiting.sopt.org" />
   </head>
   <body>
     <div id="modal"></div>

--- a/src/common/components/Layout/index.tsx
+++ b/src/common/components/Layout/index.tsx
@@ -15,13 +15,15 @@ const Head = () => {
   const TOUCH_ICON = isMakers ? '/makers-touch-icon.png' : '/apple-touch-icon.png';
   const ICON = isMakers ? '/makersIcon.svg' : '/icon.svg';
   const FAVICON = isMakers ? '/makersFavicon.ico' : '/favicon.ico';
-  const SITE_NAME = isMakers === undefined ? 'SOPT 리크루팅' : `SOPT ${isMakers && 'makers '}리크루팅`;
-  const TITLE = season === undefined ? 'SOPT 모집 지원하기' : `SOPT ${isMakers && 'makers '}${season}기 모집 지원하기`;
+  const SITE_NAME = isMakers === undefined ? 'SOPT 리크루팅' : `SOPT ${isMakers ? 'makers ' : ''}리크루팅`;
+  const TITLE =
+    season === undefined ? 'SOPT 모집 지원하기' : `SOPT ${isMakers ? 'makers ' : ''}${season}기 모집 지원하기`;
   const IMAGE = isMakers ? '/makersOg.png' : '/imgOg.png';
   const DESCRIPTION =
     isMakers === undefined
       ? `SOPT의 신입 기수 모집페이지입니다.`
-      : `SOPT${isMakers && ' makers'}의 신입 기수 모집페이지입니다.`;
+      : `SOPT${isMakers ? ' makers' : ''}의 신입 기수 모집페이지입니다.`;
+  const URL = isMakers ? 'https://recruiting.sopt.org' : 'https://recruit.sopt.org';
 
   return (
     <Helmet>
@@ -34,6 +36,7 @@ const Head = () => {
       <meta property="og:title" content={TITLE} />
       <meta property="og:description" content={DESCRIPTION} />
       <meta property="og:site_name" content={SITE_NAME} />
+      <meta property="og:url" content={URL} />
 
       <meta property="og:image" content={IMAGE} />
       <meta property="og:image:alt" content={SITE_NAME} />
@@ -45,6 +48,7 @@ const Head = () => {
       <meta name="twitter:description" content={DESCRIPTION} />
       <meta name="twitter:image" content={IMAGE} />
       <meta property="twitter:image:alt" content={SITE_NAME} />
+      <meta property="twitter:site" content={URL} />
 
       <title>{TITLE}</title>
       <meta name="author" content="sopt makers team official 4th" />


### PR DESCRIPTION
**Related Issue :** Closes #402 

---

## 🧑‍🎤 Summary
메타태그에 && 연산자 사용해서 저번처럼 `false` 가 들어가서, 삼항연산자로 바꿔주었어요 ! 

## 🧑‍🎤 Screenshot
(이런 문제였음!) 
![image](https://github.com/user-attachments/assets/46a68a4f-4b89-4ceb-89c0-e7095d238e5e)

