### PR TITLE
[Refactor] 번들 크기 개선 - 3

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,11 +11,13 @@ import DeviceTypeProvider from 'contexts/DeviceTypeProvider';
 import RecruitingInfoProvider from 'contexts/RecruitingInfoProvider';
 import ThemeProvider, { useTheme } from 'contexts/ThemeProvider';
 import { dark, light } from 'styles/theme.css';
-import { SessionExpiredDialog } from 'views/dialogs';
 import BigLoading from 'views/loadings/BigLoding';
 
 import 'styles/reset.css';
 
+const SessionExpiredDialog = lazy(() =>
+  import('views/dialogs').then(({ SessionExpiredDialog }) => ({ default: SessionExpiredDialog })),
+);
 const MainPage = lazy(() => import('views/MainPage'));
 const PasswordPage = lazy(() => import('views/PasswordPage'));
 const ResultPage = lazy(() => import('views/ResultPage'));

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,7 +3,7 @@ import { sessionReplayPlugin } from '@amplitude/plugin-session-replay-browser';
 import { MutationCache, QueryCache, QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { AxiosError } from 'axios';
-import { useEffect, useRef, useState } from 'react';
+import { lazy, Suspense, useEffect, useRef, useState } from 'react';
 import { RouterProvider, createBrowserRouter } from 'react-router-dom';
 
 import Layout from '@components/Layout';
@@ -12,14 +12,16 @@ import RecruitingInfoProvider from 'contexts/RecruitingInfoProvider';
 import ThemeProvider, { useTheme } from 'contexts/ThemeProvider';
 import { dark, light } from 'styles/theme.css';
 import { SessionExpiredDialog } from 'views/dialogs';
-import ErrorPage from 'views/ErrorPage';
-import MainPage from 'views/MainPage';
-import PasswordPage from 'views/PasswordPage';
-import ResultPage from 'views/ResultPage';
-import ReviewPage from 'views/ReviewPage';
-import SignupPage from 'views/SignupPage';
+import BigLoading from 'views/loadings/BigLoding';
 
 import 'styles/reset.css';
+
+const MainPage = lazy(() => import('views/MainPage'));
+const PasswordPage = lazy(() => import('views/PasswordPage'));
+const ResultPage = lazy(() => import('views/ResultPage'));
+const ReviewPage = lazy(() => import('views/ReviewPage'));
+const SignupPage = lazy(() => import('views/SignupPage'));
+const ErrorPage = lazy(() => import('views/ErrorPage'));
 
 const router = createBrowserRouter([
   {
@@ -113,7 +115,9 @@ const App = () => {
             <QueryClientProvider client={queryClient}>
               <ReactQueryDevtools />
               <div className={isLight ? light : dark}>
-                <RouterProvider router={router} />
+                <Suspense fallback={<BigLoading />}>
+                  <RouterProvider router={router} />
+                </Suspense>
               </div>
             </QueryClientProvider>
           </RecruitingInfoProvider>

--- a/src/views/ApplyPage/index.tsx
+++ b/src/views/ApplyPage/index.tsx
@@ -1,5 +1,5 @@
 import { track } from '@amplitude/analytics-browser';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { lazy, useCallback, useEffect, useRef, useState } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import { useNavigate } from 'react-router-dom';
 
@@ -10,7 +10,6 @@ import useDate from '@hooks/useDate';
 import useScrollToHash from '@hooks/useScrollToHash';
 import { useDeviceType } from 'contexts/DeviceTypeProvider';
 import { DraftDialog, PreventApplyDialog, SubmitDialog } from 'views/dialogs';
-import NoMore from 'views/ErrorPage/components/NoMore';
 import BigLoading from 'views/loadings/BigLoding';
 
 import ApplyCategory from './components/ApplyCategory';
@@ -28,6 +27,8 @@ import useMutateSubmit from './hooks/useMutateSubmit';
 import { buttonWrapper, container, formContainerVar } from './style.css';
 
 import type { ApplyRequest } from './types';
+
+const NoMore = lazy(() => import('views/ErrorPage/components/NoMore'));
 
 interface ApplyPageProps {
   onSetComplete?: () => void;

--- a/src/views/ApplyPage/index.tsx
+++ b/src/views/ApplyPage/index.tsx
@@ -9,7 +9,6 @@ import useCheckBrowser from '@hooks/useCheckBrowser';
 import useDate from '@hooks/useDate';
 import useScrollToHash from '@hooks/useScrollToHash';
 import { useDeviceType } from 'contexts/DeviceTypeProvider';
-import { DraftDialog, PreventApplyDialog, SubmitDialog } from 'views/dialogs';
 import BigLoading from 'views/loadings/BigLoding';
 
 import ApplyCategory from './components/ApplyCategory';
@@ -28,6 +27,11 @@ import { buttonWrapper, container, formContainerVar } from './style.css';
 
 import type { ApplyRequest } from './types';
 
+const DraftDialog = lazy(() => import('views/dialogs').then(({ DraftDialog }) => ({ default: DraftDialog })));
+const PreventApplyDialog = lazy(() =>
+  import('views/dialogs').then(({ PreventApplyDialog }) => ({ default: PreventApplyDialog })),
+);
+const SubmitDialog = lazy(() => import('views/dialogs').then(({ SubmitDialog }) => ({ default: SubmitDialog })));
 const NoMore = lazy(() => import('views/ErrorPage/components/NoMore'));
 
 interface ApplyPageProps {

--- a/src/views/MyPage/index.tsx
+++ b/src/views/MyPage/index.tsx
@@ -1,4 +1,5 @@
 import { track } from '@amplitude/analytics-browser';
+import { lazy } from 'react';
 
 import Button from '@components/Button';
 import Callout from '@components/Callout';
@@ -6,7 +7,6 @@ import Title from '@components/Title';
 import useDate from '@hooks/useDate';
 import { useDeviceType } from 'contexts/DeviceTypeProvider';
 import { useRecruitingInfo } from 'contexts/RecruitingInfoProvider';
-import NoMore from 'views/ErrorPage/components/NoMore';
 import BigLoading from 'views/loadings/BigLoding';
 
 import {
@@ -18,6 +18,8 @@ import {
   infoValueVar,
   buttonWidthVar,
 } from './style.css';
+
+const NoMore = lazy(() => import('views/ErrorPage/components/NoMore'));
 
 const MyInfoItem = ({ label, value }: { label: string; value?: string | number | boolean }) => {
   const { deviceType } = useDeviceType();

--- a/src/views/PasswordPage/components/PasswordForm/index.tsx
+++ b/src/views/PasswordPage/components/PasswordForm/index.tsx
@@ -1,5 +1,5 @@
 import { track } from '@amplitude/analytics-browser';
-import { useRef } from 'react';
+import { lazy, useRef } from 'react';
 import { FormProvider, useForm, type FieldValues } from 'react-hook-form';
 
 import Button from '@components/Button';
@@ -7,10 +7,11 @@ import { TextBox비밀번호, TextBox이름, TextBox이메일 } from '@component
 import { VALIDATION_CHECK } from '@constants/validationCheck';
 import useVerificationStatus from '@hooks/useVerificationStatus';
 import { useRecruitingInfo } from 'contexts/RecruitingInfoProvider';
-import { CompleteDialog } from 'views/dialogs';
 import useMutateChangePassword from 'views/PasswordPage/hooks/useMutateChangePassword';
 
 import { formWrapper } from './style.css';
+
+const CompleteDialog = lazy(() => import('views/dialogs').then(({ CompleteDialog }) => ({ default: CompleteDialog })));
 
 const PasswordForm = () => {
   const completeDialog = useRef<HTMLDialogElement>(null);

--- a/src/views/PasswordPage/index.tsx
+++ b/src/views/PasswordPage/index.tsx
@@ -1,11 +1,14 @@
+import { lazy } from 'react';
+
 import Title from '@components/Title';
 import useDate from '@hooks/useDate';
 import { useDeviceType } from 'contexts/DeviceTypeProvider';
-import NoMore from 'views/ErrorPage/components/NoMore';
 import BigLoading from 'views/loadings/BigLoding';
 
 import PasswordForm from './components/PasswordForm';
 import { containerVar } from './style.css';
+
+const NoMore = lazy(() => import('views/ErrorPage/components/NoMore'));
 
 const PasswordPage = () => {
   const { deviceType } = useDeviceType();

--- a/src/views/ResultPage/index.tsx
+++ b/src/views/ResultPage/index.tsx
@@ -1,13 +1,14 @@
-import { useEffect } from 'react';
+import { useEffect, lazy } from 'react';
 
 import useDate from '@hooks/useDate';
 import { useTheme } from 'contexts/ThemeProvider';
-import NoMore from 'views/ErrorPage/components/NoMore';
 import BigLoading from 'views/loadings/BigLoding';
 import useGetMyInfo from 'views/SignedInPage/hooks/useGetMyInfo';
 
 import FinalResult from './components/FinalResult';
 import ScreeningResult from './components/ScreeningResult';
+
+const NoMore = lazy(() => import('views/ErrorPage/components/NoMore'));
 
 const ResultPage = () => {
   const { handleChangeMode } = useTheme();

--- a/src/views/ReviewPage/index.tsx
+++ b/src/views/ReviewPage/index.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { lazy, useCallback, useEffect, useRef, useState } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 
 import useDate from '@hooks/useDate';
@@ -16,8 +16,9 @@ import useGetDraft from 'views/ApplyPage/hooks/useGetDraft';
 import useGetQuestions from 'views/ApplyPage/hooks/useGetQuestions';
 import { container, formContainerVar } from 'views/ApplyPage/style.css';
 import { PreventReviewDialog } from 'views/dialogs';
-import NoMore from 'views/ErrorPage/components/NoMore';
 import BigLoading from 'views/loadings/BigLoding';
+
+const NoMore = lazy(() => import('views/ErrorPage/components/NoMore'));
 
 const ReviewPage = () => {
   const { deviceType } = useDeviceType();

--- a/src/views/ReviewPage/index.tsx
+++ b/src/views/ReviewPage/index.tsx
@@ -15,9 +15,11 @@ import PartSection from 'views/ApplyPage/components/PartSection';
 import useGetDraft from 'views/ApplyPage/hooks/useGetDraft';
 import useGetQuestions from 'views/ApplyPage/hooks/useGetQuestions';
 import { container, formContainerVar } from 'views/ApplyPage/style.css';
-import { PreventReviewDialog } from 'views/dialogs';
 import BigLoading from 'views/loadings/BigLoding';
 
+const PreventReviewDialog = lazy(() =>
+  import('views/dialogs').then(({ PreventReviewDialog }) => ({ default: PreventReviewDialog })),
+);
 const NoMore = lazy(() => import('views/ErrorPage/components/NoMore'));
 
 const ReviewPage = () => {

--- a/src/views/SignInPage/index.tsx
+++ b/src/views/SignInPage/index.tsx
@@ -1,11 +1,14 @@
+import { lazy } from 'react';
+
 import useDate from '@hooks/useDate';
 import { useDeviceType } from 'contexts/DeviceTypeProvider';
-import NoMore from 'views/ErrorPage/components/NoMore';
 import BigLoading from 'views/loadings/BigLoding';
 
 import SignInForm from './components/SignInForm';
 import SignInInfo from './components/SignInInfo';
 import { containerVar } from './style.css';
+
+const NoMore = lazy(() => import('views/ErrorPage/components/NoMore'));
 
 const SignInPage = () => {
   const { deviceType } = useDeviceType();

--- a/src/views/SignupPage/components/SignupForm/index.tsx
+++ b/src/views/SignupPage/components/SignupForm/index.tsx
@@ -1,5 +1,5 @@
 import { track } from '@amplitude/analytics-browser';
-import { useEffect, useRef } from 'react';
+import { lazy, useEffect, useRef } from 'react';
 import { type FieldValues, FormProvider, useForm } from 'react-hook-form';
 
 import Button from '@components/Button';
@@ -11,10 +11,13 @@ import { PRIVACY_POLICY } from '@constants/policy';
 import { VALIDATION_CHECK } from '@constants/validationCheck';
 import useVerificationStatus from '@hooks/useVerificationStatus';
 import { useRecruitingInfo } from 'contexts/RecruitingInfoProvider';
-import { ExistingApplicantDialog } from 'views/dialogs';
 import useMutateSignUp from 'views/SignupPage/hooks/useMutateSignUp';
 
 import { formWrapper } from './style.css';
+
+const ExistingApplicantDialog = lazy(() =>
+  import('views/dialogs').then(({ ExistingApplicantDialog }) => ({ default: ExistingApplicantDialog })),
+);
 
 const SignupForm = () => {
   const {

--- a/src/views/SignupPage/index.tsx
+++ b/src/views/SignupPage/index.tsx
@@ -1,11 +1,14 @@
+import { lazy } from 'react';
+
 import Title from '@components/Title';
 import useDate from '@hooks/useDate';
 import { useDeviceType } from 'contexts/DeviceTypeProvider';
-import NoMore from 'views/ErrorPage/components/NoMore';
 import BigLoading from 'views/loadings/BigLoding';
 
 import SignupForm from './components/SignupForm';
 import { containerVar } from './style.css';
+
+const NoMore = lazy(() => import('views/ErrorPage/components/NoMore'));
 
 const SignupPage = () => {
   const { deviceType } = useDeviceType();

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -17,6 +17,15 @@ export default defineConfig({
       brotliSize: true,
     }) as PluginOption,
   ],
+  build: {
+    rollupOptions: {
+      output: {
+        manualChunks: (id) => {
+          if (id.includes('firebase')) return 'firebase';
+        },
+      },
+    },
+  },
   resolve: {
     alias: [
       { find: '@apis', replacement: path.resolve(__dirname, 'src/common/apis') },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -12,7 +12,6 @@ export default defineConfig({
     vanillaExtractPlugin(),
     visualizer({
       filename: './dist/report.html',
-      open: true,
       gzipSize: true,
       brotliSize: true,
     }) as PluginOption,


### PR DESCRIPTION
**Related Issue :** Closes #431 

---

## 🧑‍🎤 Summary
- [x] manual chunk를 통한 chunk 분리
- [x] lazy loading 적용
- [x] build 속도 개선

## 🧑‍🎤 Screenshot
전
![스크린샷 2024-08-25 오전 1 51 23](https://github.com/user-attachments/assets/1640cfde-5492-47d2-bf29-b0bad869e669)

후 (번들 크기 개선 1, 2, 3이 통합된 결과예요)
<img width="701" alt="스크린샷 2024-08-25 오전 1 51 43" src="https://github.com/user-attachments/assets/bf0ddb58-2998-4b6c-b55a-4178c85c737c">

build 속도를 6.11s 에서 4.99s로 1s 정도 개선할 수 있었습니다 :)


## 🧑‍🎤 Comment
### 😈 manual chunk를 통한 chunk 분리
경고창에 manual chunk를 이용하라고 추천해줘서 바로 적용해줬어요
모든 chunk를 로드할 필요 없이 필요한 chunk만 필요한 곳에서 사용하자는 개념이에요

firebase는 지원서 페이지의 파일 input에서만 사용되기에 다른 페이지에선 쓸 일이 없어요
그래서 firebase를 별도의 chunk로 분리해줬답니다

### 😈 lazy loading 적용
manual chunk와 비슷한 개념인데요 잘 아실거라고 생각들어요
dialog와 error page, nomore page는 특정 상황에서만 필요하기에 첫 페이지 로딩 때는 필요가 없어요
그래서 lazy loading 적용 시켜줬어요
추가로 하나의 페이지에 접속했을 때 다른 페이지는 필요하지 않으므로
router에서 각 페이지에 대한 lazy loading도 적용시켜줬어요
