### PR TITLE
[Feat] mode에 따라 primary 색상 다르게 적용

### DIFF
--- a/src/common/constants/mode.ts
+++ b/src/common/constants/mode.ts
@@ -1,2 +1,2 @@
 /** 메이커스인지 확인 */
-export const IS_MAKERS = import.meta.env.MODE === 'makers';
+export const IS_MAKERS = __IS_MAKERS__;

--- a/src/styles/theme.css.ts
+++ b/src/styles/theme.css.ts
@@ -1,6 +1,26 @@
+import { IS_MAKERS } from '@constants/mode';
 import { colors } from '@sopt-makers/colors';
 import { fontsObject } from '@sopt-makers/fonts';
 import { createTheme, createThemeContract } from '@vanilla-extract/css';
+
+const primaryColor = () => {
+  if (IS_MAKERS) {
+    return {
+      // makers 기본 컬러
+      primary: colors.gray600,
+      primaryLight: colors.gray30,
+      primaryDark: colors.gray950,
+      primaryLinear: 'linear-gradient(rgba(63, 63, 71, 0.3) 0%, rgba(63, 63, 71, 1) 45%, rgba(63, 63, 71, 0.3) 100%)',
+    };
+  }
+  return {
+    // 기수 컬러 (매 기수마다 변경 필요)
+    primary: '#FF5976',
+    primaryLight: '#66242F',
+    primaryDark: '#FF5976',
+    primaryLinear: '#613039',
+  };
+};
 
 const color = createThemeContract({
   primary: null, // 기수 컬러
@@ -37,14 +57,10 @@ const color = createThemeContract({
 });
 
 export const light = createTheme(color, {
-  primary: '#FF5976',
-  primaryLight: '#66242F',
-  primaryDark: '#FF5976',
-  primaryLinear: '#613039',
-  // primary: colors.gray600,
-  // primaryLight: colors.gray30,
-  // primaryDark: colors.gray950,
-  // primaryLinear: 'linear-gradient(rgba(63, 63, 71, 0.3) 0%, rgba(63, 63, 71, 1) 45%, rgba(63, 63, 71, 0.3) 100%)',
+  primary: primaryColor().primary,
+  primaryLight: primaryColor().primaryLight,
+  primaryDark: primaryColor().primaryDark,
+  primaryLinear: primaryColor().primaryLinear,
   error: colors.error,
 
   background: colors.white,
@@ -74,14 +90,10 @@ export const light = createTheme(color, {
 });
 
 export const dark = createTheme(color, {
-  primary: '#FF5976',
-  primaryLight: '#66242F',
-  primaryDark: '#FF5976',
-  primaryLinear: '#613039',
-  // primary: colors.gray600,
-  // primaryLight: colors.gray30,
-  // primaryDark: colors.gray950,
-  // primaryLinear: 'linear-gradient(rgba(63, 63, 71, 0.3) 0%, rgba(63, 63, 71, 1) 45%, rgba(63, 63, 71, 0.3) 100%)',
+  primary: primaryColor().primary,
+  primaryLight: primaryColor().primaryLight,
+  primaryDark: primaryColor().primaryDark,
+  primaryLinear: primaryColor().primaryLinear,
   error: colors.error,
 
   background: colors.gray950,

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,3 @@
 /// <reference types="vite/client" />
+
+declare const __IS_MAKERS__: boolean;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,7 +7,7 @@ import { visualizer } from 'rollup-plugin-visualizer';
 import { defineConfig, type PluginOption } from 'vite';
 
 // https://vitejs.dev/config/
-export default defineConfig({
+export default defineConfig(({ mode }) => ({
   plugins: [
     react(),
     vanillaExtractPlugin(),
@@ -17,6 +17,9 @@ export default defineConfig({
       brotliSize: true,
     }) as PluginOption,
   ],
+  define: {
+    'import.meta.env.MODE': JSON.stringify(mode),
+  },
   build: {
     rollupOptions: {
       output: {
@@ -75,4 +78,4 @@ export default defineConfig({
     environment: 'jsdom',
     setupFiles: './src/tests/setupTests.ts',
   },
-});
+}));

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -18,7 +18,7 @@ export default defineConfig(({ mode }) => ({
     }) as PluginOption,
   ],
   define: {
-    'import.meta.env.MODE': JSON.stringify(mode),
+    __IS_MAKERS__: JSON.stringify(mode === 'makers'),
   },
   build: {
     rollupOptions: {


### PR DESCRIPTION
**Related Issue :** Closes  #521 

---

## 🧑‍🎤 Summary
Vite는 기본적으로 .env 파일을 로드하지 않는다고 합니다.

하지만 env.mode를 통해 스타일도 분기 처리 해야하기 때문에 vite.config.ts에서 env mode를 전달하여 빌드 타임에 컴파일 되는 vanilla extract에서 makers모드를 파악할 수 있게 변경했습니다.

```ts
  define: {
    __IS_MAKERS__: JSON.stringify(mode === 'makers'),
  },
```

또한 가독성을 위해 __IS_MAKERS__라는 환경변수명으로 변경해주었어요.

## 🧑‍🎤 Screenshot


<img width="706" height="741" alt="스크린샷 2025-08-21 오후 5 00 39" src="https://github.com/user-attachments/assets/e02890d5-02c0-4aa0-91f5-dd241b7d17fe" />

<img width="879" height="836" alt="스크린샷 2025-08-21 오후 5 00 49" src="https://github.com/user-attachments/assets/cada0d21-0bd0-4095-b385-2b838d0e3be2" />


## 🧑‍🎤 Comment

