### PR TITLE
[Refactor] 번들 크기 개선 - 2

### DIFF
--- a/src/common/apis/tokenInstance.ts
+++ b/src/common/apis/tokenInstance.ts
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import { isBefore } from 'date-fns';
+import { isBefore } from 'date-fns/isBefore';
 
 const tokenInstance = axios.create({
   baseURL: import.meta.env.VITE_BASE_URL,

--- a/src/common/components/Input/components/Timer/index.tsx
+++ b/src/common/components/Input/components/Timer/index.tsx
@@ -1,4 +1,4 @@
-import { differenceInSeconds } from 'date-fns';
+import { differenceInSeconds } from 'date-fns/differenceInSeconds';
 import { useEffect, useState } from 'react';
 
 import { useDeviceType } from 'contexts/DeviceTypeProvider';

--- a/src/common/hooks/useDate.tsx
+++ b/src/common/hooks/useDate.tsx
@@ -1,4 +1,5 @@
-import { isAfter, isBefore } from 'date-fns';
+import { isAfter } from 'date-fns/isAfter';
+import { isBefore } from 'date-fns/isBefore';
 import { useEffect } from 'react';
 
 import { useRecruitingInfo } from 'contexts/RecruitingInfoProvider';

--- a/src/views/ApplyPage/components/ApplyInfo/index.tsx
+++ b/src/views/ApplyPage/components/ApplyInfo/index.tsx
@@ -1,5 +1,6 @@
-import { format, subMinutes } from 'date-fns';
-import { ko } from 'date-fns/locale';
+import { format } from 'date-fns/format';
+import { ko } from 'date-fns/locale/ko';
+import { subMinutes } from 'date-fns/subMinutes';
 import { memo } from 'react';
 
 import Callout from '@components/Callout';

--- a/src/views/ResultPage/components/FinalResult.tsx
+++ b/src/views/ResultPage/components/FinalResult.tsx
@@ -1,6 +1,6 @@
 import { track } from '@amplitude/analytics-browser';
-import { format } from 'date-fns';
-import { ko } from 'date-fns/locale';
+import { format } from 'date-fns/format';
+import { ko } from 'date-fns/locale/ko';
 import { useEffect } from 'react';
 
 import Title from '@components/Title';
@@ -122,7 +122,7 @@ const FinalResult = () => {
       <div style={{ overflow: 'auto', height: '100%' }}>
         <div className={contentWrapperVar[deviceType]}>
           <Title>결과 확인</Title>
-          <Content pass={pass} />
+          <Content pass={true} />
         </div>
       </div>
       {deviceType !== 'MOB' && pass && (

--- a/src/views/ResultPage/components/FinalResult.tsx
+++ b/src/views/ResultPage/components/FinalResult.tsx
@@ -122,7 +122,7 @@ const FinalResult = () => {
       <div style={{ overflow: 'auto', height: '100%' }}>
         <div className={contentWrapperVar[deviceType]}>
           <Title>결과 확인</Title>
-          <Content pass={true} />
+          <Content pass={pass} />
         </div>
       </div>
       {deviceType !== 'MOB' && pass && (

--- a/src/views/ResultPage/components/ScreeningResult.tsx
+++ b/src/views/ResultPage/components/ScreeningResult.tsx
@@ -1,6 +1,6 @@
 import { track } from '@amplitude/analytics-browser';
-import { format } from 'date-fns';
-import { ko } from 'date-fns/locale';
+import { format } from 'date-fns/format';
+import { ko } from 'date-fns/locale/ko';
 import { useEffect } from 'react';
 
 import Title from '@components/Title';


### PR DESCRIPTION
**Related Issue :** Closes #431 

---

## 🧑‍🎤 Summary
- [x] date-fns import 범위 축소

## 🧑‍🎤 Screenshot
개선된 건 [PR 3](https://github.com/sopt-makers/sopt-recruiting-frontend/pull/432)에서 확인할 수 있어요

## 🧑‍🎤 Comment
### 😈 date-fns import 범위 축소
필요 없는 부분들 까지 같이 import 되고 있더라고요?
예를 들어 ko가 아닌 다른 나라 locale 등등
<img width="586" alt="스크린샷 2024-08-25 오전 2 53 49" src="https://github.com/user-attachments/assets/3032ea5f-8f64-4f8b-a625-23670443052a">
<img width="518" alt="스크린샷 2024-08-25 오전 2 53 55" src="https://github.com/user-attachments/assets/11bc33f8-2f23-473d-a618-dede357cb17e">
정말 필요한 부분만 import 되도록 범위 수정해 줬어요

사실 그렇다할 유의미한 차이(0.01kb 감소)는 없었는데요 build 시간을 조금 단축(0.5s 단축)할 수 있었어요
<img width="672" alt="스크린샷 2024-08-25 오전 2 59 56" src="https://github.com/user-attachments/assets/0a305305-f92d-4e04-afca-b246406a11a0">

