### PR TITLE
[Refactor] token 필요없는 fetch custom hook 만들기

### DIFF
--- a/src/common/apis/getRecruitingInfo.ts
+++ b/src/common/apis/getRecruitingInfo.ts
@@ -1,7 +1,7 @@
 import instance from '@apis/instance';
 
 export const getRecruitingInfo = async () => {
-  const res = await instance.get('/recruiting-season/latest');
+  const res = await instance('/recruiting-season/latest', { method: 'GET' });
 
   return res;
 };

--- a/src/common/apis/instance.ts
+++ b/src/common/apis/instance.ts
@@ -1,7 +1,9 @@
 const baseURL = import.meta.env.VITE_BASE_URL;
 
+type StandardHeaders = 'Content-Type' | 'Authorization' | 'Accept' | 'Cache-Control' | 'User-Agent';
+
 interface FetchOptions extends RequestInit {
-  headers?: Record<string, string>;
+  headers?: Record<StandardHeaders, string>;
 }
 
 const instance = async (url: string, options: FetchOptions = {}) => {

--- a/src/common/apis/instance.ts
+++ b/src/common/apis/instance.ts
@@ -1,10 +1,23 @@
-import axios from 'axios';
+const baseURL = import.meta.env.VITE_BASE_URL;
 
-const instance = axios.create({
-  baseURL: import.meta.env.VITE_BASE_URL,
-  headers: {
-    'Content-Type': 'application/json',
-  },
-});
+interface FetchOptions extends RequestInit {
+  headers?: Record<string, string>;
+}
+
+const instance = async (url: string, options: FetchOptions = {}) => {
+  const response = await fetch(`${baseURL}${url}`, {
+    headers: {
+      'Content-Type': 'application/json',
+      ...options.headers,
+    },
+    ...options,
+  });
+
+  if (!response.ok) {
+    throw new Error('network response가 도착하지 않았어요');
+  }
+
+  return response.json();
+};
 
 export default instance;

--- a/src/common/apis/instance.ts
+++ b/src/common/apis/instance.ts
@@ -1,8 +1,10 @@
 const baseURL = import.meta.env.VITE_BASE_URL;
 
 type StandardHeaders = 'Content-Type' | 'Authorization' | 'Accept' | 'Cache-Control' | 'User-Agent';
+type RequestMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
 
 interface FetchOptions extends RequestInit {
+  method?: RequestMethod;
   headers?: Record<StandardHeaders, string>;
 }
 

--- a/src/common/components/Input/apis.ts
+++ b/src/common/components/Input/apis.ts
@@ -4,31 +4,40 @@ import { CheckUserRequest } from './types';
 
 export const checkUser = async (userInfo: CheckUserRequest) => {
   const { email, name, season, group } = userInfo;
-  const res = await instance.post('/recruiting-auth/check/user', {
-    email,
-    name,
-    season,
-    group,
+  const res = await instance('/recruiting-auth/check/user', {
+    method: 'POST',
+    body: JSON.stringify({
+      email,
+      name,
+      season,
+      group,
+    }),
   });
 
   return res;
 };
 
 export const sendVerificationCode = async (email: string, season: number, group: string, isSignup: boolean) => {
-  const res = await instance.post('/recruiting-auth/verify/send', {
-    email,
-    season,
-    group,
-    isSignup,
+  const res = await instance('/recruiting-auth/verify/send', {
+    method: 'POST',
+    body: JSON.stringify({
+      email,
+      season,
+      group,
+      isSignup,
+    }),
   });
 
   return res;
 };
 
 export const checkVerificationCode = async (email: string, code: string) => {
-  const res = await instance.post('/recruiting-auth/verify/email', {
-    email,
-    code,
+  const res = await instance('/recruiting-auth/verify/email', {
+    method: 'POST',
+    body: JSON.stringify({
+      email,
+      code,
+    }),
   });
 
   return res;

--- a/src/views/PasswordPage/apis.ts
+++ b/src/views/PasswordPage/apis.ts
@@ -4,12 +4,15 @@ import type { PasswordRequest } from './types';
 
 export const sendPasswordChange = async (userInfo: PasswordRequest) => {
   const { email, season, group, password, passwordCheck } = userInfo;
-  const res = await instance.post('/recruiting-auth/change/password', {
-    email,
-    season,
-    group,
-    password,
-    passwordCheck,
+  const res = await instance('/recruiting-auth/change/password', {
+    method: 'POST',
+    body: JSON.stringify({
+      email,
+      season,
+      group,
+      password,
+      passwordCheck,
+    }),
   });
 
   return res;

--- a/src/views/SignInPage/apis.ts
+++ b/src/views/SignInPage/apis.ts
@@ -4,11 +4,14 @@ import type { SignInRequest } from './types';
 
 export const sendSignIn = async (userInfo: SignInRequest) => {
   const { email, season, group, password } = userInfo;
-  const res = await instance.post('/recruiting-auth/login', {
-    email,
-    season,
-    group,
-    password,
+  const res = await instance('/recruiting-auth/login', {
+    method: 'POST',
+    body: JSON.stringify({
+      email,
+      season,
+      group,
+      password,
+    }),
   });
 
   return res;

--- a/src/views/SignupPage/apis.ts
+++ b/src/views/SignupPage/apis.ts
@@ -4,14 +4,17 @@ import type { SignUpRequest } from './types';
 
 export const sendSignUp = async (userInfo: SignUpRequest) => {
   const { email, password, passwordCheck, name, phone, season, group } = userInfo;
-  const res = await instance.post('/recruiting-auth/signup', {
-    email,
-    password,
-    passwordCheck,
-    name,
-    phone,
-    season,
-    group,
+  const res = await instance('/recruiting-auth/signup', {
+    method: 'POST',
+    body: JSON.stringify({
+      email,
+      password,
+      passwordCheck,
+      name,
+      phone,
+      season,
+      group,
+    }),
   });
 
   return res;


### PR DESCRIPTION
**Related Issue :** Closes #444 

---

## 🧑‍🎤 Summary
- [x] axios를 이용한 instance에서 fetch를 이용한 instance로 변경
- [x] 기존 axios instance 이용한 부분 fetch instance로 변경

## 🧑‍🎤 Comment
코드 짜기 전에는 hook으로 분리해줄까 했었는데
짜고 보니 분리할 필요가 없더라고요?
원래 방식처럼 그냥 바로 instance 가져다가 사용하면 됐어요

사용법은 비슷해요

첫 번째 인자로 url 넣어주고 두 번째 인자로 options들 넣어주면 됩니다~
단 body는 JSON.stringify()로 감싸줘야 해요!

```tsx
const api요청 = async (인자들) => {
  const res = await fetchInstance(url, {
    method: 'POST',
    headers: {
      // ...
    },
    body: JSON.stringify({
      // ...
    }),
    // ...
  });

  return res;
};
```