### PR TITLE
[Fix] manifest 및 og tag link 수정

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,18 +18,18 @@
     <meta property="og:type" content="website" />
     <meta property="og:locale" content="ko_KR" />
 
-    <link rel="manifest" href="/manifest.webmanifest" />
+    <link rel="manifest" href="https://recruiting.sopt.org/manifest.webmanifest" />
 
-    <link rel="icon" href="/makersFavicon.ico" sizes="32x32" />
-    <link rel="icon" href="/makersIcon.svg" type="image/svg+xml" />
-    <link rel="apple-touch-icon" href="/makers-touch-icon.png" />
+    <link rel="icon" href="https://recruiting.sopt.org/makersFavicon.ico" sizes="32x32" />
+    <link rel="icon" href="https://recruiting.sopt.org/makersIcon.svg" type="image/svg+xml" />
+    <link rel="apple-touch-icon" href="https://recruiting.sopt.org/makers-touch-icon.png" />
 
     <meta property="og:title" content="SOPT makers 모집 지원하기" />
     <meta property="og:description" content="SOPT makers의 신입 기수 모집페이지입니다." />
     <meta property="og:site_name" content="SOPT makers 리크루팅" />
     <meta property="og:url" content="https://recruiting.sopt.org" />
 
-    <meta property="og:image" content="/makersOg.png" />
+    <meta property="og:image" content="https://recruiting.sopt.org/makersOg.png" />
     <meta property="og:image:alt" content="SOPT makers 리크루팅" />
     <meta property="og:image:width" content="800" />
     <meta property="og:image:height" content="400" />
@@ -37,7 +37,7 @@
     <meta property="twitter:card" content="website" />
     <meta name="twitter:title" content="SOPT makers 모집 지원하기" />
     <meta name="twitter:description" content="SOPT makers의 신입 기수 모집페이지입니다." />
-    <meta name="twitter:image" content="/makersOg.png" />
+    <meta name="twitter:image" content="https://recruiting.sopt.org/makersOg.png" />
     <meta property="twitter:image:alt" content="SOPT makers 리크루팅" />
     <meta property="twitter:site" content="https://recruiting.sopt.org" />
 

--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
     <meta property="og:type" content="website" />
     <meta property="og:locale" content="ko_KR" />
 
-    <link rel="manifest" href="/makersManifest.webmanifest" />
+    <link rel="manifest" href="/manifest.webmanifest" />
 
     <link rel="icon" href="/makersFavicon.ico" sizes="32x32" />
     <link rel="icon" href="/makersIcon.svg" type="image/svg+xml" />


### PR DESCRIPTION
**Related Issue :** Closes #418 

---

## 🧑‍🎤 Summary
- index.html 하드코딩 수정 과정에서 manifest 파일명을 잘못써서 수정했습니다 
- og tag Link를 full url로 수정해주었습니다. 

## 🧑‍🎤 Screenshot & Comment
<img width="333" alt="image" src="https://github.com/user-attachments/assets/47ae1f2f-492d-431c-b569-51882a276878">

현재 위와 같이 다른 Og는 잘 뜨는데, 이미지만 안뜨고 있는걸 확인할 수 있어요. 
og의 경우 public 폴더 하의 에셋들을 사용할 때, 경로를 작성하면 안되고 도메인까지 붙인 full url을 넣어줘야 정상작동합니다. 
따라서 url로 고쳐주었어요! 
배포해서 확인해보고 잘 되면 SOPT 레포에도 반영할 예정입니다 