### PR TITLE
[Feat] 37기 메이커스 합불 문구 수정

### DIFF
--- a/src/common/components/Input/components/InputTheme/index.tsx
+++ b/src/common/components/Input/components/InputTheme/index.tsx
@@ -117,11 +117,18 @@ export const TextBox이메일 = ({
     }
 
     if (location.pathname === '/sign-up' && !errors.email && isDone) {
-      if (!season || !group) return;
+      const isMakers = import.meta.env.MODE === 'makers';
+
+      let updatedGroup = group;
+      if (isMakers) {
+        updatedGroup = 'OB';
+      }
+
+      if (!season || !updatedGroup) return;
       track('click-signup-email');
       setValue('code', '');
       clearErrors('email');
-      sendVerificationCodeMutate({ email, season, group, isSignup: true });
+      sendVerificationCodeMutate({ email, season, group: updatedGroup, isSignup: true });
     }
   };
 

--- a/src/views/ApplyPage/index.tsx
+++ b/src/views/ApplyPage/index.tsx
@@ -68,7 +68,7 @@ const ApplyPage = ({ onSetComplete }: ApplyPageProps) => {
   // 5. 임시저장된 data 붙이기
   useEffect(() => {
     if (applicantDraft?.part) {
-      setValue('part', applicantDraft?.part === 'IOS' ? 'iOS' : applicantDraft?.part);
+      setValue('part', applicantDraft?.part);
     }
     if (applicantDraft?.pictureKey) {
       setValue('pictureKey', applicantDraft?.pictureKey);
@@ -257,7 +257,7 @@ const ApplyPage = ({ onSetComplete }: ApplyPageProps) => {
 
     const jsonValues: ApplyRequest = {
       pictureKey: getValues('pictureKey'),
-      part: part === 'IOS' ? 'iOS' : part,
+      part,
       address,
       birthday,
       college,

--- a/src/views/ResultPage/components/FinalResult.tsx
+++ b/src/views/ResultPage/components/FinalResult.tsx
@@ -26,9 +26,10 @@ const DESKTOP_HEADER_HEIGHT = 79;
 const Content = ({ pass }: { pass?: boolean }) => {
   const { deviceType } = useDeviceType();
   const {
-    recruitingInfo: { name, soptName, season, group, isMakers },
+    recruitingInfo: { name, soptName, season, group },
   } = useRecruitingInfo();
 
+  const isMakers = import.meta.env.MODE === 'makers';
   if (!name) return;
 
   // const finalDate = new Date(finalPassConfirmStart || '');
@@ -88,10 +89,10 @@ const FinalResult = () => {
   const { deviceType } = useDeviceType();
   const { finalResult, finalResultIsLoading } = useGetFinalResult();
   const {
-    recruitingInfo: { isMakers },
     handleSaveRecruitingInfo,
   } = useRecruitingInfo();
 
+  const isMakers = import.meta.env.MODE === 'makers';
   const { name, pass } = finalResult?.data || {}; 
 
   useEffect(() => {
@@ -110,7 +111,6 @@ const FinalResult = () => {
           <Content pass={pass} />
         </div>
       </div>
-      {pass && (
         <>
           <div className={bottomAnimation[isMakers ? 'makers' : 'sopt']} />
           {isMakers ? (
@@ -125,7 +125,6 @@ const FinalResult = () => {
             </div>
           )}
         </>
-      )}
       <div className={scrollBottomGradVar[deviceType]} />
     </section>
   );

--- a/src/views/ResultPage/components/FinalResult.tsx
+++ b/src/views/ResultPage/components/FinalResult.tsx
@@ -1,12 +1,9 @@
-import { useEffect } from 'react';
 
 import Title from '@components/Title';
 import { useDeviceType } from 'contexts/DeviceTypeProvider';
 import { useRecruitingInfo } from 'contexts/RecruitingInfoProvider';
-import BigLoading from 'views/loadings/BigLoding';
 import IconMakersLogo from '../assets/IconMakersLogo';
 
-import useGetFinalResult from '../hooks/useGetFinalResult';
 import {
   bottomAnimation,
   bottomImgVar,
@@ -15,10 +12,16 @@ import {
   contentVar,
   contentWrapperVar,
   scrollBottomGradVar,
-  strongText,
+  strongText
 } from './style.css';
 
 import IconSoptRecrutingLogo from 'views/ResultPage/assets/IconSoptRecrutingLogo';
+import { useEffect } from 'react';
+import useGetFinalResult from 'views/ResultPage/hooks/useGetFinalResult';
+import BigLoading from 'views/loadings/BigLoding';
+
+const MOBILE_HEADER_HEIGHT = 73;
+const DESKTOP_HEADER_HEIGHT = 79;
 
 const Content = ({ pass }: { pass?: boolean }) => {
   const { deviceType } = useDeviceType();
@@ -31,39 +34,50 @@ const Content = ({ pass }: { pass?: boolean }) => {
   // const finalDate = new Date(finalPassConfirmStart || '');
   // const formattedFinalPassConfirmStart = format(finalDate, 'dd일');
 
-  const SOPT_NAME = isMakers ? `SOPT ${soptName}` : soptName;
+  const SOPT_NAME = isMakers ? `SOPT makers` : `${season}기 ${soptName}`;
   return (
     <>
       {pass ? (
         <p className={contentVar[deviceType]}>
-          <span>{`안녕하세요. ${season}기 ${SOPT_NAME}입니다.\n\n`}</span>
-          <strong className={strongText[isMakers ? 'makers' : 'sopt']}>{`축하드립니다!`}</strong>
-          <span className="amp-mask">
+          <span>
             {`
-              ${name}님은 ${season}기 ${SOPT_NAME} ${!isMakers ? group : ''}회원 모집에 최종 합격하셨습니다.
+            안녕하세요. ${SOPT_NAME} 입니다.
 
-              ${name}님과 ${season}기 ${SOPT_NAME}를 함께하게 되어 진심으로 기쁩니다.
-
-              향후 활동은 ${SOPT_NAME} 공식 노션과 카카오톡 단체 대화방, 디스코드를 통해 운영 및 진행됩니다. 오늘 중으로 카카오톡 단체 대화방에 초대해드릴 예정입니다.
-
-              SOPT의 ${season}번째 열정이 되신 것을 축하드립니다!
+            축하드립니다!
             `}
-          </span>
+            </span>
+          <span className="amp-mask">
+            {`${name}님은 ${season}기 ${SOPT_NAME} ${!isMakers ? group : ''}회원 모집에 `}</span>
+              <strong className={strongText[isMakers ? 'makers' : 'sopt']}>{`최종 합격`}</strong>
+            {`하셨습니다.\n\n`}
+      
+            <span className="amp-mask">
+              {`${name}님과 함께하게 되어 진심으로 기쁩니다.\n`}
+            </span>
+            <span className="amp-mask">
+                {`향후 활동은 ${SOPT_NAME} 공식 노션과 카카오톡 단체 대화방, SOPT 공식 디스코드등을 통해 운영 및 진행됩니다. 
+                
+                오늘 중으로 카카오톡 단체 대화방에 초대해드릴 예정이니 참고 부탁드립니다.\n\n`}
+            </span>
+            <span className="amp-mask">
+              {`다시 한 번 ${SOPT_NAME} ${season}기 합류를 진심으로 축하드립니다!`}
+            </span>
         </p>
       ) : (
         <p className={`amp-mask ${contentVar[deviceType]}`}>
-          {`안녕하세요. ${season}기 ${SOPT_NAME}입니다.
-          먼저 ${season}기 ${SOPT_NAME} ${group}회원 모집에 관심을 가지고
-          합류 여정을 함께해주셔서 감사하다는 말씀을 드립니다.
+          {`안녕하세요. ${SOPT_NAME}입니다.
 
-          ${name}님은 ${season}기 ${SOPT_NAME} ${group}회원 모집에 불합격하셨습니다.
+          ${SOPT_NAME}에 관심을 갖고 지원해 주셔서 감사드립니다.
+          ${name}님의 뛰어난 역량과 잠재력에도 불구하고 안타깝게도 귀하의 합격 소식을 전해드리지 못하게 되었습니다.
 
-          지원자님의 뛰어난 역량과 잠재력에도 불구하고
-          안타깝게도 귀하의 최종 합격 소식을 전해드리지 못하게 되었습니다.
+          비록 이번 ${season}기 makers에 모시지 못하게 되었으나, makers에 지원하시고자 쓰인 소중한 시간과 노력이 지원자님께서 IT 창업인으로서 멋진 역할을 해나가시는 데 작게나마 도움이 되는 경험이 되셨길 바랍니다.
 
-          한 분 한 분에게 개별적인 피드백을 드리기는 어렵겠으나 저희 SOPT에 지원하셨던 경험이 IT 창업인으로서 멋진 역할을 해나가시는 데 큰 도움이 되기를 바랍니다.
+          ${SOPT_NAME}에 귀한 시간을 내어주셔서 다시 한 번 깊이 감사드립니다 :)
+          향후에 더 좋은 인연으로 뵙기를 기다리겠습니다.
+          감사합니다.
 
-          감사합니다.`}
+          SOPT makers 드림
+          `}
         </p>
       )}
     </>
@@ -78,7 +92,7 @@ const FinalResult = () => {
     handleSaveRecruitingInfo,
   } = useRecruitingInfo();
 
-  const { name, pass } = finalResult?.data || {};
+  const { name, pass } = finalResult?.data || {}; 
 
   useEffect(() => {
     handleSaveRecruitingInfo({
@@ -90,7 +104,7 @@ const FinalResult = () => {
 
   return (
     <section className={container}>
-      <div style={{ overflow: 'auto', height: '100%' }}>
+      <div style={{ overflow: 'auto', height: `calc(100dvh - ${deviceType === 'MOB' ? MOBILE_HEADER_HEIGHT : DESKTOP_HEADER_HEIGHT}px)` }}>
         <div className={contentWrapperVar[deviceType]}>
           <Title>결과 확인</Title>
           <Content pass={pass} />

--- a/src/views/ResultPage/components/ScreeningResult.tsx
+++ b/src/views/ResultPage/components/ScreeningResult.tsx
@@ -1,25 +1,24 @@
-import { useEffect } from 'react';
 
 import Title from '@components/Title';
 import { useDeviceType } from 'contexts/DeviceTypeProvider';
 import { useRecruitingInfo } from 'contexts/RecruitingInfoProvider';
-import BigLoading from 'views/loadings/BigLoding';
 
 import {
   bottomAnimation,
   bottomSvg,
   container,
   contentVar,
-  contentWrapperVar,
-  link,
-  scrollBottomGradVar,
-  strongText,
+  contentWrapperVar, scrollBottomGradVar,
+  strongText
 } from './style.css';
 import IconMakersLogo from '../assets/IconMakersLogo';
-import useGetScreeningResult from '../hooks/useGetScreeningResult';
-// import { format } from '@utils/dateFormatter';
-import { track } from '@amplitude/analytics-browser';
 import { format } from '@utils/dateFormatter';
+import useGetScreeningResult from 'views/ResultPage/hooks/useGetScreeningResult';
+import { useEffect } from 'react';
+import BigLoading from 'views/loadings/BigLoding';
+
+const MOBILE_HEADER_HEIGHT = 73;
+const DESKTOP_HEADER_HEIGHT = 79;
 
 const Content = ({ pass }: { pass?: boolean }) => {
   const { deviceType } = useDeviceType();
@@ -47,55 +46,56 @@ const Content = ({ pass }: { pass?: boolean }) => {
   // const formattedApplicationPassConfirmStart = format(applicationDate, 'M월 dd일 E');
   // const formattedApplicationPassConfirmNextDay = format(new Date(applicationPassConfirmNextDay || ''), 'M월 dd일');
 
-  const SOPT_NAME = isMakers ? `SOPT ${soptName}` : soptName;
-  const GROUP_NAME = isMakers ? 'Makers' : group;
+  const SOPT_NAME = isMakers ? `SOPT makers` : `${season}기 ${soptName}`;
+  const GROUP_NAME = isMakers ? 'SOPT makers' : group;
 
   return (
     <>
       {pass ? (
         <p className={contentVar[deviceType]}>
-          <span>{`안녕하세요. ${season}기 ${SOPT_NAME} 입니다.\n\n`}</span>
-          <strong className={strongText[isMakers ? 'makers' : 'sopt']}>{`축하드립니다!`}</strong>
+          <span>{`안녕하세요. ${SOPT_NAME} 입니다.\n\n`}</span>
+          <strong className={strongText[isMakers ? 'makers' : 'sopt']}>{`축하드립니다!\n`}</strong>
           <span className="amp-mask">
-            {`
-              서류 검토 결과, ${name}님은 면접 대상자로 선정되셨습니다.
-
-              ${season}기 ${GROUP_NAME} 면접은 ${formattedInterviewStart} ~ ${formattedInterviewEnd} 양일 간 \n 오프라인으로 진행될 예정입니다.\n
-              모든 면접 대상자 분들을 대상으로 면접 가능 시간을 조사하려 합니다. 아래 구글폼을 금일 22시 (3월 20일 목요일 오후 10시)까지 제출해주세요.
-            `}
+            {`서류 검토 결과, ${name}님은 인터뷰 대상자로 선정되셨습니다.\n\n`}
           </span>
-          <a
-            className={link}
-            onClick={() => track('click-screening-google_form')}
-            href={`https://${import.meta.env.VITE_SCREENING_PASS_LINK}`}
-            target="_blank"
-            rel="noreferrer noopener">
-            {`https://${deviceType !== 'DESK' ? '\n' : ''}${import.meta.env.VITE_SCREENING_PASS_LINK}`}
-          </a>
-          <br />
+          <span className="amp-mask">{`${season}기 ${GROUP_NAME} 인터뷰는 `}</span>
+          <strong className={strongText[isMakers ? 'makers' : 'sopt']}>{`${formattedInterviewStart} ~ ${formattedInterviewEnd}`}</strong>
+          <span className="amp-mask">{` 기간 중 진행될 예정입니다.\n\n`}</span>
+          <span className="amp-mask">{`원할한 면접 진행을 위해, 아래 구글 폼에 `}</span>
+          <strong className={strongText[isMakers ? 'makers' : 'sopt']}>{`불가능한 시간대를 모두 선택`}</strong>
+          <span className="amp-mask">{`해 제출 부탁드립니다.\n`}</span>
+          <span className="amp-mask">{`(제출 마감 : `}</span>
+          <strong className={strongText[isMakers ? 'makers' : 'sopt']}>{`8월 20일 수요일 오후 8시`}</strong>
+          <span> {`)\n`}</span>
+          <span>{`(구글폼 : `}</span>
+          <a style={{textDecoration: 'underline'}} href={`https://${import.meta.env.VITE_SCREENING_PASS_LINK}`} target="_blank" rel="noreferrer noopener">{`https:/${import.meta.env.VITE_SCREENING_PASS_LINK})\n`}</a>
           <span>
             {`
-            면접 안내 사항 및 폼 제출 내용을 기반으로 한 면접 시간표를 내일 (21일 금요일) 오후 12시 전으로 이메일을 통해 전해드리겠습니다.
+            제출해주신 폼 내용을 기반으로 확정된 면접 일정 및 면접 안내를 내일(8월 21일) 오후 12시 전으로 이메일을 통해 공유드리겠습니다. 
 
-            다시 한 번 진심으로 축하드리며,\n 면접에서 뵙도록 하겠습니다 :)
+            다시 한 번 진심으로 축하드리며, 인터뷰에서 뵙겠습니다!
+
+            문의 사항 및 궁금한 점은 아래 연락처로 문의 부탁드립니다.
+            김가연 : 010-9477-0304
+            
+            감사합니다.
             `}
           </span>
         </p>
       ) : (
         <p className={`amp-mask ${contentVar[deviceType]}`}>
-          {`안녕하세요. ${season}기 ${SOPT_NAME}입니다.
+          {`안녕하세요. ${SOPT_NAME}입니다.
 
-          먼저 ${season}기 ${SOPT_NAME} ${group}회원 모집에 관심을 가지고
-          합류 여정을 함께해주셔서 감사하다는 말씀을 드립니다.
+          ${SOPT_NAME}에 관심을 갖고 지원해 주셔서 감사드립니다.
+          ${name}님의 뛰어난 역량과 잠재력에도 불구하고 안타깝게도 귀하의 합격 소식을 전해드리지 못하게 되었습니다.
 
-          ${name}님은 ${season}기 ${SOPT_NAME} ${group}회원 모집에 불합격하셨습니다.
-          
-          지원자님의 뛰어난 역량과 잠재력에도 불구하고
-          안타깝게도 귀하의 서류 합격 소식을 전해드리지 못하게 되었습니다.
+          비록 이번 ${season}기 makers에 모시지 못하게 되었으나, makers에 지원하시고자 쓰인 소중한 시간과 노력이 지원자님께서 IT 창업인으로서 멋진 역할을 해나가시는 데 작게나마 도움이 되는 경험이 되셨길 바랍니다.
 
-          한 분 한 분에게 개별적인 피드백을 드리기는 어렵겠으나 저희 SOPT에 지원하셨던 경험이 IT 창업인으로서 멋진 역할을 해나가시는 데 큰 도움이 되기를 바랍니다. 
-
+          ${SOPT_NAME}에 귀한 시간을 내어주셔서 다시 한 번 깊이 감사드립니다 :)
+          향후에 더 좋은 인연으로 뵙기를 기다리겠습니다.
           감사합니다.
+
+          SOPT makers 드림
           `}
         </p>
       )}
@@ -123,7 +123,7 @@ const ScreeningResult = () => {
 
   return (
     <section className={container}>
-      <div style={{ overflow: 'auto', height: '100%' }}>
+      <div style={{ overflow: 'auto', height: `calc(100dvh - ${deviceType === 'MOB' ? MOBILE_HEADER_HEIGHT : DESKTOP_HEADER_HEIGHT}px)` }}>
         <div className={contentWrapperVar[deviceType]}>
           <Title>결과 확인</Title>
           <Content pass={pass} />

--- a/src/views/ResultPage/components/ScreeningResult.tsx
+++ b/src/views/ResultPage/components/ScreeningResult.tsx
@@ -31,9 +31,10 @@ const Content = ({ pass }: { pass?: boolean }) => {
       interviewStart,
       interviewEnd,
       applicationResultStart,
-      isMakers,
     },
   } = useRecruitingInfo();
+
+  const isMakers = import.meta.env.MODE === 'makers';
 
   if (!name) return;
 
@@ -41,8 +42,8 @@ const Content = ({ pass }: { pass?: boolean }) => {
   const applicationPassConfirmNextDay = new Date(applicationDate);
   applicationPassConfirmNextDay.setDate(applicationDate.getDate() + 1);
 
-  const formattedInterviewStart = format(new Date(interviewStart || ''), 'M월 dd일 E');
-  const formattedInterviewEnd = format(new Date(interviewEnd || ''), 'M월 dd일 E');
+  const formattedInterviewStart = format(new Date(interviewStart || ''), 'M월 dd일');
+  const formattedInterviewEnd = format(new Date(interviewEnd || ''), 'M월 dd일');
   // const formattedApplicationPassConfirmStart = format(applicationDate, 'M월 dd일 E');
   // const formattedApplicationPassConfirmNextDay = format(new Date(applicationPassConfirmNextDay || ''), 'M월 dd일');
 
@@ -129,7 +130,7 @@ const ScreeningResult = () => {
           <Content pass={pass} />
         </div>
       </div>
-      {deviceType !== 'MOB' && pass && (
+      {deviceType !== 'MOB' && isMakers && (
         <>
           <div className={bottomAnimation[isMakers ? 'makers' : 'sopt']} />
           {isMakers && (

--- a/src/views/SignInPage/components/SignInForm/index.tsx
+++ b/src/views/SignInPage/components/SignInForm/index.tsx
@@ -22,13 +22,20 @@ const SignInForm = () => {
   });
 
   const handleSignIn = ({ email, password }: FieldValues) => {
-    if (!season || !group) return;
+    const isMakers = import.meta.env.MODE === 'makers';
+
+    let updatedGroup = group;
+    if (isMakers) {
+      updatedGroup = 'OB';
+    }
+
+    if (!season || !updatedGroup) return;
 
     signInMutate({
       email,
       password,
       season,
-      group,
+      group: updatedGroup,
     });
   };
 

--- a/src/views/SignupPage/components/SignupForm/index.tsx
+++ b/src/views/SignupPage/components/SignupForm/index.tsx
@@ -47,7 +47,14 @@ const SignupForm = () => {
       return;
     }
 
-    if (!season || !group) return;
+    const isMakers = import.meta.env.MODE === 'makers';
+
+    let updatedGroup = group;
+    if (isMakers) {
+      updatedGroup = 'OB';
+    }
+
+    if (!season || !updatedGroup) return;
 
     signUpMutate({
       email,
@@ -56,7 +63,7 @@ const SignupForm = () => {
       name,
       phone,
       season,
-      group,
+      group: updatedGroup,
     });
   };
 


### PR DESCRIPTION
**Related Issue :** Closes  #496 

---

## 🧑‍🎤 Summary

합불 문구 업데이트 했습니다.

+ dev(makers)에서 회원가입 하려고 할 때 group이 null 값이어서 얼리 리턴되어 이메일 인증코드 수신 버튼, 회원가입 버튼이 작동이 안되는 이슈가 있었어요.

기존의 코드처럼 isMakers를 env.MODE를 통해 파악하고 메이커스면 OB로 설정해줬습니다.
그리고 지원서 결과 확인에서 context에서 isMakers 값을 가져오는 부분을 env 관련 코드로 통일해주었어요.

## 🧑‍🎤 Screenshot

<img width="1049" height="753" alt="스크린샷 2025-08-03 오후 9 27 27" src="https://github.com/user-attachments/assets/0e6efce9-1565-442a-b998-dcd712a5855e" />

<img width="1053" height="763" alt="스크린샷 2025-08-03 오후 9 28 01" src="https://github.com/user-attachments/assets/600dd195-15ba-42e9-a447-6b0261234369" />

<img width="959" height="763" alt="스크린샷 2025-08-03 오후 9 23 34" src="https://github.com/user-attachments/assets/9b879b54-e49b-4a53-8d94-a2264c0d1890" />



## 🧑‍🎤 Comment

