### PR TITLE
[Feat] GNB 메뉴 로그인 상태별 분기 처리

### DIFF
--- a/src/common/components/Layout/components/Header/Nav/MenuList/index.tsx
+++ b/src/common/components/Layout/components/Header/Nav/MenuList/index.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useState } from 'react';
 import { useDeviceType } from 'contexts/DeviceTypeProvider';
-import { useRecruitingInfo } from 'contexts/RecruitingInfoProvider';
 
 import { dimmedBgVar, menuContainerVar, menuList, menuMobListVar } from './style.css';
 import { MENU_ITEMS_MAKERS, MENU_ITEMS_SOPT, SIGNED_IN_MENU_ITEMS_SOPT } from '../../contants';
@@ -24,9 +23,6 @@ const MenuList = ({ isMenuOpen, onClickMenuToggle }: { isMenuOpen?: boolean; onC
 
   const isSignedIn = localStorage.getItem('soptApplyAccessToken');
 
-  const {
-    recruitingInfo: { name },
-  } = useRecruitingInfo();
   const menuItems = __IS_MAKERS__ ? MENU_ITEMS_MAKERS : isSignedIn ? SIGNED_IN_MENU_ITEMS_SOPT : MENU_ITEMS_SOPT;
 
   if (onClickMenuToggle && !isShown) return null;
@@ -42,7 +38,7 @@ const MenuList = ({ isMenuOpen, onClickMenuToggle }: { isMenuOpen?: boolean; onC
             <MenuItem key="로그인" text="로그인" path="/auth" amplitudeId="click-gnb-signin" />
           </>
         )}
-        {isSignedIn && name && (
+        {isSignedIn && (
           <>
             {menuItems.map(({ text, path, target, amplitudeId }) => (
               <MenuItem key={text} text={text} path={path} target={target} amplitudeId={amplitudeId} />

--- a/src/common/components/Layout/components/Header/Nav/MenuList/index.tsx
+++ b/src/common/components/Layout/components/Header/Nav/MenuList/index.tsx
@@ -1,4 +1,3 @@
-import { reset } from '@amplitude/analytics-browser';
 import { useEffect, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 
@@ -6,9 +5,8 @@ import { useDeviceType } from 'contexts/DeviceTypeProvider';
 import { useRecruitingInfo } from 'contexts/RecruitingInfoProvider';
 
 import { dimmedBgVar, menuContainerVar, menuList, menuMobListVar } from './style.css';
-import { MENU_ITEMS, MENU_ITEMS_MAKERS } from '../../contants';
+import { MENU_ITEMS_MAKERS, MENU_ITEMS_SOPT, SIGNED_IN_MENU_ITEMS_SOPT } from '../../contants';
 import MenuItem from '../MenuItem';
-import AmplitudeEventTrack from '@components/Button/AmplitudeEventTrack';
 
 const MenuList = ({ isMenuOpen, onClickMenuToggle }: { isMenuOpen?: boolean; onClickMenuToggle?: () => void }) => {
   const { deviceType } = useDeviceType();
@@ -33,13 +31,7 @@ const MenuList = ({ isMenuOpen, onClickMenuToggle }: { isMenuOpen?: boolean; onC
   const {
     recruitingInfo: { name },
   } = useRecruitingInfo();
-  const menuItems = __IS_MAKERS__ ? MENU_ITEMS_MAKERS : MENU_ITEMS;
-  const handleLogout = () => {
-    reset();
-    localStorage.removeItem('soptApplyAccessToken');
-    localStorage.removeItem('soptApplyAccessTokenExpiredTime');
-    pathname === '/' ? window.location.reload() : navigate('/');
-  };
+  const menuItems = __IS_MAKERS__ ? MENU_ITEMS_MAKERS : isSignedIn ? SIGNED_IN_MENU_ITEMS_SOPT : MENU_ITEMS_SOPT;
 
   if (onClickMenuToggle && !isShown) return null;
 
@@ -59,10 +51,6 @@ const MenuList = ({ isMenuOpen, onClickMenuToggle }: { isMenuOpen?: boolean; onC
             {menuItems.map(({ text, path, target, amplitudeId }) => (
               <MenuItem key={text} text={text} path={path} target={target} amplitudeId={amplitudeId} />
             ))}
-            <AmplitudeEventTrack eventName="click-gnb-logout">
-              <MenuItem key="로그아웃" text="로그아웃" onClick={handleLogout} />
-            </AmplitudeEventTrack>
-            <MenuItem key="로그인완료" text={`${name}님`} className="amp-block" />
           </>
         )}
       </ul>

--- a/src/common/components/Layout/components/Header/Nav/MenuList/index.tsx
+++ b/src/common/components/Layout/components/Header/Nav/MenuList/index.tsx
@@ -1,6 +1,4 @@
 import { useEffect, useState } from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
-
 import { useDeviceType } from 'contexts/DeviceTypeProvider';
 import { useRecruitingInfo } from 'contexts/RecruitingInfoProvider';
 
@@ -10,8 +8,6 @@ import MenuItem from '../MenuItem';
 
 const MenuList = ({ isMenuOpen, onClickMenuToggle }: { isMenuOpen?: boolean; onClickMenuToggle?: () => void }) => {
   const { deviceType } = useDeviceType();
-  const navigate = useNavigate();
-  const { pathname } = useLocation();
   const [isShown, setIsShown] = useState(isMenuOpen);
   const [animation, setAnimation] = useState<'open' | 'close'>(isMenuOpen ? 'open' : 'close');
 

--- a/src/common/components/Layout/components/Header/contants.ts
+++ b/src/common/components/Layout/components/Header/contants.ts
@@ -2,21 +2,29 @@ type menuItemsTypes = {
   text: string;
   path?: string;
   amplitudeId?: string;
-  target?: '_blank';
+  target?: '_blank' | '_self';
 };
 
-export const MENU_ITEMS: menuItemsTypes[] = [
-  {
-    text: '모집공고',
-    path: 'https://www.sopt.org/recruit',
-    amplitudeId: 'click-gnb-recruitment_notice',
-    target: '_blank',
-  },
+export const MENU_ITEMS_SOPT: menuItemsTypes[] = [
   {
     text: '문의하기',
     path: 'mailto:manager@sopt.org',
     amplitudeId: 'click-gnb-ask',
     target: '_blank',
+  },
+];
+
+export const SIGNED_IN_MENU_ITEMS_SOPT: menuItemsTypes[] = [
+  {
+    text: '문의하기',
+    path: 'mailto:manager@sopt.org',
+    amplitudeId: 'click-gnb-ask',
+    target: '_blank',
+  },
+  {
+    text: '마이페이지',
+    path: '/auth',
+    target: '_self',
   },
 ];
 

--- a/src/views/ErrorPage/components/NoMore/index.tsx
+++ b/src/views/ErrorPage/components/NoMore/index.tsx
@@ -2,7 +2,7 @@ import { useDeviceType } from 'contexts/DeviceTypeProvider';
 
 import { article, contactButtonVar, container, errorButtonVar, errorTextVar, instructionVar } from '../../style.css';
 import AmplitudeEventTrack from '@components/Button/AmplitudeEventTrack';
-import { MENU_ITEMS, MENU_ITEMS_MAKERS } from '@components/Layout/components/Header/contants';
+import { MENU_ITEMS_SOPT, MENU_ITEMS_MAKERS } from '@components/Layout/components/Header/contants';
 
 interface NoMoreProps {
   isMakers?: boolean;
@@ -33,7 +33,7 @@ const NoMore = ({ isMakers, content }: NoMoreProps) => {
           href={
             isMakers
               ? MENU_ITEMS_MAKERS.find((item) => item.text === '문의하기')?.path
-              : MENU_ITEMS.find((item) => item.text === '문의하기')?.path
+              : MENU_ITEMS_SOPT.find((item) => item.text === '문의하기')?.path
           }
           target="_blank"
           rel="noreferrer noopener"


### PR DESCRIPTION
## 📋 작업 내용

- [x] 로그인 상태에 따른 GNB 메뉴 항목 분기 처리 구현
- [x] 비로그인 시 로그인 버튼만 노출, 로그인 시 문의하기·마이페이지 메뉴 노출
- [x] `MENU_ITEMS` → `MENU_ITEMS_SOPT` 상수명 변경 및 `SIGNED_IN_MENU_ITEMS_SOPT` 신규 추가
- [x] GNB에서 로그아웃 버튼 및 사용자 이름(`${name}님`) 표시 제거
- [x] 불필요한 의존성 제거 (`useRecruitingInfo`, `useNavigate`, `useLocation`, Amplitude `reset`)
- [x] `NoMore` 에러페이지 컴포넌트의 상수 참조 업데이트

## 📌 PR Point

- 기존에는 `isSignedIn && name` 조건으로 메뉴를 노출했으나, `name`을 별도로 fetch해야 하는 의존성이 생겨 로그인 여부만으로 단순화했습니다.
- 로그인/비로그인 메뉴를 각각 `MENU_ITEMS_SOPT` / `SIGNED_IN_MENU_ITEMS_SOPT` 상수로 분리해 메뉴 구성 변경 시 한 곳에서만 수정하도록 개선했습니다.
- 로그아웃 기능이 GNB에서 제거됩니다. 마이페이지(`/auth`) 내에서 로그아웃을 처리하는 흐름으로 변경된 것인지 확인 부탁드립니다.
- `menuItemsTypes`의 `target`에 `'_self'`를 추가했습니다 (마이페이지는 외부 링크가 아닌 내부 라우팅이므로).

## 📸 스크린샷

| As-is | To-be |
| ----- | ----- |
|       |       |

---

🤖 made by [claude](https://claude.ai)
