### PR TITLE
[Fix] ReviewPage 클릭 비활성화 처리 

### DIFF
--- a/src/common/components/Checkbox/index.tsx
+++ b/src/common/components/Checkbox/index.tsx
@@ -33,6 +33,7 @@ const Checkbox = <T extends FieldValues>({
             })}
             type="checkbox"
             className={`amp-unmask ${hiddenCheckbox}`}
+            disabled
             {...checkboxElementProps}
           />
           <span className={checkmark[errors && errors[name] ? 'error' : 'default']} />

--- a/src/common/components/Checkbox/style.css.ts
+++ b/src/common/components/Checkbox/style.css.ts
@@ -48,7 +48,7 @@ const checkmarkBase = style({
     },
 
     /* 마우스 hover시 */
-    [`${checkboxContainer}:hover input ~ &`]: {
+    [`${checkboxContainer}:hover input:enabled ~ &`]: {
       backgroundColor: theme.color.subBackground,
     },
 
@@ -58,7 +58,7 @@ const checkmarkBase = style({
       backgroundColor: theme.color.primary,
     },
 
-    [`${checkboxContainer} input:checked:hover ~ &`]: {
+    [`${checkboxContainer} input:checked:enabled:hover ~ &`]: {
       border: `1px solid ${theme.color.primaryDark}`,
       backgroundColor: theme.color.primaryDark,
     },

--- a/src/common/components/Checkbox/style.css.ts
+++ b/src/common/components/Checkbox/style.css.ts
@@ -15,7 +15,6 @@ export const checkboxContainer = style({
   gap: 6,
   position: 'relative',
   width: 'fit-content',
-  cursor: 'pointer',
   WebkitUserSelect: 'none',
   MozUserSelect: 'none',
   msUserSelect: 'none',
@@ -38,6 +37,7 @@ const checkmarkBase = style({
   width: 22,
   borderRadius: 5,
   transition: 'all 0.3s ease',
+  cursor: 'pointer',
 
   selectors: {
     /* Create the checkmark/indicator (hidden when not checked) */
@@ -85,6 +85,11 @@ const checkmarkBase = style({
     [`${checkboxContainer} input:focus-visible ~ &`]: {
       outline: `2px dotted ${theme.color.primary}`,
       outlineOffset: 2,
+    },
+
+    /* ReviewPage에서는 disabled 처리 */
+    [`${checkboxContainer} input:disabled ~ &`]: {
+      cursor: 'not-allowed',
     },
   },
 });

--- a/src/common/components/Radio/components/Option/style.css.ts
+++ b/src/common/components/Radio/components/Option/style.css.ts
@@ -16,10 +16,6 @@ const inputBase = style({
   transition: 'all 0.3s ease',
   cursor: 'pointer',
 
-  ':hover': {
-    backgroundColor: theme.color.subBackground,
-  },
-
   ':checked': {
     border: `6px solid ${theme.color.primary}`,
   },
@@ -29,7 +25,15 @@ const inputBase = style({
     outlineOffset: 2,
   },
 
+  ':disabled': {
+    cursor: 'not-allowed',
+  },
+
   selectors: {
+    '&:enabled:hover': {
+      backgroundColor: theme.color.subBackground,
+    },
+
     '&:checked:hover': {
       backgroundColor: theme.color.background,
       border: `6px solid ${theme.color.primaryDark}`,
@@ -55,4 +59,10 @@ export const inputStyle = styleVariants({
 export const labelStyle = style({
   ...theme.font.BODY_2_16_M,
   cursor: 'pointer',
+
+  selectors: {
+    [`${container} input:disabled ~ &`]: {
+      cursor: 'not-allowed',
+    },
+  },
 });

--- a/src/views/ApplyPage/components/BottomSection/index.tsx
+++ b/src/views/ApplyPage/components/BottomSection/index.tsx
@@ -40,12 +40,20 @@ const BottomSection = ({ isReview, knownPath }: BottomSectionProps) => {
             ? 'SOPT makers의 행사 및 정기 모임은 일요일에 진행됩니다.'
             : 'SOPT의 행사 및 세미나는 매주 토요일에 진행됩니다.'}
         </p>
-        <Checkbox checked={isReview ? true : undefined} name="attendance" required>
+        <Checkbox
+          checked={isReview ? true : undefined}
+          name="attendance"
+          required
+          disabled={isReview ? true : undefined}>
           참석 가능합니다.
         </Checkbox>
       </div>
       <div>
-        <Checkbox checked={isReview ? true : undefined} required name="personalInformation">
+        <Checkbox
+          checked={isReview ? true : undefined}
+          required
+          name="personalInformation"
+          disabled={isReview ? true : undefined}>
           개인정보 수집 ‧ 이용에 동의합니다.
         </Checkbox>
         <Contentbox>{PRIVACY_POLICY}</Contentbox>


### PR DESCRIPTION
**Related Issue :** Closes #381 

---

## 🧑‍🎤 Summary
ReviewPage에서 click 및 hover 비활성화 처리가 누락되어있는 부분들이 있어서 마저 처리해주었습니다. 

## 🧑‍🎤 Screenshot
- Radio

https://github.com/user-attachments/assets/adb10731-b6e3-4440-ac7e-65c28b1aa870

- CheckBox

https://github.com/user-attachments/assets/1547c0c5-d3fb-4bc2-a033-9accea0a46ef




## 🧑‍🎤 Comment
> 동적 metatag pre-render 이슈는 생각보다 더 오래 걸릴 것 같아서 중간에 멈추고 자잘한 버그픽스부터 하려고 해요! ㅠㅠ

cursor도 not-allowed로 바꿔주고, hover 했을 때 색 달라지는 것도 disabled의 느낌을 방해한다고 생각해서 hover 조건에 enabled (disabled 아닐 때) 도 추가해주었어요! 
