### PR TITLE
[Refactor] ApplyPage 로직 분리 - 1

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,7 +3,7 @@ import { sessionReplayPlugin } from '@amplitude/plugin-session-replay-browser';
 import { MutationCache, QueryCache, QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { AxiosError } from 'axios';
-import { lazy, Suspense, useEffect, useRef, useState } from 'react';
+import { lazy, Suspense, useEffect, useState } from 'react';
 import { RouterProvider, createBrowserRouter } from 'react-router-dom';
 
 import Layout from '@components/Layout';
@@ -14,6 +14,7 @@ import { dark, light } from 'styles/theme.css';
 import BigLoading from 'views/loadings/BigLoding';
 
 import 'styles/reset.css';
+import useDialog from '@hooks/useDialog';
 
 const SessionExpiredDialog = lazy(() =>
   import('views/dialogs').then(({ SessionExpiredDialog }) => ({ default: SessionExpiredDialog })),
@@ -55,7 +56,7 @@ const App = () => {
   //   }
   // }, []);
 
-  const sessionRef = useRef<HTMLDialogElement>(null);
+  const { ref: sessionExpiredDialogRef, handleShowDialog: handleShowSessionExpiredDialog } = useDialog();
   const [isAmplitudeInitialized, setIsAmplitudeInitialized] = useState(false);
   const { isLight } = useTheme();
 
@@ -74,7 +75,7 @@ const App = () => {
         const axiosError = error as AxiosError;
 
         if (axiosError.response?.status === 401) {
-          sessionRef.current?.showModal();
+          handleShowSessionExpiredDialog();
         } else if (axiosError.response?.status === 500) {
           window.location.href = '/error';
         }
@@ -85,7 +86,7 @@ const App = () => {
         const axiosError = error as AxiosError;
 
         if (axiosError.response?.status === 401) {
-          sessionRef.current?.showModal();
+          handleShowSessionExpiredDialog();
         } else if (axiosError.response?.status === 500) {
           window.location.href = '/error';
         }
@@ -110,7 +111,7 @@ const App = () => {
 
   return (
     <>
-      <SessionExpiredDialog ref={sessionRef} />
+      <SessionExpiredDialog ref={sessionExpiredDialogRef} />
       <ThemeProvider>
         <DeviceTypeProvider>
           <RecruitingInfoProvider>

--- a/src/common/hooks/useDialog.tsx
+++ b/src/common/hooks/useDialog.tsx
@@ -7,7 +7,11 @@ const useDialog = () => {
     ref.current?.showModal();
   };
 
-  return { ref, handleShowDialog };
+  const handleCloseDialog = () => {
+    ref.current?.close();
+  };
+
+  return { ref, handleShowDialog, handleCloseDialog };
 };
 
 export default useDialog;

--- a/src/common/hooks/useDialog.tsx
+++ b/src/common/hooks/useDialog.tsx
@@ -1,0 +1,13 @@
+import { useRef } from 'react';
+
+const useDialog = () => {
+  const ref = useRef<HTMLDialogElement>(null);
+
+  const handleShowDialog = () => {
+    ref.current?.showModal();
+  };
+
+  return { ref, handleShowDialog };
+};
+
+export default useDialog;

--- a/src/common/hooks/useEventListener.tsx
+++ b/src/common/hooks/useEventListener.tsx
@@ -1,0 +1,14 @@
+import { useEffect } from 'react';
+
+type EventType = keyof WindowEventMap;
+type EventListener = (event: Event) => void;
+
+const useEventListener = (eventName: EventType, callbackFn: EventListener) => {
+  useEffect(() => {
+    window.addEventListener(eventName, callbackFn);
+
+    return () => window.removeEventListener(eventName, callbackFn);
+  }, [eventName, callbackFn]);
+};
+
+export default useEventListener;

--- a/src/views/ApplyPage/components/ApplyCategory/index.tsx
+++ b/src/views/ApplyPage/components/ApplyCategory/index.tsx
@@ -8,10 +8,10 @@ import { CATEGORY } from './constant';
 import { activeLinkStyleVar, categoryLinkStyleVar, categoryList, container, containerVar } from './style.css';
 
 interface ApplyCategoryProps {
-  isReview: boolean;
+  isReview?: boolean;
   minIndex: number;
 }
-const ApplyCategory = memo(({ isReview, minIndex }: ApplyCategoryProps) => {
+const ApplyCategory = memo(({ minIndex, isReview = false }: ApplyCategoryProps) => {
   const { deviceType } = useDeviceType();
   const { isScrollingDown, isScrollTop } = useScrollPosition(isReview ? 380 : 950);
 

--- a/src/views/ApplyPage/components/ApplyHeader/index.tsx
+++ b/src/views/ApplyPage/components/ApplyHeader/index.tsx
@@ -6,13 +6,13 @@ import { useRecruitingInfo } from 'contexts/RecruitingInfoProvider';
 import { buttonWrapper, headerContainerVar } from './style.css';
 
 interface ApplyHeaderProps {
-  isReview: boolean;
+  isReview?: boolean;
   isLoading?: boolean;
   onSaveDraft?: () => void;
   onSubmitData?: () => void;
 }
 
-const ApplyHeader = ({ isReview, isLoading, onSaveDraft, onSubmitData }: ApplyHeaderProps) => {
+const ApplyHeader = ({ isLoading, onSaveDraft, onSubmitData, isReview = false }: ApplyHeaderProps) => {
   const { deviceType } = useDeviceType();
   const {
     recruitingInfo: { soptName, season, group, isMakers },

--- a/src/views/ApplyPage/components/ApplyInfo/index.tsx
+++ b/src/views/ApplyPage/components/ApplyInfo/index.tsx
@@ -19,7 +19,7 @@ import {
 } from './style.css';
 import { APPLY_INFO } from '../../constant';
 
-const ApplyInfo = memo(({ isReview }: { isReview: boolean }) => {
+const ApplyInfo = memo(({ isReview = false }: { isReview?: boolean }) => {
   const { deviceType } = useDeviceType();
   const {
     recruitingInfo: {

--- a/src/views/ApplyPage/components/BottomSection/index.tsx
+++ b/src/views/ApplyPage/components/BottomSection/index.tsx
@@ -9,11 +9,11 @@ import { SELECT_OPTIONS } from 'views/ApplyPage/constant';
 import { doubleLineCheck, labelVar, line, sectionContainer } from './style.css';
 
 interface BottomSectionProps {
-  isReview: boolean;
+  isReview?: boolean;
   knownPath?: string;
 }
 
-const BottomSection = ({ isReview, knownPath }: BottomSectionProps) => {
+const BottomSection = ({ knownPath, isReview = false }: BottomSectionProps) => {
   const { deviceType } = useDeviceType();
   const {
     recruitingInfo: { isMakers },

--- a/src/views/ApplyPage/components/CommonSection/index.tsx
+++ b/src/views/ApplyPage/components/CommonSection/index.tsx
@@ -8,13 +8,13 @@ import Info from '../Info';
 import LinkInput from '../LinkInput';
 
 interface CommonSectionProps {
-  isReview: boolean;
+  isReview?: boolean;
   refCallback: (elem: HTMLSelectElement) => void;
   questions?: Questions[];
   commonQuestionsDraft?: Answers[];
 }
 
-const CommonSection = ({ isReview, refCallback, questions, commonQuestionsDraft }: CommonSectionProps) => {
+const CommonSection = ({ refCallback, questions, commonQuestionsDraft, isReview = false }: CommonSectionProps) => {
   const { deviceType } = useDeviceType();
   const commonQuestionsById = commonQuestionsDraft?.reduce(
     (acc, draft) => {

--- a/src/views/ApplyPage/components/DefaultSection/index.tsx
+++ b/src/views/ApplyPage/components/DefaultSection/index.tsx
@@ -107,12 +107,12 @@ const ProfileImage = ({ disabled, pic, deviceType }: ProfileImageProps) => {
 
 interface DefaultSectionProps {
   isMakers?: boolean;
-  isReview: boolean;
+  isReview?: boolean;
   refCallback?: (elem: HTMLSelectElement) => void;
   applicantDraft?: Applicant;
 }
 
-const DefaultSection = ({ isMakers, isReview, refCallback, applicantDraft }: DefaultSectionProps) => {
+const DefaultSection = ({ isMakers, refCallback, applicantDraft, isReview = false }: DefaultSectionProps) => {
   const { deviceType } = useDeviceType();
   const {
     address,

--- a/src/views/ApplyPage/components/PartSection/index.tsx
+++ b/src/views/ApplyPage/components/PartSection/index.tsx
@@ -11,7 +11,7 @@ import Info from '../Info';
 import LinkInput from '../LinkInput';
 
 interface PartSectionProps {
-  isReview: boolean;
+  isReview?: boolean;
   refCallback: (elem: HTMLSelectElement) => void;
   part?: string;
   questions?: {
@@ -24,12 +24,12 @@ interface PartSectionProps {
 }
 
 const PartSection = ({
-  isReview,
   refCallback,
   part,
   questions,
   partQuestionsDraft,
   questionTypes,
+  isReview = false,
 }: PartSectionProps) => {
   const { deviceType } = useDeviceType();
   const { getValues } = useFormContext();

--- a/src/views/ApplyPage/hooks/useBeforeExitPageAlert.tsx
+++ b/src/views/ApplyPage/hooks/useBeforeExitPageAlert.tsx
@@ -1,17 +1,13 @@
-import { useEffect } from 'react';
+import useEventListener from '@hooks/useEventListener';
 
 /** 페이지 이탈 시 alert 띄우기 */
 const useBeforeExitPageAlert = () => {
-  useEffect(() => {
-    const handleBeforeUnload = (e: BeforeUnloadEvent) => {
-      e.preventDefault();
-      e.returnValue = ''; // Included for legacy support, e.g. Chrome/Edeg < 119;
-    };
+  const handleBeforeUnload = (e: BeforeUnloadEvent) => {
+    e.preventDefault();
+    e.returnValue = ''; // Included for legacy support, e.g. Chrome/Edeg < 119;
+  };
 
-    window.addEventListener('beforeunload', handleBeforeUnload);
-
-    return () => window.removeEventListener('beforeunload', handleBeforeUnload);
-  }, []);
+  useEventListener('beforeunload', handleBeforeUnload);
 };
 
 export default useBeforeExitPageAlert;

--- a/src/views/ApplyPage/hooks/useBeforeExitPageAlert.tsx
+++ b/src/views/ApplyPage/hooks/useBeforeExitPageAlert.tsx
@@ -1,0 +1,17 @@
+import { useEffect } from 'react';
+
+/** 페이지 이탈 시 alert 띄우기 */
+const useBeforeExitPageAlert = () => {
+  useEffect(() => {
+    const handleBeforeUnload = (e: BeforeUnloadEvent) => {
+      e.preventDefault();
+      e.returnValue = ''; // Included for legacy support, e.g. Chrome/Edeg < 119;
+    };
+
+    window.addEventListener('beforeunload', handleBeforeUnload);
+
+    return () => window.removeEventListener('beforeunload', handleBeforeUnload);
+  }, []);
+};
+
+export default useBeforeExitPageAlert;

--- a/src/views/ApplyPage/index.tsx
+++ b/src/views/ApplyPage/index.tsx
@@ -34,6 +34,7 @@ const PreventApplyDialog = lazy(() =>
 );
 const SubmitDialog = lazy(() => import('views/dialogs').then(({ SubmitDialog }) => ({ default: SubmitDialog })));
 const NoMore = lazy(() => import('views/ErrorPage/components/NoMore'));
+const IS_REVIEW = false;
 
 interface ApplyPageProps {
   onSetComplete?: () => void;
@@ -43,9 +44,6 @@ const ApplyPage = ({ onSetComplete }: ApplyPageProps) => {
   // 반응형 페이지
   const { deviceType } = useDeviceType();
   useCheckBrowser(); // 크롬 브라우저 권장 알럿
-
-  // 1. review page가 아님
-  const isReview = false;
 
   // 2. 모달 관련 ref
   const draftDialog = useRef<HTMLDialogElement>(null);
@@ -304,13 +302,13 @@ const ApplyPage = ({ onSetComplete }: ApplyPageProps) => {
       />
       <div className={container}>
         <ApplyHeader
-          isReview={isReview}
+          isReview={IS_REVIEW}
           isLoading={draftIsPending || submitIsPending}
           onSaveDraft={() => handleSendData('draft')}
           onSubmitData={handleSubmit(handleApplySubmit)}
         />
-        <ApplyInfo isReview={isReview} />
-        <ApplyCategory isReview={isReview} minIndex={minIndex} />
+        <ApplyInfo isReview={IS_REVIEW} />
+        <ApplyCategory isReview={IS_REVIEW} minIndex={minIndex} />
         <form
           id="apply-form"
           name="apply-form"
@@ -318,38 +316,36 @@ const ApplyPage = ({ onSetComplete }: ApplyPageProps) => {
           className={formContainerVar[deviceType]}>
           <DefaultSection
             isMakers={isMakers}
-            isReview={isReview}
+            isReview={IS_REVIEW}
             refCallback={refCallback}
             applicantDraft={applicantDraft}
           />
           <CommonSection
-            isReview={isReview}
+            isReview={IS_REVIEW}
             refCallback={refCallback}
             questions={commonQuestions?.questions}
             commonQuestionsDraft={commonQuestionsDraft}
           />
           <PartSection
-            isReview={isReview}
+            isReview={IS_REVIEW}
             refCallback={refCallback}
             part={applicantDraft?.part}
             questions={partQuestions}
             partQuestionsDraft={partQuestionsDraft}
             questionTypes={questionTypes}
           />
-          <BottomSection isReview={isReview} knownPath={applicantDraft?.knownPath} />
-          {!isReview && (
-            <div className={buttonWrapper}>
-              <Button
-                isLoading={draftIsPending || submitIsPending}
-                onClick={() => handleSendData('draft')}
-                buttonStyle="line">
-                임시저장
-              </Button>
-              <Button isLoading={draftIsPending || submitIsPending} type="submit">
-                제출하기
-              </Button>
-            </div>
-          )}
+          <BottomSection isReview={IS_REVIEW} knownPath={applicantDraft?.knownPath} />
+          <div className={buttonWrapper}>
+            <Button
+              isLoading={draftIsPending || submitIsPending}
+              onClick={() => handleSendData('draft')}
+              buttonStyle="line">
+              임시저장
+            </Button>
+            <Button isLoading={draftIsPending || submitIsPending} type="submit">
+              제출하기
+            </Button>
+          </div>
         </form>
       </div>
       <Footer />

--- a/src/views/ApplyPage/index.tsx
+++ b/src/views/ApplyPage/index.tsx
@@ -284,7 +284,7 @@ const ApplyPage = ({ onSetComplete }: ApplyPageProps) => {
   };
 
   return (
-    <FormProvider {...methods}>
+    <>
       <DraftDialog ref={draftDialogRef} />
       <PreventApplyDialog ref={preventApplyDialogRef} />
       <SubmitDialog
@@ -301,56 +301,58 @@ const ApplyPage = ({ onSetComplete }: ApplyPageProps) => {
           handleCloseSubmitDialog();
         }}
       />
-      <div className={container}>
-        <ApplyHeader
-          isReview={IS_REVIEW}
-          isLoading={draftIsPending || submitIsPending}
-          onSaveDraft={() => handleSendData('draft')}
-          onSubmitData={handleSubmit(handleApplySubmit)}
-        />
-        <ApplyInfo isReview={IS_REVIEW} />
-        <ApplyCategory isReview={IS_REVIEW} minIndex={minIndex} />
-        <form
-          id="apply-form"
-          name="apply-form"
-          onSubmit={handleSubmit(handleApplySubmit)}
-          className={formContainerVar[deviceType]}>
-          <DefaultSection
-            isMakers={isMakers}
+      <FormProvider {...methods}>
+        <div className={container}>
+          <ApplyHeader
             isReview={IS_REVIEW}
-            refCallback={refCallback}
-            applicantDraft={applicantDraft}
+            isLoading={draftIsPending || submitIsPending}
+            onSaveDraft={() => handleSendData('draft')}
+            onSubmitData={handleSubmit(handleApplySubmit)}
           />
-          <CommonSection
-            isReview={IS_REVIEW}
-            refCallback={refCallback}
-            questions={commonQuestions?.questions}
-            commonQuestionsDraft={commonQuestionsDraft}
-          />
-          <PartSection
-            isReview={IS_REVIEW}
-            refCallback={refCallback}
-            part={applicantDraft?.part}
-            questions={partQuestions}
-            partQuestionsDraft={partQuestionsDraft}
-            questionTypes={questionTypes}
-          />
-          <BottomSection isReview={IS_REVIEW} knownPath={applicantDraft?.knownPath} />
-          <div className={buttonWrapper}>
-            <Button
-              isLoading={draftIsPending || submitIsPending}
-              onClick={() => handleSendData('draft')}
-              buttonStyle="line">
-              임시저장
-            </Button>
-            <Button isLoading={draftIsPending || submitIsPending} type="submit">
-              제출하기
-            </Button>
-          </div>
-        </form>
-      </div>
-      <Footer />
-    </FormProvider>
+          <ApplyInfo isReview={IS_REVIEW} />
+          <ApplyCategory isReview={IS_REVIEW} minIndex={minIndex} />
+          <form
+            id="apply-form"
+            name="apply-form"
+            onSubmit={handleSubmit(handleApplySubmit)}
+            className={formContainerVar[deviceType]}>
+            <DefaultSection
+              isMakers={isMakers}
+              isReview={IS_REVIEW}
+              refCallback={refCallback}
+              applicantDraft={applicantDraft}
+            />
+            <CommonSection
+              isReview={IS_REVIEW}
+              refCallback={refCallback}
+              questions={commonQuestions?.questions}
+              commonQuestionsDraft={commonQuestionsDraft}
+            />
+            <PartSection
+              isReview={IS_REVIEW}
+              refCallback={refCallback}
+              part={applicantDraft?.part}
+              questions={partQuestions}
+              partQuestionsDraft={partQuestionsDraft}
+              questionTypes={questionTypes}
+            />
+            <BottomSection isReview={IS_REVIEW} knownPath={applicantDraft?.knownPath} />
+            <div className={buttonWrapper}>
+              <Button
+                isLoading={draftIsPending || submitIsPending}
+                onClick={() => handleSendData('draft')}
+                buttonStyle="line">
+                임시저장
+              </Button>
+              <Button isLoading={draftIsPending || submitIsPending} type="submit">
+                제출하기
+              </Button>
+            </div>
+          </form>
+        </div>
+        <Footer />
+      </FormProvider>
+    </>
   );
 };
 

--- a/src/views/ApplyPage/index.tsx
+++ b/src/views/ApplyPage/index.tsx
@@ -34,7 +34,6 @@ const PreventApplyDialog = lazy(() =>
 );
 const SubmitDialog = lazy(() => import('views/dialogs').then(({ SubmitDialog }) => ({ default: SubmitDialog })));
 const NoMore = lazy(() => import('views/ErrorPage/components/NoMore'));
-const IS_REVIEW = false;
 
 interface ApplyPageProps {
   onSetComplete?: () => void;
@@ -304,39 +303,31 @@ const ApplyPage = ({ onSetComplete }: ApplyPageProps) => {
       <FormProvider {...methods}>
         <div className={container}>
           <ApplyHeader
-            isReview={IS_REVIEW}
             isLoading={draftIsPending || submitIsPending}
             onSaveDraft={() => handleSendData('draft')}
             onSubmitData={handleSubmit(handleApplySubmit)}
           />
-          <ApplyInfo isReview={IS_REVIEW} />
-          <ApplyCategory isReview={IS_REVIEW} minIndex={minIndex} />
+          <ApplyInfo />
+          <ApplyCategory minIndex={minIndex} />
           <form
             id="apply-form"
             name="apply-form"
             onSubmit={handleSubmit(handleApplySubmit)}
             className={formContainerVar[deviceType]}>
-            <DefaultSection
-              isMakers={isMakers}
-              isReview={IS_REVIEW}
-              refCallback={refCallback}
-              applicantDraft={applicantDraft}
-            />
+            <DefaultSection isMakers={isMakers} refCallback={refCallback} applicantDraft={applicantDraft} />
             <CommonSection
-              isReview={IS_REVIEW}
               refCallback={refCallback}
               questions={commonQuestions?.questions}
               commonQuestionsDraft={commonQuestionsDraft}
             />
             <PartSection
-              isReview={IS_REVIEW}
               refCallback={refCallback}
               part={applicantDraft?.part}
               questions={partQuestions}
               partQuestionsDraft={partQuestionsDraft}
               questionTypes={questionTypes}
             />
-            <BottomSection isReview={IS_REVIEW} knownPath={applicantDraft?.knownPath} />
+            <BottomSection knownPath={applicantDraft?.knownPath} />
             <div className={buttonWrapper}>
               <Button
                 isLoading={draftIsPending || submitIsPending}

--- a/src/views/ApplyPage/index.tsx
+++ b/src/views/ApplyPage/index.tsx
@@ -19,6 +19,7 @@ import CommonSection from './components/CommonSection';
 import DefaultSection from './components/DefaultSection';
 import PartSection from './components/PartSection';
 import { SELECT_OPTIONS } from './constant';
+import useBeforeExitPageAlert from './hooks/useBeforeExitPageAlert';
 import useGetDraft from './hooks/useGetDraft';
 import useGetQuestions from './hooks/useGetQuestions';
 import useMutateDraft from './hooks/useMutateDraft';
@@ -182,17 +183,7 @@ const ApplyPage = ({ onSetComplete }: ApplyPageProps) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [errors.attendance, errors.personalInformation]);
 
-  // 10. 페이지 이탈 시 alert 띄우기
-  useEffect(() => {
-    const handleBeforeUnload = (e: BeforeUnloadEvent) => {
-      e.preventDefault();
-      e.returnValue = ''; // Included for legacy support, e.g. Chrome/Edeg < 119;
-    };
-
-    window.addEventListener('beforeunload', handleBeforeUnload);
-
-    return () => window.removeEventListener('beforeunload', handleBeforeUnload);
-  }, []);
+  useBeforeExitPageAlert();
 
   // 11. 지원 기간 아니면 에러 페이지 띄우기
   const { NoMoreApply, isLoading, isMakers } = useDate();

--- a/src/views/ApplyPage/index.tsx
+++ b/src/views/ApplyPage/index.tsx
@@ -78,7 +78,7 @@ const ApplyPage = ({ onSetComplete }: ApplyPageProps) => {
   }, [applicantDraft]);
 
   // 6. 데이터 보내기
-  const { draftMutate, draftIsPending } = useMutateDraft({ onSuccess: () => handleShowDraftDialog });
+  const { draftMutate, draftIsPending } = useMutateDraft({ onSuccess: handleShowDraftDialog });
   const { submitMutate, submitIsPending } = useMutateSubmit({ onSuccess: onSetComplete });
 
   // 7. react hook form method 생성

--- a/src/views/ApplyPage/index.tsx
+++ b/src/views/ApplyPage/index.tsx
@@ -9,7 +9,6 @@ import useCheckBrowser from '@hooks/useCheckBrowser';
 import useDate from '@hooks/useDate';
 import useScrollToHash from '@hooks/useScrollToHash';
 import { useDeviceType } from 'contexts/DeviceTypeProvider';
-import BigLoading from 'views/loadings/BigLoding';
 
 import ApplyCategory from './components/ApplyCategory';
 import ApplyHeader from './components/ApplyHeader';
@@ -56,13 +55,13 @@ const ApplyPage = ({ onSetComplete }: ApplyPageProps) => {
   const minIndex = isInView.findIndex((value) => value === true);
 
   // 4. 데이터 불러오기
-  const { draftData, draftIsLoading } = useGetDraft();
+  const { draftData } = useGetDraft();
   const {
     applicant: applicantDraft,
     commonQuestions: commonQuestionsDraft,
     partQuestions: partQuestionsDraft,
   } = draftData?.data || {};
-  const { questionsData, questionsIsLoading } = useGetQuestions(applicantDraft);
+  const { questionsData } = useGetQuestions(applicantDraft);
   const { commonQuestions, partQuestions, questionTypes } = questionsData?.data || {};
 
   // 5. 임시저장된 part data 붙이기
@@ -184,11 +183,8 @@ const ApplyPage = ({ onSetComplete }: ApplyPageProps) => {
   useBeforeExitPageAlert();
 
   // 11. 지원 기간 아니면 에러 페이지 띄우기
-  const { NoMoreApply, isLoading, isMakers } = useDate();
+  const { NoMoreApply, isMakers } = useDate();
   if (NoMoreApply) return <NoMore isMakers={isMakers} content="모집 기간이 아니에요" />;
-
-  // 12. 로딩
-  if (questionsIsLoading || isLoading || draftIsLoading) return <BigLoading />;
 
   // 13. data 전송 로직
   const selectedPartId = questionTypes?.find((type) => type.typeKr === getValues('part'))?.id;

--- a/src/views/ApplyPage/index.tsx
+++ b/src/views/ApplyPage/index.tsx
@@ -48,7 +48,11 @@ const ApplyPage = ({ onSetComplete }: ApplyPageProps) => {
   // 2. 모달 관련 ref
   const { ref: draftDialogRef, handleShowDialog: handleShowDraftDialog } = useDialog();
   const { ref: preventApplyDialogRef, handleShowDialog: handleShowPreventApplyDialog } = useDialog();
-  const { ref: submitDialogRef, handleShowDialog: handleShowSubmitDialog } = useDialog();
+  const {
+    ref: submitDialogRef,
+    handleShowDialog: handleShowSubmitDialog,
+    handleCloseDialog: handleCloseSubmitDialog,
+  } = useDialog();
 
   // 3. category active 상태 관리
   useScrollToHash(); // scrollTo 카테고리
@@ -294,7 +298,7 @@ const ApplyPage = ({ onSetComplete }: ApplyPageProps) => {
         ref={submitDialogRef}
         onSendData={() => {
           handleSendData('submit');
-          submitDialog.current?.close();
+          handleCloseSubmitDialog();
         }}
       />
       <div className={container}>

--- a/src/views/ApplyPage/index.tsx
+++ b/src/views/ApplyPage/index.tsx
@@ -26,6 +26,7 @@ import useMutateSubmit from './hooks/useMutateSubmit';
 import { buttonWrapper, container, formContainerVar } from './style.css';
 
 import type { ApplyRequest } from './types';
+import useDialog from '@hooks/useDialog';
 
 const DraftDialog = lazy(() => import('views/dialogs').then(({ DraftDialog }) => ({ default: DraftDialog })));
 const PreventApplyDialog = lazy(() =>
@@ -45,9 +46,9 @@ const ApplyPage = ({ onSetComplete }: ApplyPageProps) => {
   useCheckBrowser(); // 크롬 브라우저 권장 알럿
 
   // 2. 모달 관련 ref
-  const draftDialog = useRef<HTMLDialogElement>(null);
-  const preventApplyDialog = useRef<HTMLDialogElement>(null);
-  const submitDialog = useRef<HTMLDialogElement>(null);
+  const { ref: draftDialogRef, handleShowDialog: handleShowDraftDialog } = useDialog();
+  const { ref: preventApplyDialogRef, handleShowDialog: handleShowPreventApplyDialog } = useDialog();
+  const { ref: submitDialogRef, handleShowDialog: handleShowSubmitDialog } = useDialog();
 
   // 3. category active 상태 관리
   useScrollToHash(); // scrollTo 카테고리
@@ -73,7 +74,7 @@ const ApplyPage = ({ onSetComplete }: ApplyPageProps) => {
   }, [applicantDraft]);
 
   // 6. 데이터 보내기
-  const { draftMutate, draftIsPending } = useMutateDraft({ onSuccess: () => draftDialog.current?.showModal() });
+  const { draftMutate, draftIsPending } = useMutateDraft({ onSuccess: () => handleShowDraftDialog });
   const { submitMutate, submitIsPending } = useMutateSubmit({ onSuccess: onSetComplete });
 
   // 7. react hook form method 생성
@@ -194,7 +195,7 @@ const ApplyPage = ({ onSetComplete }: ApplyPageProps) => {
 
   const handleSendData = (type: 'draft' | 'submit') => {
     if (NoMoreApply) {
-      preventApplyDialog.current?.showModal();
+      handleShowPreventApplyDialog();
 
       return;
     }
@@ -275,13 +276,13 @@ const ApplyPage = ({ onSetComplete }: ApplyPageProps) => {
 
   const handleApplySubmit = () => {
     track('click-apply-submit');
-    submitDialog.current?.showModal();
+    handleShowSubmitDialog();
   };
 
   return (
     <FormProvider {...methods}>
-      <DraftDialog ref={draftDialog} />
-      <PreventApplyDialog ref={preventApplyDialog} />
+      <DraftDialog ref={draftDialogRef} />
+      <PreventApplyDialog ref={preventApplyDialogRef} />
       <SubmitDialog
         userInfo={{
           name,
@@ -290,7 +291,7 @@ const ApplyPage = ({ onSetComplete }: ApplyPageProps) => {
           part,
         }}
         dataIsPending={submitIsPending}
-        ref={submitDialog}
+        ref={submitDialogRef}
         onSendData={() => {
           handleSendData('submit');
           submitDialog.current?.close();

--- a/src/views/PasswordPage/components/PasswordForm/index.tsx
+++ b/src/views/PasswordPage/components/PasswordForm/index.tsx
@@ -1,5 +1,5 @@
 import { track } from '@amplitude/analytics-browser';
-import { lazy, useRef } from 'react';
+import { lazy } from 'react';
 import { FormProvider, useForm, type FieldValues } from 'react-hook-form';
 
 import Button from '@components/Button';
@@ -10,11 +10,13 @@ import { useRecruitingInfo } from 'contexts/RecruitingInfoProvider';
 import useMutateChangePassword from 'views/PasswordPage/hooks/useMutateChangePassword';
 
 import { formWrapper } from './style.css';
+import useDialog from '@hooks/useDialog';
 
 const CompleteDialog = lazy(() => import('views/dialogs').then(({ CompleteDialog }) => ({ default: CompleteDialog })));
 
 const PasswordForm = () => {
-  const completeDialog = useRef<HTMLDialogElement>(null);
+  const { ref: completeDialogRef, handleShowDialog: handleShowCompleteDialog } = useDialog();
+
   const {
     recruitingInfo: { season, group },
   } = useRecruitingInfo();
@@ -23,7 +25,7 @@ const PasswordForm = () => {
   const { handleSubmit, setError } = methods;
 
   const handleCompleteChangePassword = () => {
-    completeDialog.current?.showModal();
+    handleShowCompleteDialog();
   };
 
   const { changePasswordMutate, changePasswordIsPending } = useMutateChangePassword({
@@ -53,7 +55,7 @@ const PasswordForm = () => {
 
   return (
     <>
-      <CompleteDialog ref={completeDialog} />
+      <CompleteDialog ref={completeDialogRef} />
       <FormProvider {...methods}>
         <form
           id="password-form"

--- a/src/views/ReviewPage/index.tsx
+++ b/src/views/ReviewPage/index.tsx
@@ -16,6 +16,7 @@ import useGetDraft from 'views/ApplyPage/hooks/useGetDraft';
 import useGetQuestions from 'views/ApplyPage/hooks/useGetQuestions';
 import { container, formContainerVar } from 'views/ApplyPage/style.css';
 import BigLoading from 'views/loadings/BigLoding';
+import useDialog from '@hooks/useDialog';
 
 const PreventReviewDialog = lazy(() =>
   import('views/dialogs').then(({ PreventReviewDialog }) => ({ default: PreventReviewDialog })),
@@ -24,7 +25,7 @@ const NoMore = lazy(() => import('views/ErrorPage/components/NoMore'));
 
 const ReviewPage = () => {
   const { deviceType } = useDeviceType();
-  const preventReviewDialog = useRef<HTMLDialogElement>(null);
+  const { ref: preventReviewDialogRef, handleShowDialog: handleShowPreventReviewDialog } = useDialog();
   const sectionsRef = useRef<HTMLSelectElement[]>([]);
 
   const { handleSaveRecruitingInfo } = useRecruitingInfo();
@@ -52,8 +53,8 @@ const ReviewPage = () => {
   const { setValue } = methods;
 
   useEffect(() => {
-    if (preventReviewDialog.current && !applicantDraft?.submit) {
-      preventReviewDialog.current.showModal();
+    if (preventReviewDialogRef.current && !applicantDraft?.submit) {
+      handleShowPreventReviewDialog();
     }
 
     if (applicantDraft?.part) {
@@ -64,7 +65,7 @@ const ReviewPage = () => {
       name: applicantDraft?.name,
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [applicantDraft, preventReviewDialog.current]);
+  }, [applicantDraft, preventReviewDialogRef.current]);
 
   const refCallback = useCallback((element: HTMLSelectElement) => {
     if (element) {
@@ -109,7 +110,7 @@ const ReviewPage = () => {
 
   return (
     <>
-      <PreventReviewDialog ref={preventReviewDialog} />
+      <PreventReviewDialog ref={preventReviewDialogRef} />
       <FormProvider {...methods}>
         <div className={container}>
           <ApplyHeader isReview={isReview} />

--- a/src/views/SignupPage/components/SignupForm/index.tsx
+++ b/src/views/SignupPage/components/SignupForm/index.tsx
@@ -1,5 +1,5 @@
 import { track } from '@amplitude/analytics-browser';
-import { lazy, useEffect, useRef } from 'react';
+import { lazy, useEffect } from 'react';
 import { type FieldValues, FormProvider, useForm } from 'react-hook-form';
 
 import Button from '@components/Button';
@@ -14,6 +14,7 @@ import { useRecruitingInfo } from 'contexts/RecruitingInfoProvider';
 import useMutateSignUp from 'views/SignupPage/hooks/useMutateSignUp';
 
 import { formWrapper } from './style.css';
+import useDialog from '@hooks/useDialog';
 
 const ExistingApplicantDialog = lazy(() =>
   import('views/dialogs').then(({ ExistingApplicantDialog }) => ({ default: ExistingApplicantDialog })),
@@ -23,7 +24,7 @@ const SignupForm = () => {
   const {
     recruitingInfo: { season, group },
   } = useRecruitingInfo();
-  const existingApplicantRef = useRef<HTMLDialogElement>(null);
+  const { ref: existingApplicantDialogRef, handleShowDialog: handleShowExistingApplicantDialog } = useDialog();
 
   const { isVerified, handleVerified } = useVerificationStatus();
   const methods = useForm({ mode: 'onBlur' });
@@ -34,7 +35,7 @@ const SignupForm = () => {
     formState: { errors },
   } = methods;
   const { signUpMutate, signUpIsPending } = useMutateSignUp({
-    onCheckExistence: () => existingApplicantRef.current?.showModal(),
+    onCheckExistence: () => handleShowExistingApplicantDialog(),
   });
 
   const handleSubmitSignUp = ({ email, password, passwordCheck, name, phone }: FieldValues) => {
@@ -69,7 +70,7 @@ const SignupForm = () => {
 
   return (
     <>
-      <ExistingApplicantDialog ref={existingApplicantRef} />
+      <ExistingApplicantDialog ref={existingApplicantDialogRef} />
       <FormProvider {...methods}>
         <form
           id="sign-up-form"


### PR DESCRIPTION
**Related Issue :** #440 

---

## 🧑‍🎤 Summary
apply page 내에서

- [x] custom hook 분리
   - [x] 페이지 이탈 시 alert 띄우기
   - [x] dialog 
- [x] isReview 전역 변수로 분리
- [x] loading 전역에서 관리

## 🧑‍🎤 Comment
### 💬 페이지 이탈 시 alert 띄우기 custom hook 분리
관심사 분리하려고 따로 분리해줬습니다 :)

### 💬 dialog custom hook 분리
dialog 관련 함수들이 모여있는 hook을 생성해줬어요
분리하는 김에 다른 페이지에 있는 dialog들도 다 분리해줬습니다 :)

### 💬 isReview 전역 변수로 분리
변하지 않는 변수라 component 내에 있을 필요가 없어 보였어요
외부로 빼줬습니다

### 💬 loading 전역에서 관리
<App />에 Suspense로 fallback을 제공하고 있어서 제거해 줬습니다 :)