### PR TITLE
[Fix] 텍스트필드 모바일뷰 폰트 사이즈 14->16px 수정 

### DIFF
--- a/src/common/components/Input/components/InputLine/index.tsx
+++ b/src/common/components/Input/components/InputLine/index.tsx
@@ -3,7 +3,7 @@ import { useFormContext } from 'react-hook-form';
 
 import { DeviceTypeContext } from '@store/deviceTypeContext';
 
-import { inputFontVar, inputLineVar, inputVar } from './style.css';
+import { inputFont, inputLineVar, inputVar } from './style.css';
 import { formatBirthdate } from './utils/formatBirthdate';
 import { formatPhoneNumber } from './utils/formatPhoneNumber';
 import { TextBoxProps } from '../../types';
@@ -50,7 +50,7 @@ const InputLine = ({
         <input
           id={name}
           defaultValue={defaultValue}
-          className={`${inputVar[errors[name] ? 'error' : 'default']} ${inputFontVar[deviceType]}`}
+          className={`${inputVar[errors[name] ? 'error' : 'default']} ${inputFont}`}
           {...inputElementProps}
           {...register(name, {
             required: required && '필수 입력 항목이에요.',

--- a/src/common/components/Input/components/InputLine/style.css.ts
+++ b/src/common/components/Input/components/InputLine/style.css.ts
@@ -70,6 +70,5 @@ export const inputFont = style({
 
   '::placeholder': {
     color: theme.color.placeholder,
-    ...theme.font.BODY_2_16_R,
   },
 });

--- a/src/common/components/Input/components/InputLine/style.css.ts
+++ b/src/common/components/Input/components/InputLine/style.css.ts
@@ -64,21 +64,12 @@ export const inputVar = styleVariants(formColors, ({ boxShadow, focusShadow }) =
   },
 ]);
 
-export const inputFontVar = styleVariants(
-  {
-    DESK: theme.font.BODY_2_16_R,
-    TAB: theme.font.BODY_2_16_R,
-    MOB: theme.font.BODY_3_14_R,
-  },
-  (font) => [
-    {
-      color: theme.color.baseText,
-      ...font,
+export const inputFont = style({
+  color: theme.color.baseText,
+  ...theme.font.BODY_2_16_R,
 
-      '::placeholder': {
-        color: theme.color.placeholder,
-        ...font,
-      },
-    },
-  ],
-);
+  '::placeholder': {
+    color: theme.color.placeholder,
+    ...theme.font.BODY_2_16_R,
+  },
+});


### PR DESCRIPTION
**Related Issue :** Closes #427 

---

## 🧑‍🎤 Summary
16px 미만으로 설정되어있는 input 때문에 iOS safari에서 입력창 focus 시 자동으로 zoom이 되는 이슈 해결 

## 🧑‍🎤 Screenshot
- 14px

https://github.com/user-attachments/assets/bb0fa021-d051-4d8e-ad9a-777031ac7c88

- 16px

https://github.com/user-attachments/assets/83a98c27-0ebc-4d2f-ad18-7bb000a13529



## 🧑‍🎤 Comment
meta tag viewport에서 user-scalable 설정을 해줘서 막는 방법도 있지만, 
이는 접근성을 위한 기능을 강제로 막는 방식이기 때문에 최대한 지양하는 것이 좋다고 판단했습니다 
따라서 디자이너분들께 이슈 공유하고 14px이었던 모바일뷰 폰트 사이즈를 16px로 수정 (다른 뷰와 통일) 하는 것으로 수정했습니다 ~~ 
