### PR TITLE
[Feat] 전체 FAQ 탭 상수 추가 및 스타일 개선

### DIFF
--- a/src/views/IntroducePage/components/FAQ/components/TabBar/index.tsx
+++ b/src/views/IntroducePage/components/FAQ/components/TabBar/index.tsx
@@ -1,4 +1,3 @@
-import { useDeviceType } from 'contexts/DeviceTypeProvider';
 import { FAQ_TABS } from 'views/IntroducePage/constants/constant';
 import { PartDataType } from 'views/IntroducePage/types';
 import { tabBar, tabRecipe } from './style.css';
@@ -9,18 +8,13 @@ interface Props {
 }
 
 const TabBar = ({ selectedTab, onChange }: Props) => {
-  const { deviceType } = useDeviceType();
-
   return (
-    <nav className={tabBar[deviceType]}>
+    <nav className={tabBar}>
       {FAQ_TABS.map((tab) => (
         <button
           key={tab}
           type="button"
-          className={tabRecipe({
-            state: selectedTab === tab ? 'selected' : 'default',
-            viewport: deviceType,
-          })}
+          className={tabRecipe({ state: selectedTab === tab ? 'selected' : 'default' })}
           onClick={() => onChange(tab)}>
           {tab}
         </button>

--- a/src/views/IntroducePage/components/FAQ/components/TabBar/style.css.ts
+++ b/src/views/IntroducePage/components/FAQ/components/TabBar/style.css.ts
@@ -1,0 +1,46 @@
+import { colors } from '@sopt-makers/colors';
+import { style } from '@vanilla-extract/css';
+import { recipe } from '@vanilla-extract/recipes';
+import { breakpoints } from 'styles/breakpoints';
+import { theme } from 'styles/theme.css';
+
+export const tabBar = style({
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+  gap: '8px',
+  '@media': {
+    [breakpoints.mobile]: {
+      flexWrap: 'wrap',
+      justifyContent: 'center',
+    },
+  },
+});
+
+export const tabRecipe = recipe({
+  base: {
+    border: 'none',
+    borderRadius: '14px',
+    cursor: 'pointer',
+    transition: '0.2s',
+    whiteSpace: 'nowrap',
+    padding: '14px 40px',
+    ...theme.font.HEADING_4_24_B,
+    '@media': {
+      [breakpoints.tablet]: {
+        padding: '10px 12px',
+        ...theme.font.LABEL_2_16_SB,
+      },
+      [breakpoints.mobile]: {
+        padding: '8px 14px',
+        ...theme.font.LABEL_3_14_SB,
+      },
+    },
+  },
+  variants: {
+    state: {
+      selected: { backgroundColor: '#f6f6f6', color: colors.gray950 },
+      default: { backgroundColor: colors.gray10, color: colors.gray500 },
+    },
+  },
+});

--- a/src/views/IntroducePage/components/FAQ/index.tsx
+++ b/src/views/IntroducePage/components/FAQ/index.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useState } from 'react';
 import SectionTitle from '@components/SectionTitle';
 import { FAQ_전체, TITLE } from 'views/IntroducePage/constants/constant';
 import { PartDataType, RecruitQuestion, RecruitQuestionItem } from 'views/IntroducePage/types';
@@ -13,10 +13,11 @@ import {
   questionTextVar,
   listWrapperVar,
 } from './style.css';
-import TabBar from 'views/IntroducePage/components/FAQ/TabBar';
+
 import { IconChevronDown } from '@sopt-makers/icons';
 import { useDeviceType } from 'contexts/DeviceTypeProvider';
 import useToggleSet from 'views/IntroducePage/components/FAQ/hooks/useToggleSet';
+import TabBar from 'views/IntroducePage/components/FAQ/components/TabBar';
 
 interface FAQProps {
   faqData?: RecruitQuestion[];
@@ -33,13 +34,8 @@ const FAQ = ({ faqData }: FAQProps) => {
     reset();
   };
 
-  const faqByPart = useMemo(() => {
-    if (!faqData) return {};
-
-    return Object.fromEntries(faqData.filter((p) => p.part !== '전체').map((p) => [p.part, p.questions]));
-  }, [faqData]);
-
-  const selectedFaqItems = selectedTab === '전체' ? FAQ_전체 : faqByPart[selectedTab] || [];
+  const selectedFaqItems =
+    selectedTab === '전체' ? FAQ_전체 : (faqData?.find((p) => p.part === selectedTab)?.questions ?? []);
 
   if (!faqData || faqData.length === 0) return null;
 

--- a/src/views/IntroducePage/components/FAQ/index.tsx
+++ b/src/views/IntroducePage/components/FAQ/index.tsx
@@ -8,14 +8,13 @@ import {
   questionWrapper,
   iconWrapperVar,
   answerWrapper,
-  answerLabelVar,
-  answerTextVar,
-  questionTextVar,
-  listWrapperVar,
+  answerLabel,
+  answerText,
+  questionText,
+  listWrapper,
 } from './style.css';
 
 import { IconChevronDown } from '@sopt-makers/icons';
-import { useDeviceType } from 'contexts/DeviceTypeProvider';
 import useToggleSet from 'views/IntroducePage/components/FAQ/hooks/useToggleSet';
 import TabBar from 'views/IntroducePage/components/FAQ/components/TabBar';
 
@@ -27,7 +26,6 @@ const FAQ = ({ faqData }: FAQProps) => {
   const [selectedTab, setSelectedTab] = useState<PartDataType>('전체');
 
   const { items, toggle, reset } = useToggleSet();
-  const { deviceType } = useDeviceType();
 
   const handleTabChange = (tab: PartDataType) => {
     setSelectedTab(tab);
@@ -40,7 +38,7 @@ const FAQ = ({ faqData }: FAQProps) => {
   if (!faqData || faqData.length === 0) return null;
 
   return (
-    <section className={wrapper[deviceType]}>
+    <section className={wrapper}>
       <SectionTitle label={TITLE.FAQ.label} title={TITLE.FAQ.title} />
       <TabBar selectedTab={selectedTab} onChange={handleTabChange} />
       <FAQList faqItems={selectedFaqItems} selectedTab={selectedTab} openedItems={items} toggle={toggle} />
@@ -58,10 +56,8 @@ interface FAQListProps {
 }
 
 const FAQList = ({ faqItems, selectedTab, openedItems, toggle }: FAQListProps) => {
-  const { deviceType } = useDeviceType();
-
   return (
-    <ul className={listWrapperVar[deviceType]}>
+    <ul className={listWrapper}>
       {faqItems.map((faq, index) => {
         const isOpened = openedItems.has(index);
         return <FAQItem key={`${selectedTab}-${index}`} faq={faq} isOpened={isOpened} onClick={() => toggle(index)} />;
@@ -77,21 +73,20 @@ interface FAQItemProps {
 }
 
 const FAQItem = ({ faq, isOpened, onClick }: FAQItemProps) => {
-  const { deviceType } = useDeviceType();
   const state = isOpened ? 'opened' : 'closed';
 
   return (
-    <li className={itemVar({ state, viewport: deviceType })} onClick={onClick}>
+    <li className={itemVar({ state })} onClick={onClick}>
       <div className={questionWrapper}>
-        <p className={questionTextVar[deviceType]}>{faq.question}</p>
-        <span className={iconWrapperVar({ state, viewport: deviceType })}>
+        <p className={questionText}>{faq.question}</p>
+        <span className={iconWrapperVar({ state })}>
           <IconChevronDown />
         </span>
       </div>
       {isOpened && (
         <div className={answerWrapper}>
-          <span className={answerLabelVar[deviceType]}>A.</span>
-          <p className={answerTextVar[deviceType]}>{faq.answer}</p>
+          <span className={answerLabel}>A.</span>
+          <p className={answerText}>{faq.answer}</p>
         </div>
       )}
     </li>

--- a/src/views/IntroducePage/components/FAQ/index.tsx
+++ b/src/views/IntroducePage/components/FAQ/index.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from 'react';
 import SectionTitle from '@components/SectionTitle';
-import { TITLE } from 'views/IntroducePage/constants/constant';
+import { FAQ_전체, TITLE } from 'views/IntroducePage/constants/constant';
 import { PartDataType, RecruitQuestion, RecruitQuestionItem } from 'views/IntroducePage/types';
 import {
   wrapper,
@@ -36,8 +36,10 @@ const FAQ = ({ faqData }: FAQProps) => {
   const faqByPart = useMemo(() => {
     if (!faqData) return {};
 
-    return Object.fromEntries(faqData.map((p) => [p.part, p.questions]));
+    return Object.fromEntries(faqData.filter((p) => p.part !== '전체').map((p) => [p.part, p.questions]));
   }, [faqData]);
+
+  const selectedFaqItems = selectedTab === '전체' ? FAQ_전체 : faqByPart[selectedTab] || [];
 
   if (!faqData || faqData.length === 0) return null;
 
@@ -45,7 +47,7 @@ const FAQ = ({ faqData }: FAQProps) => {
     <section className={wrapper[deviceType]}>
       <SectionTitle label={TITLE.FAQ.label} title={TITLE.FAQ.title} />
       <TabBar selectedTab={selectedTab} onChange={handleTabChange} />
-      <FAQList faqItems={faqByPart[selectedTab] || []} selectedTab={selectedTab} openedItems={items} toggle={toggle} />
+      <FAQList faqItems={selectedFaqItems} selectedTab={selectedTab} openedItems={items} toggle={toggle} />
     </section>
   );
 };

--- a/src/views/IntroducePage/components/FAQ/style.css.ts
+++ b/src/views/IntroducePage/components/FAQ/style.css.ts
@@ -27,7 +27,7 @@ const listWrapperBase = style({
 });
 
 export const listWrapperVar = styleVariants({
-  DESK: [listWrapperBase, { paddingTop: '32px', gap: '48px' }],
+  DESK: [listWrapperBase, { paddingTop: '32px', gap: '16px' }],
   TAB: [listWrapperBase, { gap: '8px' }],
   MOB: [listWrapperBase, { gap: '8px' }],
 });

--- a/src/views/IntroducePage/components/FAQ/style.css.ts
+++ b/src/views/IntroducePage/components/FAQ/style.css.ts
@@ -1,22 +1,23 @@
 import { colors } from '@sopt-makers/colors';
-import { style, styleVariants } from '@vanilla-extract/css';
+import { style } from '@vanilla-extract/css';
 import { recipe } from '@vanilla-extract/recipes';
+import { breakpoints } from 'styles/breakpoints';
 import { theme } from 'styles/theme.css';
 
-const wrapperBase = style({
+export const wrapper = style({
   display: 'flex',
   flexDirection: 'column',
   alignItems: 'center',
   justifyContent: 'center',
+  gap: '48px',
+  '@media': {
+    [breakpoints.tabletAndMobile]: {
+      gap: '16px',
+    },
+  },
 });
 
-export const wrapper = styleVariants({
-  DESK: [wrapperBase, { gap: '48px' }],
-  TAB: [wrapperBase, { gap: '16px' }],
-  MOB: [wrapperBase, { gap: '16px' }],
-});
-
-const listWrapperBase = style({
+export const listWrapper = style({
   display: 'flex',
   width: '100%',
   justifyContent: 'center',
@@ -24,36 +25,35 @@ const listWrapperBase = style({
   flexDirection: 'column',
   gap: '16px',
   listStyle: 'none',
-});
-
-export const listWrapperVar = styleVariants({
-  DESK: [listWrapperBase, { paddingTop: '32px', gap: '16px' }],
-  TAB: [listWrapperBase, { gap: '8px' }],
-  MOB: [listWrapperBase, { gap: '8px' }],
-});
-
-const itemBase = style({
-  display: 'flex',
-  maxWidth: '1200px',
-  width: '100%',
-  flexDirection: 'column',
-  borderRadius: '30px',
-  padding: '40px 50px',
-  cursor: 'pointer',
-  transition: '0.2s',
+  paddingTop: '32px',
+  '@media': {
+    [breakpoints.tabletAndMobile]: {
+      gap: '8px',
+      paddingTop: 0,
+    },
+  },
 });
 
 export const itemVar = recipe({
-  base: itemBase,
+  base: {
+    display: 'flex',
+    maxWidth: '1200px',
+    width: '100%',
+    flexDirection: 'column',
+    borderRadius: '30px',
+    padding: '40px 50px',
+    cursor: 'pointer',
+    transition: '0.2s',
+    '@media': {
+      [breakpoints.tabletAndMobile]: {
+        padding: '20px',
+      },
+    },
+  },
   variants: {
     state: {
       opened: { backgroundColor: '#f6f6f6' },
       closed: { backgroundColor: 'transparent' },
-    },
-    viewport: {
-      DESK: { padding: '40px 50px' },
-      TAB: { padding: '20px' },
-      MOB: { padding: '20px' },
     },
   },
 });
@@ -64,115 +64,89 @@ export const questionWrapper = style({
   gap: '14px',
 });
 
-const questionTextBase = style({
+export const questionText = style({
   fontFamily: 'SUIT',
   color: colors.gray950,
+  fontSize: '24px',
+  lineHeight: '36px',
+  fontWeight: 600,
+  '@media': {
+    [breakpoints.tabletAndMobile]: {
+      ...theme.font.BODY_3_14_M,
+    },
+  },
 
   selectors: {
     '&::before': {
       content: '"Q. "',
       color: theme.color.primary,
       fontFamily: 'SUIT',
+      fontWeight: 800,
+      fontSize: '27px',
+      lineHeight: '46px',
+      '@media': {
+        [breakpoints.tabletAndMobile]: {
+          fontWeight: 400,
+          fontSize: theme.font.BODY_3_14_M.fontSize,
+          lineHeight: theme.font.BODY_3_14_M.lineHeight,
+        },
+      },
     },
   },
 });
 
-export const questionTextVar = styleVariants({
-  DESK: [
-    questionTextBase,
-    {
-      fontSize: '24px',
-      lineHeight: '36px',
-      fontWeight: 600,
-      selectors: { '&::before': { fontWeight: 800, fontSize: '27px', lineHeight: '46px' } },
-    },
-  ],
-  TAB: [questionTextBase, { ...theme.font.BODY_3_14_M }],
-  MOB: [questionTextBase, { ...theme.font.BODY_3_14_M }],
-});
-
-const answerLabelBase = style({
+export const answerLabel = style({
   color: theme.color.primary,
   fontFamily: 'SUIT',
   fontWeight: 800,
   flexShrink: 0,
+  fontSize: '27px',
+  lineHeight: '44px',
+  '@media': {
+    [breakpoints.tabletAndMobile]: {
+      ...theme.font.BODY_3_14_M,
+    },
+  },
 });
 
-export const answerLabelVar = styleVariants({
-  DESK: [answerLabelBase, { fontSize: '27px', lineHeight: '44px' }],
-  TAB: [answerLabelBase, { ...theme.font.BODY_3_14_M }],
-  MOB: [answerLabelBase, { ...theme.font.BODY_3_14_M }],
-});
-
-const answerTextBase = style({
+export const answerText = style({
   fontFamily: 'SUIT',
   fontWeight: 400,
   wordBreak: 'keep-all',
   color: colors.gray600,
   whiteSpace: 'pre-line',
-});
-
-export const answerTextVar = styleVariants({
-  DESK: [answerTextBase, { fontSize: '24px', lineHeight: '44px' }],
-  TAB: [answerTextBase, { ...theme.font.BODY_2_16_R }],
-  MOB: [answerTextBase, { ...theme.font.BODY_3_14_M }],
-});
-
-const iconWrapperBase = style({
-  display: 'flex',
-  justifyContent: 'center',
-  alignItems: 'center',
-  width: '40px',
-  height: '40px',
-  flexShrink: 0,
-  transition: 'transform 0.2s',
+  fontSize: '24px',
+  lineHeight: '44px',
+  '@media': {
+    [breakpoints.tablet]: {
+      ...theme.font.BODY_2_16_R,
+    },
+    [breakpoints.mobile]: {
+      ...theme.font.BODY_3_14_M,
+    },
+  },
 });
 
 export const iconWrapperVar = recipe({
-  base: iconWrapperBase,
+  base: {
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center',
+    width: '40px',
+    height: '40px',
+    flexShrink: 0,
+    transition: 'transform 0.2s',
+    '@media': {
+      [breakpoints.tabletAndMobile]: {
+        width: '24px',
+        height: '24px',
+      },
+    },
+  },
   variants: {
     state: {
       opened: { transform: 'rotate(180deg)' },
       closed: { transform: 'rotate(0deg)' },
-    },
-    viewport: {
-      DESK: { width: '40px', height: '40px' },
-      TAB: { width: '24px', height: '24px' },
-      MOB: { width: '24px', height: '24px' },
-    },
-  },
-});
-
-const tabBarBase = style({
-  display: 'flex',
-  justifyContent: 'center',
-  alignItems: 'center',
-  gap: '8px',
-});
-
-export const tabBar = styleVariants({
-  DESK: [tabBarBase, { gap: '8px' }],
-  TAB: [tabBarBase, { gap: '8px' }],
-  MOB: [tabBarBase, { flexWrap: 'wrap', justifyContent: 'center' }],
-});
-
-export const tabRecipe = recipe({
-  base: {
-    border: 'none',
-    borderRadius: '14px',
-    cursor: 'pointer',
-    transition: '0.2s',
-    whiteSpace: 'nowrap',
-  },
-  variants: {
-    state: {
-      selected: { backgroundColor: '#f6f6f6', color: colors.gray950 },
-      default: { backgroundColor: colors.gray10, color: colors.gray500 },
-    },
-    viewport: {
-      DESK: { padding: '14px 40px', ...theme.font.HEADING_4_24_B },
-      TAB: { padding: '10px 12px', ...theme.font.LABEL_2_16_SB },
-      MOB: { padding: '8px 14px', ...theme.font.LABEL_3_14_SB },
     },
   },
 });

--- a/src/views/IntroducePage/components/SoptPart/index.tsx
+++ b/src/views/IntroducePage/components/SoptPart/index.tsx
@@ -1,6 +1,6 @@
 import SectionTitle from '@components/SectionTitle';
 import { TITLE } from 'views/IntroducePage/constants/constant';
-import { wrapper, container, name, description, card } from './style.css';
+import { wrapper, container, name, description, itemWrapper } from './style.css';
 import { Tag } from '@sopt-makers/ui';
 import { PART_ORDER, type SoptPartIntroduction } from 'views/IntroducePage/types';
 import { useDeviceType } from 'contexts/DeviceTypeProvider';
@@ -45,7 +45,7 @@ const PartItem = ({ part }: ItemProps) => {
   const { deviceType } = useDeviceType();
 
   return (
-    <li className={card}>
+    <li className={itemWrapper}>
       <Tag variant="secondary" size={deviceType === 'DESK' ? 'lg' : 'sm'}>
         {part.part}
       </Tag>

--- a/src/views/IntroducePage/components/SoptPart/style.css.ts
+++ b/src/views/IntroducePage/components/SoptPart/style.css.ts
@@ -44,13 +44,14 @@ export const container = style({
   },
 });
 
-export const card = style({
+export const itemWrapper = style({
   display: 'flex',
   maxWidth: '380px',
   flexDirection: 'column',
   backgroundColor: '#f6f6f6',
   borderRadius: '24px',
   padding: '38px 40px',
+  cursor: 'pointer',
   '@media': {
     [breakpoints.tablet]: {
       width: '224px',

--- a/src/views/IntroducePage/constants/constant.ts
+++ b/src/views/IntroducePage/constants/constant.ts
@@ -1,4 +1,4 @@
-import { ContactItem, ContactType, PartDataType } from 'views/IntroducePage/types';
+import { ContactItem, ContactType, PartDataType, RecruitQuestionItem } from 'views/IntroducePage/types';
 
 export const TITLE = {
   RECRUITMENT_TARGET: {
@@ -46,6 +46,23 @@ export const RECRUITMENT_TARGET = [
 
 export const FAQ_TABS: PartDataType[] = ['전체', '기획', '디자인', '안드로이드', 'iOS', '웹', '서버'];
 
+export const FAQ_전체: RecruitQuestionItem[] = [
+  {
+    question: '직장인/휴학생/졸업유예생도 활동할 수 있나요?',
+    answer:
+      '재직, 휴학, 졸업유예 여부에 관계없이 대학생이면 지원 가능해요.\n다만, 대부분의 SOPT 회원들이 활동에 많은 시간을 투자하고 있으므로 직장 재직자는 활동에 충분히 참여할\n 여유가 있을 경우에 지원하시는 것을 권장해요.',
+  },
+  {
+    question: '파트별 커리큘럼이 어떻게 되나요?',
+    answer: '상단의 ‘리크루팅’ 메뉴 또는 ‘SOPT 인스타그램’에 파트별로 자세하게 안내되어 있으니 참고해 주세요.',
+  },
+  {
+    question: '경험과 실력이 부족한데 지원해도 괜찮을까요?',
+    answer:
+      'SOPT는 기획, 디자인, 개발 각 분야에 열정이 있는 사람들이 모여 화합을 통해 변화하고 성장하는 가치를\n추구해요. 따라서 경험과 실력보다는 각 파트에 대한 열정과 SOPT 활동을 통해 이루고자 하는 명확한 목표를 더\n중요시해요. 열정을 갖춘 분들의 용기 있는 도전을 기다릴게요! Shout Our Passion Together!',
+  },
+];
+
 export const contactMap: Record<ContactType, ContactItem> = {
   [ContactType.EMAIL]: {
     label: '이메일',
@@ -72,4 +89,3 @@ export const contactMap: Record<ContactType, ContactItem> = {
     link: { target: '_blank', href: 'https://www.facebook.com/clubsopt/' },
   },
 };
-


### PR DESCRIPTION
## 📋 작업 내용

- [x] `전체` 탭 선택 시 표시할 공통 FAQ 상수(`FAQ_전체`) 추가
- [x] FAQ 컴포넌트에서 `전체` 탭일 때 상수 데이터를 사용하도록 로직 분기 처리
- [x] `faqByPart` 생성 시 `전체` 파트를 필터링하여 API 데이터와 혼용 방지
- [x] FAQ 리스트 DESK 뷰 gap 조정 (`48px` → `16px`)
- [x] SoptPart 카드 컴포넌트에 `cursor: pointer` 스타일 추가 및 클래스명 `card` → `itemWrapper` 리네임

## 📌 PR Point

- `전체` 탭의 FAQ는 서버 API 데이터가 아닌 프론트엔드 상수로 관리해요. API 응답에 `전체` 파트 데이터가 포함되지 않기 때문에 `faqByPart` 필터링과 함께 처리했어요.
- `FAQ_전체` 상수에 공통 질문 3개(직장인/커리큘럼/경험 부족)를 포함했어요. 내용 변경이 필요하면 `constants/constant.ts`만 수정하면 돼요.
- SoptPart 클래스명 `card` → `itemWrapper` 리네임은 의미를 더 명확하게 하기 위한 변경이에요.

## 📸 스크린샷

<img width="1204" height="705" alt="스크린샷 2026-04-30 오후 3 50 07" src="https://github.com/user-attachments/assets/d3b10039-b564-492b-888c-7e5944c36049" />


---

🤖 made by [claude](https://claude.ai)
