### PR TITLE
[Fix] 전체화면 권장 제거

### DIFF
--- a/src/views/MyPage/index.tsx
+++ b/src/views/MyPage/index.tsx
@@ -1,5 +1,5 @@
 import { track } from '@amplitude/analytics-browser';
-import { MouseEvent, useContext } from 'react';
+import { useContext } from 'react';
 
 import Button from '@components/Button';
 import Callout from '@components/Callout';

--- a/src/views/MyPage/index.tsx
+++ b/src/views/MyPage/index.tsx
@@ -35,26 +35,15 @@ const MyInfoItem = ({ label, value }: { label: string; value?: string | number |
 const StatusButton = ({ label, to, trackingEvent }: { label: string; to: string; trackingEvent: string }) => {
   const deviceType = useDevice();
 
-  const handlePreventMobile = (e: MouseEvent<HTMLButtonElement>) => {
-    track(trackingEvent);
-    if (label === '지원상태') return;
-
-    const isMobile = /Mobi/i.test(window.navigator.userAgent);
-    if (isMobile) {
-      alert('PC로 이용해주세요.');
-      e.preventDefault();
-      return;
-    }
-    if (deviceType !== 'DESK') {
-      alert('전체화면 이용을 권장드려요.');
-      return;
-    }
-  };
-
   return (
     <li className={buttonValue}>
       <span className={infoLabelVar[deviceType]}>{label}</span>
-      <Button isLink to={to} className={buttonWidthVar[deviceType]} onClick={handlePreventMobile} padding="15x25">
+      <Button
+        isLink
+        to={to}
+        className={buttonWidthVar[deviceType]}
+        onClick={() => track(trackingEvent)}
+        padding="15x25">
         {label === '지원서' ? '지원서 확인' : '결과 확인'}
       </Button>
     </li>


### PR DESCRIPTION
**Related Issue :** Closes #408 

---

## 🧑‍🎤 Summary
- [x] 지원서 다시보기 누를 시 전체 페이지 이용해달라는 alert 뜨는 이슈 해결

## 🧑‍🎤 Comment
다시보기도 이제 반응형 지원하니까 해당 alert는 없어도 될 거 같아 제거했어요!

App.tsx에 mobile 관련 regex가 주석으로 남아있어서
MyPage에는 해당 코드 제거해줬어요!