### PR TITLE
[Fix] deviceType undefined 에러 뜨는 이슈 해결

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,8 @@ import { HelmetProvider } from 'react-helmet-async';
 import { RouterProvider, createBrowserRouter } from 'react-router-dom';
 
 import Layout from '@components/Layout';
+import { useDevice } from '@hooks/useDevice';
+import { DeviceTypeContext } from '@store/deviceTypeContext';
 import { RecruitingInfoContext, RecruitingInfoType } from '@store/recruitingInfoContext';
 import { ModeType, ThemeContext } from '@store/themeContext';
 import { dark, light } from 'styles/theme.css';
@@ -109,6 +111,8 @@ const App = () => {
     }, []),
   };
 
+  const deviceType = useDevice();
+
   useEffect(() => {
     if (!isAmplitudeInitialized) {
       init(import.meta.env.VITE_AMPLITUDE_API_KEY);
@@ -129,14 +133,16 @@ const App = () => {
       <SessionExpiredDialog ref={sessionRef} />
       <HelmetProvider>
         <ThemeContext.Provider value={themeContextValue}>
-          <RecruitingInfoContext.Provider value={recruitingInfoContextValue}>
-            <QueryClientProvider client={queryClient}>
-              <ReactQueryDevtools />
-              <div className={isLight ? light : dark}>
-                <RouterProvider router={router} />
-              </div>
-            </QueryClientProvider>
-          </RecruitingInfoContext.Provider>
+          <DeviceTypeContext.Provider value={{ deviceType }}>
+            <RecruitingInfoContext.Provider value={recruitingInfoContextValue}>
+              <QueryClientProvider client={queryClient}>
+                <ReactQueryDevtools />
+                <div className={isLight ? light : dark}>
+                  <RouterProvider router={router} />
+                </div>
+              </QueryClientProvider>
+            </RecruitingInfoContext.Provider>
+          </DeviceTypeContext.Provider>
         </ThemeContext.Provider>
       </HelmetProvider>
     </>

--- a/src/common/components/Button/index.tsx
+++ b/src/common/components/Button/index.tsx
@@ -1,7 +1,7 @@
-import { useId, type ButtonHTMLAttributes, type ReactNode } from 'react';
+import { useContext, useId, type ButtonHTMLAttributes, type ReactNode } from 'react';
 import { Link, To } from 'react-router-dom';
 
-import { useDevice } from '@hooks/useDevice';
+import { DeviceTypeContext } from '@store/deviceTypeContext';
 import ButtonLoading from 'views/loadings/ButtonLoading';
 
 import { buttonFontVar, container, outsideBox, paddings } from './style.css';
@@ -26,7 +26,7 @@ const Button = ({
   isLink = false,
   ...buttonElementProps
 }: ButtonProps) => {
-  const deviceType = useDevice();
+  const { deviceType } = useContext(DeviceTypeContext);
   const { disabled, type = 'button' } = buttonElementProps;
   const Tag = isLink ? Link : 'button';
 

--- a/src/common/components/Callout/index.tsx
+++ b/src/common/components/Callout/index.tsx
@@ -1,11 +1,10 @@
 import { colors } from '@sopt-makers/colors';
 import { IconAlertCircle } from '@sopt-makers/icons';
+import { useContext, type HTMLAttributes, type ReactNode } from 'react';
 
-import { useDevice } from '@hooks/useDevice';
+import { DeviceTypeContext } from '@store/deviceTypeContext';
 
 import { buttonVar, container, warningWrapperVar } from './style.css';
-
-import type { HTMLAttributes, ReactNode } from 'react';
 
 interface CalloutProps extends HTMLAttributes<HTMLElement> {
   children?: ReactNode;
@@ -14,7 +13,7 @@ interface CalloutProps extends HTMLAttributes<HTMLElement> {
 }
 
 const Callout = ({ children, size = 'sm', Button, ...calloutElementProps }: CalloutProps) => {
-  const deviceType = useDevice();
+  const { deviceType } = useContext(DeviceTypeContext);
   return (
     <article className={container[deviceType === 'DESK' ? size : deviceType]} {...calloutElementProps}>
       <div className={warningWrapperVar[deviceType]}>

--- a/src/common/components/Dialog/index.tsx
+++ b/src/common/components/Dialog/index.tsx
@@ -1,7 +1,7 @@
-import { forwardRef, type DialogHTMLAttributes, type ReactNode } from 'react';
+import { forwardRef, useContext, type DialogHTMLAttributes, type ReactNode } from 'react';
 import { createPortal } from 'react-dom';
 
-import { useDevice } from '@hooks/useDevice';
+import { DeviceTypeContext } from '@store/deviceTypeContext';
 
 import { containerVar } from './style.css';
 
@@ -10,7 +10,7 @@ interface DialogProps extends DialogHTMLAttributes<HTMLDialogElement> {
 }
 
 const Dialog = forwardRef<HTMLDialogElement, DialogProps>(({ children, ...dialogElementProps }: DialogProps, ref) => {
-  const deviceType = useDevice();
+  const { deviceType } = useContext(DeviceTypeContext);
 
   return createPortal(
     <dialog ref={ref} className={containerVar[deviceType]} {...dialogElementProps}>

--- a/src/common/components/Input/components/Description/index.tsx
+++ b/src/common/components/Input/components/Description/index.tsx
@@ -1,13 +1,13 @@
 import { useContext } from 'react';
 
 import { TextBoxProps } from '@components/Input/types';
+import { DeviceTypeContext } from '@store/deviceTypeContext';
 
 import { descriptionFontVar, descriptionVar } from './style.css';
-import { FormContext } from '../TextBox';
 
 // TextBox 내부 Input 하단의 부가텍스트
 const Description = ({ children, styleType = 'default' }: Pick<TextBoxProps, 'children' | 'styleType'>) => {
-  const { deviceType } = useContext(FormContext);
+  const { deviceType } = useContext(DeviceTypeContext);
 
   return <div className={`${descriptionVar[styleType]} ${descriptionFontVar[deviceType]}`}>{children}</div>;
 };

--- a/src/common/components/Input/components/InputButton/index.tsx
+++ b/src/common/components/Input/components/InputButton/index.tsx
@@ -1,14 +1,14 @@
 import { useContext } from 'react';
 
 import Button from '@components/Button';
+import { DeviceTypeContext } from '@store/deviceTypeContext';
 
 import { buttonVar } from './style.css';
 import { InputButtonProps } from './types';
-import { FormContext } from '../TextBox';
 
 // TextBox 내부 InputLine 우측 버튼
 const InputButton = ({ isLoading, text, ...props }: InputButtonProps) => {
-  const { deviceType } = useContext(FormContext);
+  const { deviceType } = useContext(DeviceTypeContext);
   return (
     <Button isLoading={isLoading} className={buttonVar[deviceType]} {...props}>
       {text}

--- a/src/common/components/Input/components/InputLine/index.tsx
+++ b/src/common/components/Input/components/InputLine/index.tsx
@@ -1,6 +1,8 @@
 import { ChangeEvent, useContext } from 'react';
 import { useFormContext } from 'react-hook-form';
 
+import { DeviceTypeContext } from '@store/deviceTypeContext';
+
 import { inputFontVar, inputLineVar, inputVar } from './style.css';
 import { formatBirthdate } from './utils/formatBirthdate';
 import { formatPhoneNumber } from './utils/formatPhoneNumber';
@@ -24,7 +26,8 @@ const InputLine = ({
     trigger,
     setValue,
   } = useFormContext();
-  const { required, deviceType } = useContext(FormContext);
+  const { required } = useContext(FormContext);
+  const { deviceType } = useContext(DeviceTypeContext);
   const { maxLength, minLength } = inputElementProps;
   const { defaultValue } = inputElementProps;
 

--- a/src/common/components/Input/components/InputTheme/index.tsx
+++ b/src/common/components/Input/components/InputTheme/index.tsx
@@ -9,10 +9,10 @@ import useMutateCheckUser from '@components/Input/hooks/useMutateCheckUser';
 import useMutateSendCode from '@components/Input/hooks/useMutateSendCode';
 import { VALIDATION_CHECK } from '@constants/validationCheck';
 import useScrollToHash from '@hooks/useScrollToHash';
+import { DeviceTypeContext } from '@store/deviceTypeContext';
 
 import { successVar } from './style.css';
 import InputLine from '../InputLine';
-import { FormContext } from '../TextBox';
 
 export const TextBox이름 = () => {
   return (
@@ -40,7 +40,7 @@ export const TextBox이메일 = ({
   isVerified,
   onChangeVerification,
 }: TextBox이메일Props) => {
-  const { deviceType } = useContext(FormContext);
+  const { deviceType } = useContext(DeviceTypeContext);
   const location = useLocation();
   const navigate = useNavigate();
 
@@ -188,7 +188,7 @@ export const TextBox이메일 = ({
 };
 
 export const TextBox비밀번호 = () => {
-  const { deviceType } = useContext(FormContext);
+  const { deviceType } = useContext(DeviceTypeContext);
 
   const location = useLocation();
   const textVar = location.pathname === '/password' ? '새 비밀번호' : '비밀번호';

--- a/src/common/components/Input/components/TextBox/index.tsx
+++ b/src/common/components/Input/components/TextBox/index.tsx
@@ -1,11 +1,10 @@
 import { createContext } from 'react';
 
 import { TextBoxProps } from '@components/Input/types';
-import { DeviceType, useDevice } from '@hooks/useDevice';
 
 import { circle, containerVar, titleVar } from './style.css';
 
-export const FormContext = createContext({} as Pick<TextBoxProps, 'required'> & { deviceType: DeviceType });
+export const FormContext = createContext({} as Pick<TextBoxProps, 'required'>);
 
 // TextBox Container
 export const TextBox = ({
@@ -15,10 +14,8 @@ export const TextBox = ({
   size = 'md',
   required,
 }: Pick<TextBoxProps, 'children' | 'label' | 'name' | 'size' | 'required'>) => {
-  const deviceType = useDevice();
-
   return (
-    <FormContext.Provider value={{ required, deviceType }}>
+    <FormContext.Provider value={{ required }}>
       <div className={containerVar[deviceType === 'DESK' ? size : deviceType]}>
         <label className={titleVar[deviceType]} htmlFor={name}>
           <span>{label}</span>

--- a/src/common/components/Input/components/TextBox/index.tsx
+++ b/src/common/components/Input/components/TextBox/index.tsx
@@ -1,6 +1,7 @@
-import { createContext } from 'react';
+import { createContext, useContext } from 'react';
 
 import { TextBoxProps } from '@components/Input/types';
+import { DeviceTypeContext } from '@store/deviceTypeContext';
 
 import { circle, containerVar, titleVar } from './style.css';
 
@@ -14,6 +15,8 @@ export const TextBox = ({
   size = 'md',
   required,
 }: Pick<TextBoxProps, 'children' | 'label' | 'name' | 'size' | 'required'>) => {
+  const { deviceType } = useContext(DeviceTypeContext);
+
   return (
     <FormContext.Provider value={{ required }}>
       <div className={containerVar[deviceType === 'DESK' ? size : deviceType]}>

--- a/src/common/components/Input/components/Timer/index.tsx
+++ b/src/common/components/Input/components/Timer/index.tsx
@@ -1,16 +1,17 @@
 import { differenceInSeconds } from 'date-fns';
 import { useContext, useEffect, useState } from 'react';
 
+import { DeviceTypeContext } from '@store/deviceTypeContext';
+
 import { timerVar } from './style.css';
 import { TimerProps } from './types';
 import formatTimer from './utils/formatTimer';
-import { FormContext } from '../TextBox';
 
 const INITIAL_TIME = 300;
 
 // TextBox 내부 타이머
 const Timer = ({ isActive, onResetTimer }: TimerProps) => {
-  const { deviceType } = useContext(FormContext);
+  const { deviceType } = useContext(DeviceTypeContext);
   const [seconds, setSeconds] = useState(INITIAL_TIME - 1);
 
   useEffect(() => {

--- a/src/common/components/Layout/components/Header/Nav/MenuItem/index.tsx
+++ b/src/common/components/Layout/components/Header/Nav/MenuItem/index.tsx
@@ -1,7 +1,8 @@
 import { track } from '@amplitude/analytics-browser';
+import { useContext } from 'react';
 import { NavLink } from 'react-router-dom';
 
-import { useDevice } from '@hooks/useDevice';
+import { DeviceTypeContext } from '@store/deviceTypeContext';
 
 import { menuItemVar, menuLinkVar } from './style.css';
 
@@ -15,7 +16,7 @@ interface MenuItemProps {
 }
 
 const MenuItem = ({ text, path, target, amplitudeId, className, onClick }: MenuItemProps) => {
-  const deviceType = useDevice();
+  const { deviceType } = useContext(DeviceTypeContext);
 
   return (
     <li className={`${className} ${menuItemVar[deviceType]}`}>

--- a/src/common/components/Layout/components/Header/Nav/MenuList/index.tsx
+++ b/src/common/components/Layout/components/Header/Nav/MenuList/index.tsx
@@ -2,7 +2,7 @@ import { reset, track } from '@amplitude/analytics-browser';
 import { useContext, useEffect, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 
-import { useDevice } from '@hooks/useDevice';
+import { DeviceTypeContext } from '@store/deviceTypeContext';
 import { RecruitingInfoContext } from '@store/recruitingInfoContext';
 
 import { dimmedBgVar, menuContainerVar, menuList, menuMobListVar } from './style.css';
@@ -10,7 +10,7 @@ import { MENU_ITEMS, MENU_ITEMS_MAKERS } from '../../contants';
 import MenuItem from '../MenuItem';
 
 const MenuList = ({ isMenuOpen, onClickMenuToggle }: { isMenuOpen?: boolean; onClickMenuToggle?: () => void }) => {
-  const deviceType = useDevice();
+  const { deviceType } = useContext(DeviceTypeContext);
   const navigate = useNavigate();
   const { pathname } = useLocation();
   const [isShown, setIsShown] = useState(isMenuOpen);

--- a/src/common/components/Layout/components/Header/Nav/index.tsx
+++ b/src/common/components/Layout/components/Header/Nav/index.tsx
@@ -1,7 +1,7 @@
 import { IconMenu, IconXClose } from '@sopt-makers/icons';
 import { useContext } from 'react';
 
-import { useDevice } from '@hooks/useDevice';
+import { DeviceTypeContext } from '@store/deviceTypeContext';
 import { ThemeContext } from '@store/themeContext';
 import { theme } from 'styles/theme.css';
 
@@ -9,7 +9,7 @@ import MenuList from './MenuList';
 import { menuIconVar } from './style.css';
 
 const Nav = ({ isMenuOpen, onClickMenuToggle }: { isMenuOpen: boolean; onClickMenuToggle: () => void }) => {
-  const deviceType = useDevice();
+  const { deviceType } = useContext(DeviceTypeContext);
   const { isLight } = useContext(ThemeContext);
 
   return deviceType !== 'DESK' ? (

--- a/src/common/components/Layout/components/Header/index.tsx
+++ b/src/common/components/Layout/components/Header/index.tsx
@@ -4,7 +4,7 @@ import { useLocation, useNavigate } from 'react-router-dom';
 import MakersDarkLogo from '@assets/MakersDarkLogo';
 import MakersLogo from '@assets/MakersLogo';
 import NowsoptLogo from '@assets/NowsoptLogo';
-import { useDevice } from '@hooks/useDevice';
+import { DeviceTypeContext } from '@store/deviceTypeContext';
 import { RecruitingInfoContext } from '@store/recruitingInfoContext';
 import { ThemeContext } from '@store/themeContext';
 
@@ -13,7 +13,7 @@ import MenuList from './Nav/MenuList';
 import { containerSizeVer, containerVar, logoVar } from './style.css';
 
 const Header = () => {
-  const deviceType = useDevice();
+  const { deviceType } = useContext(DeviceTypeContext);
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const handleClickMenuToggle = () => {
     setIsMenuOpen((prev) => !prev);

--- a/src/common/components/Select/index.tsx
+++ b/src/common/components/Select/index.tsx
@@ -1,9 +1,9 @@
 import { IconChevronDown } from '@sopt-makers/icons';
-import { ChangeEvent } from 'react';
+import { ChangeEvent, useContext } from 'react';
 import { useFormContext } from 'react-hook-form';
 
 import { circle, containerVar, titleVar } from '@components/Input/components/TextBox/style.css';
-import { useDevice } from '@hooks/useDevice';
+import { DeviceTypeContext } from '@store/deviceTypeContext';
 
 import {
   errorVar,
@@ -17,7 +17,7 @@ import {
 import { SelectBoxProps } from './type';
 
 const SelectBox = ({ label, name, options, size = 'sm', required, ...inputElementProps }: SelectBoxProps) => {
-  const deviceType = useDevice();
+  const { deviceType } = useContext(DeviceTypeContext);
 
   const { register, formState, clearErrors, getValues, setValue, setError } = useFormContext();
   const { errors } = formState;

--- a/src/common/components/Textarea/components/Input/index.tsx
+++ b/src/common/components/Textarea/components/Input/index.tsx
@@ -1,7 +1,7 @@
-import { useEffect, type TextareaHTMLAttributes } from 'react';
+import { useContext, useEffect, type TextareaHTMLAttributes } from 'react';
 import { type FieldValues, type Path, useFormContext } from 'react-hook-form';
 
-import { useDevice } from '@hooks/useDevice';
+import { DeviceTypeContext } from '@store/deviceTypeContext';
 
 import {
   containerVar,
@@ -26,7 +26,7 @@ const Input = <T extends FieldValues>({
   isFileInput,
   ...textareaElements
 }: InputProps<T>) => {
-  const deviceType = useDevice();
+  const { deviceType } = useContext(DeviceTypeContext);
 
   const {
     watch,

--- a/src/common/components/Textarea/components/Label/index.tsx
+++ b/src/common/components/Textarea/components/Label/index.tsx
@@ -1,6 +1,6 @@
-import { Fragment, type HTMLAttributes } from 'react';
+import { Fragment, useContext, type HTMLAttributes } from 'react';
 
-import { useDevice } from '@hooks/useDevice';
+import { DeviceTypeContext } from '@store/deviceTypeContext';
 
 import { requireDot, labelStyleVar } from './style.css';
 
@@ -12,7 +12,7 @@ interface LabelProps extends HTMLAttributes<HTMLHeadingElement> {
 }
 
 const Label = ({ children, maxCount, required, label, ...headerElementProps }: LabelProps) => {
-  const deviceType = useDevice();
+  const { deviceType } = useContext(DeviceTypeContext);
   const questionArray = children.split('\n');
   const firstEmptyIndex = questionArray.indexOf('');
 

--- a/src/common/components/Title/index.tsx
+++ b/src/common/components/Title/index.tsx
@@ -1,6 +1,6 @@
-import { ReactNode } from 'react';
+import { ReactNode, useContext } from 'react';
 
-import { useDevice } from '@hooks/useDevice';
+import { DeviceTypeContext } from '@store/deviceTypeContext';
 
 import { headingVar } from './style.css';
 
@@ -8,7 +8,7 @@ interface TitleProps {
   children: ReactNode;
 }
 const Title = ({ children }: TitleProps) => {
-  const deviceType = useDevice();
+  const { deviceType } = useContext(DeviceTypeContext);
   return <h1 className={headingVar[deviceType]}>{children}</h1>;
 };
 

--- a/src/common/store/deviceTypeContext.ts
+++ b/src/common/store/deviceTypeContext.ts
@@ -1,0 +1,9 @@
+import { createContext } from 'react';
+
+export interface DeviceTypeContextType {
+  deviceType: 'DESK' | 'TAB' | 'MOB';
+}
+
+export const DeviceTypeContext = createContext<DeviceTypeContextType>({
+  deviceType: 'DESK',
+});

--- a/src/views/ApplyPage/components/ApplyCategory/index.tsx
+++ b/src/views/ApplyPage/components/ApplyCategory/index.tsx
@@ -1,8 +1,8 @@
-import { memo } from 'react';
+import { memo, useContext } from 'react';
 import { Link } from 'react-router-dom';
 
-import { useDevice } from '@hooks/useDevice';
 import useScrollPosition from '@hooks/useScrollPosition';
+import { DeviceTypeContext } from '@store/deviceTypeContext';
 
 import { CATEGORY } from './constant';
 import { activeLinkStyleVar, categoryLinkStyleVar, categoryList, container, containerVar } from './style.css';
@@ -12,7 +12,7 @@ interface ApplyCategoryProps {
   minIndex: number;
 }
 const ApplyCategory = memo(({ isReview, minIndex }: ApplyCategoryProps) => {
-  const deviceType = useDevice();
+  const { deviceType } = useContext(DeviceTypeContext);
   const { isScrollingDown, isScrollTop } = useScrollPosition(isReview ? 380 : 950);
 
   return (

--- a/src/views/ApplyPage/components/ApplyHeader/index.tsx
+++ b/src/views/ApplyPage/components/ApplyHeader/index.tsx
@@ -2,7 +2,7 @@ import { useContext } from 'react';
 
 import Button from '@components/Button';
 import Title from '@components/Title';
-import { useDevice } from '@hooks/useDevice';
+import { DeviceTypeContext } from '@store/deviceTypeContext';
 import { RecruitingInfoContext } from '@store/recruitingInfoContext';
 
 import { buttonWrapper, headerContainerVar } from './style.css';
@@ -15,7 +15,7 @@ interface ApplyHeaderProps {
 }
 
 const ApplyHeader = ({ isReview, isLoading, onSaveDraft, onSubmitData }: ApplyHeaderProps) => {
-  const deviceType = useDevice();
+  const { deviceType } = useContext(DeviceTypeContext);
   const {
     recruitingInfo: { soptName, season, group, isMakers },
   } = useContext(RecruitingInfoContext);

--- a/src/views/ApplyPage/components/ApplyInfo/index.tsx
+++ b/src/views/ApplyPage/components/ApplyInfo/index.tsx
@@ -3,7 +3,7 @@ import { ko } from 'date-fns/locale';
 import { memo, useContext } from 'react';
 
 import Callout from '@components/Callout';
-import { useDevice } from '@hooks/useDevice';
+import { DeviceTypeContext } from '@store/deviceTypeContext';
 import { RecruitingInfoContext } from '@store/recruitingInfoContext';
 
 import {
@@ -19,7 +19,7 @@ import {
 import { APPLY_INFO } from '../../constant';
 
 const ApplyInfo = memo(({ isReview }: { isReview: boolean }) => {
-  const deviceType = useDevice();
+  const { deviceType } = useContext(DeviceTypeContext);
   const {
     recruitingInfo: {
       applicationStart,

--- a/src/views/ApplyPage/components/BottomSection/index.tsx
+++ b/src/views/ApplyPage/components/BottomSection/index.tsx
@@ -4,7 +4,7 @@ import Checkbox from '@components/Checkbox';
 import Contentbox from '@components/Checkbox/components/Contentbox';
 import SelectBox from '@components/Select';
 import { PRIVACY_POLICY } from '@constants/policy';
-import { useDevice } from '@hooks/useDevice';
+import { DeviceTypeContext } from '@store/deviceTypeContext';
 import { RecruitingInfoContext } from '@store/recruitingInfoContext';
 import { SELECT_OPTIONS } from 'views/ApplyPage/constant';
 
@@ -16,7 +16,7 @@ interface BottomSectionProps {
 }
 
 const BottomSection = ({ isReview, knownPath }: BottomSectionProps) => {
-  const deviceType = useDevice();
+  const { deviceType } = useContext(DeviceTypeContext);
   const {
     recruitingInfo: { isMakers },
   } = useContext(RecruitingInfoContext);

--- a/src/views/ApplyPage/components/CommonSection/index.tsx
+++ b/src/views/ApplyPage/components/CommonSection/index.tsx
@@ -1,5 +1,7 @@
+import { useContext } from 'react';
+
 import Textarea from '@components/Textarea';
-import { useDevice } from '@hooks/useDevice';
+import { DeviceTypeContext } from '@store/deviceTypeContext';
 import { sectionContainerVar, sectionTitleVar } from 'views/ApplyPage/style.css';
 import { Answers, Questions } from 'views/ApplyPage/types';
 
@@ -15,7 +17,7 @@ interface CommonSectionProps {
 }
 
 const CommonSection = ({ isReview, refCallback, questions, commonQuestionsDraft }: CommonSectionProps) => {
-  const deviceType = useDevice();
+  const { deviceType } = useContext(DeviceTypeContext);
   const commonQuestionsById = commonQuestionsDraft?.reduce(
     (acc, draft) => {
       acc ? (acc[draft.id] = draft) : undefined;

--- a/src/views/ApplyPage/components/DefaultSection/index.tsx
+++ b/src/views/ApplyPage/components/DefaultSection/index.tsx
@@ -1,11 +1,11 @@
-import { ChangeEvent, useState } from 'react';
+import { ChangeEvent, useContext, useState } from 'react';
 import { useFormContext } from 'react-hook-form';
 
 import { InputLine, TextBox } from '@components/Input';
 import Radio from '@components/Radio';
 import SelectBox from '@components/Select';
 import { VALIDATION_CHECK } from '@constants/validationCheck';
-import { useDevice } from '@hooks/useDevice';
+import { DeviceTypeContext } from '@store/deviceTypeContext';
 import { SELECT_OPTIONS } from 'views/ApplyPage/constant';
 import { sectionTitleVar } from 'views/ApplyPage/style.css';
 import { Applicant } from 'views/ApplyPage/types';
@@ -113,7 +113,7 @@ interface DefaultSectionProps {
 }
 
 const DefaultSection = ({ isMakers, isReview, refCallback, applicantDraft }: DefaultSectionProps) => {
-  const deviceType = useDevice();
+  const { deviceType } = useContext(DeviceTypeContext);
   const {
     address,
     birthday,

--- a/src/views/ApplyPage/components/FileInput/index.tsx
+++ b/src/views/ApplyPage/components/FileInput/index.tsx
@@ -1,12 +1,12 @@
 import { track } from '@amplitude/analytics-browser';
 import { nanoid } from 'nanoid';
-import { ChangeEvent, useEffect, useRef, useState } from 'react';
+import { ChangeEvent, useContext, useEffect, useRef, useState } from 'react';
 import { useFormContext } from 'react-hook-form';
 
 import 'firebase/compat/storage';
 import { STATE_CHANGED, storage } from '@constants/firebase.ts';
 import { VALIDATION_CHECK } from '@constants/validationCheck';
-import { useDevice } from '@hooks/useDevice';
+import { DeviceTypeContext } from '@store/deviceTypeContext';
 
 import IconPlusButton from './icons/IconPlusButton';
 import {
@@ -32,7 +32,7 @@ const LIMIT_SIZE = 1024 ** 2 * 50; // 50MB
 const ACCEPTED_FORMATS = '.pdf';
 
 const FileInput = ({ section, id, isReview, disabled, defaultFile }: FileInputProps) => {
-  const deviceType = useDevice();
+  const { deviceType } = useContext(DeviceTypeContext);
   const inputRef = useRef<HTMLInputElement>(null);
 
   const [uploadPercent, setUploadPercent] = useState(-1);

--- a/src/views/ApplyPage/components/Info/index.tsx
+++ b/src/views/ApplyPage/components/Info/index.tsx
@@ -1,9 +1,11 @@
-import { useDevice } from '@hooks/useDevice';
+import { useContext } from 'react';
+
+import { DeviceTypeContext } from '@store/deviceTypeContext';
 
 import { containerVar, infoVar } from './style.css';
 
 const Info = ({ value }: { value: string }) => {
-  const deviceType = useDevice();
+  const { deviceType } = useContext(DeviceTypeContext);
   return (
     <article>
       <ol className={containerVar[deviceType]}>

--- a/src/views/ApplyPage/components/LinkInput/index.tsx
+++ b/src/views/ApplyPage/components/LinkInput/index.tsx
@@ -1,9 +1,11 @@
-import { useDevice } from '@hooks/useDevice';
+import { useContext } from 'react';
+
+import { DeviceTypeContext } from '@store/deviceTypeContext';
 
 import { containerVar, label, linkVar } from './style.css';
 
 const LinkInput = ({ urls }: { urls: string[] }) => {
-  const deviceType = useDevice();
+  const { deviceType } = useContext(DeviceTypeContext);
   return (
     <>
       {urls.length === 1 && (

--- a/src/views/ApplyPage/components/PartSection/index.tsx
+++ b/src/views/ApplyPage/components/PartSection/index.tsx
@@ -1,8 +1,9 @@
+import { useContext } from 'react';
 import { useFormContext } from 'react-hook-form';
 
 import SelectBox from '@components/Select';
 import Textarea from '@components/Textarea';
-import { useDevice } from '@hooks/useDevice';
+import { DeviceTypeContext } from '@store/deviceTypeContext';
 import { sectionContainerVar, sectionTitleVar } from 'views/ApplyPage/style.css';
 import { Answers, Questions } from 'views/ApplyPage/types';
 
@@ -31,7 +32,7 @@ const PartSection = ({
   partQuestionsDraft,
   questionTypes,
 }: PartSectionProps) => {
-  const deviceType = useDevice();
+  const { deviceType } = useContext(DeviceTypeContext);
   const { getValues } = useFormContext();
 
   const partOptions = questionTypes?.sort((a, b) => a.id - b.id).map(({ typeKr }) => typeKr);

--- a/src/views/ApplyPage/index.tsx
+++ b/src/views/ApplyPage/index.tsx
@@ -1,5 +1,5 @@
 import { track } from '@amplitude/analytics-browser';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useContext, useEffect, useRef, useState } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import { useNavigate } from 'react-router-dom';
 
@@ -7,8 +7,8 @@ import Button from '@components/Button';
 import Footer from '@components/Layout/components/Footer';
 import useCheckBrowser from '@hooks/useCheckBrowser';
 import useDate from '@hooks/useDate';
-import { useDevice } from '@hooks/useDevice';
 import useScrollToHash from '@hooks/useScrollToHash';
+import { DeviceTypeContext } from '@store/deviceTypeContext';
 import { DraftDialog, PreventApplyDialog, SubmitDialog } from 'views/dialogs';
 import NoMore from 'views/ErrorPage/components/NoMore';
 import BigLoading from 'views/loadings/BigLoding';
@@ -34,7 +34,7 @@ interface ApplyPageProps {
 }
 
 const ApplyPage = ({ onSetComplete }: ApplyPageProps) => {
-  const deviceType = useDevice();
+  const { deviceType } = useContext(DeviceTypeContext);
   useCheckBrowser(); // 크롬 브라우저 권장 알럿
 
   const draftDialog = useRef<HTMLDialogElement>(null);

--- a/src/views/CompletePage/components/Survey.tsx
+++ b/src/views/CompletePage/components/Survey.tsx
@@ -1,6 +1,6 @@
-import { useState } from 'react';
+import { useContext, useState } from 'react';
 
-import { useDevice } from '@hooks/useDevice';
+import { DeviceTypeContext } from '@store/deviceTypeContext';
 
 import useMutateSatisfaction from '../hooks/useMutateSatisfaction';
 import {
@@ -13,7 +13,7 @@ import {
 } from '../style.css';
 
 const Survey = () => {
-  const deviceType = useDevice();
+  const { deviceType } = useContext(DeviceTypeContext);
   const [point, setPoint] = useState<number | 'CHANGED'>(-1);
 
   const handleSatisfaction = () => {

--- a/src/views/CompletePage/index.tsx
+++ b/src/views/CompletePage/index.tsx
@@ -3,7 +3,7 @@ import { useContext } from 'react';
 
 import Button from '@components/Button';
 import Callout from '@components/Callout';
-import { useDevice } from '@hooks/useDevice';
+import { DeviceTypeContext } from '@store/deviceTypeContext';
 import { RecruitingInfoContext } from '@store/recruitingInfoContext';
 
 import Survey from './components/Survey';
@@ -11,7 +11,7 @@ import IconCheckmark from './icons/IconCheckmark';
 import { container, iconVar, mainTextVar, subTextVar } from './style.css';
 
 const CompletePage = () => {
-  const deviceType = useDevice();
+  const { deviceType } = useContext(DeviceTypeContext);
   const {
     recruitingInfo: { name, season, group, soptName },
   } = useContext(RecruitingInfoContext);

--- a/src/views/ErrorPage/components/ErrorCode/index.tsx
+++ b/src/views/ErrorPage/components/ErrorCode/index.tsx
@@ -1,4 +1,6 @@
-import { useDevice } from '@hooks/useDevice';
+import { useContext } from 'react';
+
+import { DeviceTypeContext } from '@store/deviceTypeContext';
 import Icon404Back from 'views/ErrorPage/icons/Icon404Back';
 import Icon404Front from 'views/ErrorPage/icons/Icon404Front';
 import Icon500Back from 'views/ErrorPage/icons/Icon500Back';
@@ -9,7 +11,7 @@ import IconGhost from 'views/ErrorPage/icons/IconGhost';
 import { backText, frontText, iconWrapperVar, showIconVar } from './style.css';
 
 export default function ErrorCode({ code }: { code: 404 | 500 }) {
-  const deviceType = useDevice();
+  const { deviceType } = useContext(DeviceTypeContext);
   const isMobile = deviceType === 'MOB';
 
   return (

--- a/src/views/ErrorPage/components/NoMore/index.tsx
+++ b/src/views/ErrorPage/components/NoMore/index.tsx
@@ -1,6 +1,7 @@
 import { track } from '@amplitude/analytics-browser';
+import { useContext } from 'react';
 
-import { useDevice } from '@hooks/useDevice';
+import { DeviceTypeContext } from '@store/deviceTypeContext';
 
 import { article, contactButtonVar, container, errorButtonVar, errorTextVar, instructionVar } from '../../style.css';
 
@@ -10,7 +11,7 @@ interface NoMoreProps {
 }
 
 const NoMore = ({ isMakers, content }: NoMoreProps) => {
-  const deviceType = useDevice();
+  const { deviceType } = useContext(DeviceTypeContext);
 
   return (
     <section className={container}>

--- a/src/views/ErrorPage/index.tsx
+++ b/src/views/ErrorPage/index.tsx
@@ -1,14 +1,15 @@
 import { track } from '@amplitude/analytics-browser';
+import { useContext } from 'react';
 import { useNavigate } from 'react-router-dom';
 
-import { useDevice } from '@hooks/useDevice';
+import { DeviceTypeContext } from '@store/deviceTypeContext';
 
 import ErrorCode from './components/ErrorCode';
 import { ERROR_MESSAGE } from './constants';
 import { article, contactButtonVar, container, errorButtonVar, errorTextVar, instructionVar } from './style.css';
 
 const ErrorPage = ({ code }: { code: 404 | 500 }) => {
-  const deviceType = useDevice();
+  const { deviceType } = useContext(DeviceTypeContext);
   const navigate = useNavigate();
 
   const handleGoBack = (code: 404 | 500) => {

--- a/src/views/MyPage/index.tsx
+++ b/src/views/MyPage/index.tsx
@@ -5,7 +5,7 @@ import Button from '@components/Button';
 import Callout from '@components/Callout';
 import Title from '@components/Title';
 import useDate from '@hooks/useDate';
-import { useDevice } from '@hooks/useDevice';
+import { DeviceTypeContext } from '@store/deviceTypeContext';
 import { RecruitingInfoContext } from '@store/recruitingInfoContext';
 import NoMore from 'views/ErrorPage/components/NoMore';
 import BigLoading from 'views/loadings/BigLoding';
@@ -21,7 +21,7 @@ import {
 } from './style.css';
 
 const MyInfoItem = ({ label, value }: { label: string; value?: string | number | boolean }) => {
-  const deviceType = useDevice();
+  const { deviceType } = useContext(DeviceTypeContext);
   const isMasking = label !== '지원서';
 
   return (
@@ -33,7 +33,7 @@ const MyInfoItem = ({ label, value }: { label: string; value?: string | number |
 };
 
 const StatusButton = ({ label, to, trackingEvent }: { label: string; to: string; trackingEvent: string }) => {
-  const deviceType = useDevice();
+  const { deviceType } = useContext(DeviceTypeContext);
 
   const handlePreventMobile = (e: MouseEvent<HTMLButtonElement>) => {
     track(trackingEvent);
@@ -67,7 +67,7 @@ interface MyPageProps {
 }
 
 const MyPage = ({ part, applicationPass }: MyPageProps) => {
-  const deviceType = useDevice();
+  const { deviceType } = useContext(DeviceTypeContext);
   const {
     recruitingInfo: { name, season },
   } = useContext(RecruitingInfoContext);

--- a/src/views/PasswordPage/index.tsx
+++ b/src/views/PasswordPage/index.tsx
@@ -1,6 +1,8 @@
+import { useContext } from 'react';
+
 import Title from '@components/Title';
 import useDate from '@hooks/useDate';
-import { useDevice } from '@hooks/useDevice';
+import { DeviceTypeContext } from '@store/deviceTypeContext';
 import NoMore from 'views/ErrorPage/components/NoMore';
 import BigLoading from 'views/loadings/BigLoding';
 
@@ -8,7 +10,7 @@ import PasswordForm from './components/PasswordForm';
 import { containerVar } from './style.css';
 
 const PasswordPage = () => {
-  const deviceType = useDevice();
+  const { deviceType } = useContext(DeviceTypeContext);
   const { NoMoreRecruit, isLoading, isMakers } = useDate();
 
   if (isLoading) return <BigLoading />;

--- a/src/views/ResultPage/components/FinalResult.tsx
+++ b/src/views/ResultPage/components/FinalResult.tsx
@@ -4,7 +4,7 @@ import { ko } from 'date-fns/locale';
 import { useContext, useEffect } from 'react';
 
 import Title from '@components/Title';
-import { useDevice } from '@hooks/useDevice';
+import { DeviceTypeContext } from '@store/deviceTypeContext';
 import { RecruitingInfoContext } from '@store/recruitingInfoContext';
 import BigLoading from 'views/loadings/BigLoding';
 
@@ -25,7 +25,7 @@ import imgSoptLogoWebp from '../assets/imgSoptLogo.webp';
 import useGetFinalResult from '../hooks/useGetFinalResult';
 
 const Content = ({ pass }: { pass?: boolean }) => {
-  const deviceType = useDevice();
+  const { deviceType } = useContext(DeviceTypeContext);
   const {
     recruitingInfo: { name, soptName, season, group, isMakers, finalPassConfirmStart },
   } = useContext(RecruitingInfoContext);
@@ -100,7 +100,7 @@ const Content = ({ pass }: { pass?: boolean }) => {
 };
 
 const FinalResult = () => {
-  const deviceType = useDevice();
+  const { deviceType } = useContext(DeviceTypeContext);
   const { finalResult, finalResultIsLoading } = useGetFinalResult();
   const {
     recruitingInfo: { isMakers },

--- a/src/views/ResultPage/components/ScreeningResult.tsx
+++ b/src/views/ResultPage/components/ScreeningResult.tsx
@@ -4,7 +4,7 @@ import { ko } from 'date-fns/locale';
 import { useContext, useEffect } from 'react';
 
 import Title from '@components/Title';
-import { useDevice } from '@hooks/useDevice';
+import { DeviceTypeContext } from '@store/deviceTypeContext';
 import { RecruitingInfoContext } from '@store/recruitingInfoContext';
 import BigLoading from 'views/loadings/BigLoding';
 
@@ -25,7 +25,7 @@ import imgSoptLogoWebp from '../assets/imgSoptLogo.webp';
 import useGetScreeningResult from '../hooks/useGetScreeningResult';
 
 const Content = ({ pass }: { pass?: boolean }) => {
-  const deviceType = useDevice();
+  const { deviceType } = useContext(DeviceTypeContext);
   const {
     recruitingInfo: { name, soptName, season, interviewStart, interviewEnd, applicationPassConfirmStart, isMakers },
   } = useContext(RecruitingInfoContext);
@@ -110,7 +110,7 @@ const Content = ({ pass }: { pass?: boolean }) => {
 };
 
 const ScreeningResult = () => {
-  const deviceType = useDevice();
+  const { deviceType } = useContext(DeviceTypeContext);
   const {
     recruitingInfo: { isMakers },
     handleSaveRecruitingInfo,

--- a/src/views/ReviewPage/index.tsx
+++ b/src/views/ReviewPage/index.tsx
@@ -2,8 +2,8 @@ import { useCallback, useContext, useEffect, useRef, useState } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 
 import useDate from '@hooks/useDate';
-import { useDevice } from '@hooks/useDevice';
 import useScrollToHash from '@hooks/useScrollToHash';
+import { DeviceTypeContext } from '@store/deviceTypeContext';
 import { RecruitingInfoContext } from '@store/recruitingInfoContext';
 import ApplyCategory from 'views/ApplyPage/components/ApplyCategory';
 import ApplyHeader from 'views/ApplyPage/components/ApplyHeader';
@@ -20,7 +20,7 @@ import NoMore from 'views/ErrorPage/components/NoMore';
 import BigLoading from 'views/loadings/BigLoding';
 
 const ReviewPage = () => {
-  const deviceType = useDevice();
+  const { deviceType } = useContext(DeviceTypeContext);
   const preventReviewDialog = useRef<HTMLDialogElement>(null);
   const sectionsRef = useRef<HTMLSelectElement[]>([]);
 

--- a/src/views/SignInPage/components/SignInInfo/index.tsx
+++ b/src/views/SignInPage/components/SignInInfo/index.tsx
@@ -4,13 +4,13 @@ import { Link } from 'react-router-dom';
 
 import Callout from '@components/Callout';
 import Title from '@components/Title';
-import { useDevice } from '@hooks/useDevice';
+import { DeviceTypeContext } from '@store/deviceTypeContext';
 import { RecruitingInfoContext } from '@store/recruitingInfoContext';
 
 import { calloutButtonVar } from './style.css';
 
 const SignInInfo = () => {
-  const deviceType = useDevice();
+  const { deviceType } = useContext(DeviceTypeContext);
   const {
     recruitingInfo: { soptName, isMakers, season, group },
   } = useContext(RecruitingInfoContext);

--- a/src/views/SignInPage/index.tsx
+++ b/src/views/SignInPage/index.tsx
@@ -1,5 +1,7 @@
+import { useContext } from 'react';
+
 import useDate from '@hooks/useDate';
-import { useDevice } from '@hooks/useDevice';
+import { DeviceTypeContext } from '@store/deviceTypeContext';
 import NoMore from 'views/ErrorPage/components/NoMore';
 import BigLoading from 'views/loadings/BigLoding';
 
@@ -8,7 +10,7 @@ import SignInInfo from './components/SignInInfo';
 import { containerVar } from './style.css';
 
 const SignInPage = () => {
-  const deviceType = useDevice();
+  const { deviceType } = useContext(DeviceTypeContext);
   const { isLoading, NoMoreRecruit, isMakers } = useDate();
 
   if (isLoading) return <BigLoading />;

--- a/src/views/SignupPage/index.tsx
+++ b/src/views/SignupPage/index.tsx
@@ -1,6 +1,8 @@
+import { useContext } from 'react';
+
 import Title from '@components/Title';
 import useDate from '@hooks/useDate';
-import { useDevice } from '@hooks/useDevice';
+import { DeviceTypeContext } from '@store/deviceTypeContext';
 import NoMore from 'views/ErrorPage/components/NoMore';
 import BigLoading from 'views/loadings/BigLoding';
 
@@ -8,7 +10,7 @@ import SignupForm from './components/SignupForm';
 import { containerVar } from './style.css';
 
 const SignupPage = () => {
-  const deviceType = useDevice();
+  const { deviceType } = useContext(DeviceTypeContext);
   const { NoMoreRecruit, NoMoreApply, isLoading, isMakers } = useDate();
 
   if (isLoading) return <BigLoading />;

--- a/src/views/dialogs/CompleteDialog/index.tsx
+++ b/src/views/dialogs/CompleteDialog/index.tsx
@@ -1,13 +1,13 @@
-import { forwardRef } from 'react';
+import { forwardRef, useContext } from 'react';
 import { Link } from 'react-router-dom';
 
 import Dialog from '@components/Dialog';
-import { useDevice } from '@hooks/useDevice';
+import { DeviceTypeContext } from '@store/deviceTypeContext';
 
 import { buttonInside, buttonOutside, buttonOutsideVar, buttonWrapperVar, mainTextVar, subTextVar } from '../style.css';
 
 const CompleteDialog = forwardRef<HTMLDialogElement>((_, ref) => {
-  const deviceType = useDevice();
+  const { deviceType } = useContext(DeviceTypeContext);
 
   return (
     <Dialog ref={ref}>

--- a/src/views/dialogs/DraftDialog/index.tsx
+++ b/src/views/dialogs/DraftDialog/index.tsx
@@ -1,12 +1,12 @@
-import { forwardRef } from 'react';
+import { forwardRef, useContext } from 'react';
 
 import Dialog from '@components/Dialog';
-import { useDevice } from '@hooks/useDevice';
+import { DeviceTypeContext } from '@store/deviceTypeContext';
 
 import { buttonInside, buttonOutside, buttonOutsideVar, buttonWrapperVar, mainTextVar } from '../style.css';
 
 const DraftDialog = forwardRef<HTMLDialogElement>((_, ref) => {
-  const deviceType = useDevice();
+  const { deviceType } = useContext(DeviceTypeContext);
 
   return (
     <Dialog ref={ref}>

--- a/src/views/dialogs/ExistingApplicantDialog/index.tsx
+++ b/src/views/dialogs/ExistingApplicantDialog/index.tsx
@@ -1,13 +1,13 @@
-import { forwardRef } from 'react';
+import { forwardRef, useContext } from 'react';
 import { Link } from 'react-router-dom';
 
 import Dialog from '@components/Dialog';
-import { useDevice } from '@hooks/useDevice';
+import { DeviceTypeContext } from '@store/deviceTypeContext';
 
 import { buttonInside, buttonOutside, buttonOutsideVar, buttonWrapperVar, mainTextVar } from '../style.css';
 
 const ExistingApplicantDialog = forwardRef<HTMLDialogElement>((_, ref) => {
-  const deviceType = useDevice();
+  const { deviceType } = useContext(DeviceTypeContext);
 
   return (
     <Dialog ref={ref}>

--- a/src/views/dialogs/ExitDialog/index.tsx
+++ b/src/views/dialogs/ExitDialog/index.tsx
@@ -1,12 +1,12 @@
-import { forwardRef } from 'react';
+import { forwardRef, useContext } from 'react';
 
 import Dialog from '@components/Dialog';
-import { useDevice } from '@hooks/useDevice';
+import { DeviceTypeContext } from '@store/deviceTypeContext';
 
 import { buttonInside, buttonOutside, buttonOutsideVar, buttonWrapperVar, mainTextVar, subTextVar } from '../style.css';
 
 const ExitDialog = forwardRef<HTMLDialogElement>((_, ref) => {
-  const deviceType = useDevice();
+  const { deviceType } = useContext(DeviceTypeContext);
 
   return (
     <Dialog ref={ref}>

--- a/src/views/dialogs/PreventApplyDialog/index.tsx
+++ b/src/views/dialogs/PreventApplyDialog/index.tsx
@@ -1,12 +1,12 @@
-import { forwardRef, type KeyboardEvent } from 'react';
+import { forwardRef, useContext, type KeyboardEvent } from 'react';
 
 import Dialog from '@components/Dialog';
-import { useDevice } from '@hooks/useDevice';
+import { DeviceTypeContext } from '@store/deviceTypeContext';
 
 import { buttonInside, buttonOutside, buttonOutsideVar, buttonWrapperVar, mainTextVar } from '../style.css';
 
 const PreventApplyDialog = forwardRef<HTMLDialogElement>((_, ref) => {
-  const deviceType = useDevice();
+  const { deviceType } = useContext(DeviceTypeContext);
 
   const handlePreventESCKeyPress = (e: KeyboardEvent<HTMLDialogElement>) => {
     if (e.key === 'Escape') e.preventDefault();

--- a/src/views/dialogs/PreventReviewDialog/index.tsx
+++ b/src/views/dialogs/PreventReviewDialog/index.tsx
@@ -1,13 +1,13 @@
-import { forwardRef, type KeyboardEvent } from 'react';
+import { forwardRef, useContext, type KeyboardEvent } from 'react';
 import { Link } from 'react-router-dom';
 
 import Dialog from '@components/Dialog';
-import { useDevice } from '@hooks/useDevice';
+import { DeviceTypeContext } from '@store/deviceTypeContext';
 
 import { buttonInside, buttonOutside, buttonOutsideVar, buttonWrapperVar, mainTextVar, subTextVar } from '../style.css';
 
 const PreventReviewDialog = forwardRef<HTMLDialogElement>((_, ref) => {
-  const deviceType = useDevice();
+  const { deviceType } = useContext(DeviceTypeContext);
 
   const handlePreventESCKeyPress = (e: KeyboardEvent<HTMLDialogElement>) => {
     if (e.key === 'Escape') e.preventDefault();

--- a/src/views/dialogs/SessionExpiredDialog/index.tsx
+++ b/src/views/dialogs/SessionExpiredDialog/index.tsx
@@ -1,13 +1,13 @@
 import { track } from '@amplitude/analytics-browser';
-import { forwardRef, type KeyboardEvent } from 'react';
+import { forwardRef, useContext, type KeyboardEvent } from 'react';
 
 import Dialog from '@components/Dialog';
-import { useDevice } from '@hooks/useDevice';
+import { DeviceTypeContext } from '@store/deviceTypeContext';
 
 import { buttonInside, buttonOutside, buttonOutsideVar, buttonWrapperVar, mainTextVar, subTextVar } from '../style.css';
 
 const SessionExpiredDialog = forwardRef<HTMLDialogElement>((_, ref) => {
-  const deviceType = useDevice();
+  const { deviceType } = useContext(DeviceTypeContext);
 
   const handlePreventESCKeyPress = (e: KeyboardEvent<HTMLDialogElement>) => {
     if (e.key === 'Escape') e.preventDefault();

--- a/src/views/dialogs/SubmitDialog/index.tsx
+++ b/src/views/dialogs/SubmitDialog/index.tsx
@@ -1,8 +1,8 @@
 import { track } from '@amplitude/analytics-browser';
-import { type ChangeEvent, forwardRef, useState } from 'react';
+import { type ChangeEvent, forwardRef, useContext, useState } from 'react';
 
 import Dialog from '@components/Dialog';
-import { useDevice } from '@hooks/useDevice';
+import { DeviceTypeContext } from '@store/deviceTypeContext';
 import ButtonLoading from 'views/loadings/ButtonLoading';
 
 import {
@@ -49,7 +49,7 @@ const SubmitDialog = forwardRef<HTMLDialogElement, SubmitDialogProps>(
   ({ userInfo: { name, email, phone, part }, dataIsPending, onSendData }, ref) => {
     const [isChecked, setIsChecked] = useState(false);
 
-    const deviceType = useDevice();
+    const { deviceType } = useContext(DeviceTypeContext);
 
     const handleCheck = (e: ChangeEvent<HTMLInputElement>) => {
       setIsChecked(e.target.checked);


### PR DESCRIPTION
**Related Issue :** Closes #410 

---

## 🧑‍🎤 Summary
- [x] Form context의 device type undefined 떠서 디자인 적용 안 되는 이슈 해결
- [x] Maximum update depth exceeded. 에러 해결
![스크린샷 2024-08-17 오후 6 08 10](https://github.com/user-attachments/assets/abcd49e7-7561-4eb8-80f3-f77d357d2ac7)


## 🧑‍🎤 Screenshot
전 - css가 먹히지 않음
![스크린샷 2024-08-17 오후 5 33 51](https://github.com/user-attachments/assets/8e4aae41-40a0-46a8-9a09-6bb9df451948)

후 - css 먹힘
![스크린샷 2024-08-17 오후 6 05 18](https://github.com/user-attachments/assets/e5c84be4-b05b-4abe-83d2-5ebf2a42eef9)



## 🧑‍🎤 Comment
### 🧘🏻‍♂️ Maximum update depth exceeded. 에러 해결
일단 현재는 deviceType을 FormContext에서 관리하고 있었는데요
FormContext는 input들 각각에 required를 각자 관리해주기 위해 있는 거였어요
이때 deviceType을 이 안에 넣어주게 됨으로써
각각의 input들에서 각자의 device type을 관리하게 되었어요
다시 말해 각각의 input들에서 각각 useDevice를 실행해주는 것이죠
이 때문에 Maximum update 이슈도 발생한 것으로 파악이 돼요!

따라서 FormContext에서 deviceType을 제거하고
App.tsx에서 전체 컴포넌트에 하나의 DeciveTypeContext를 감싸준 뒤
이를 모든 곳에서 활용하도록 했어요
각 input들 마다 다른 device type이 필요한 것이 아니라
모든 곳에서 공통된 device type이 사용되니까요!

### 🧘🏻‍♂️ Form context의 device type undefined 떠서 디자인 적용 안 되는 이슈 해결
#### 왜 안 되는 거였는가?
기존에는 Textbox 안에서 FormContext를 Provider를 이용해서 감싸주고 있었어요
이 말은 곧 Textbox 하위 컴포넌트에서 해당 context를 이용할 수 있다는 얘기인데요
TextBox이메일, TextBox비밀번호 등등은
Textbox를 자식으로 가지는 부모 컴포넌트이기에 해당 context를 이용할 수가 없었어요
그렇기에 undefined가 뜨는 거였습니다!

#### 그럼 왜 디자인은 반응형으로 줄어들었는가?
deviceType이 undefined라서 웹페이지 크기가 어떻든 width는 208로 고정되어 있었어요
![스크린샷 2024-08-17 오후 6 47 51](https://github.com/user-attachments/assets/d44a8988-b3bb-4dc8-be77-f56ca6702da3)

하지만 InputLine 컴포넌트의 flex css 속성을 1로 설정해서 자동으로 늘어났다 줄어드는 거였어요
실제로 해당 속성을 제거하면 width가 고정이 됩니다!
![스크린샷 2024-08-17 오후 6 49 57](https://github.com/user-attachments/assets/5f075c95-3488-4f9a-acc6-2943a38bd242)

DeviceTypeContext를 Textbox에서 App.tsx로 옮겨줌으로써 해당 이슈도 해결이 되었어요 :)