### PR TITLE
[Hotfix] QA 반응형 스타일 수정 및 공통/파트별 질문 더미 데이터 추가

### DIFF
--- a/src/common/components/Textarea/components/Label/style.css.ts
+++ b/src/common/components/Textarea/components/Label/style.css.ts
@@ -18,14 +18,14 @@ export const labelStyleVar = styleVariants({
   TAB: [
     labelStyle,
     {
-      width: 367,
+      width: '100%',
       ...theme.font.TITLE_5_18_SB,
     },
   ],
   MOB: [
     labelStyle,
     {
-      width: 312,
+      width: '100%',
       ...theme.font.TITLE_6_16_SB,
     },
   ],

--- a/src/common/components/Textarea/style.css.ts
+++ b/src/common/components/Textarea/style.css.ts
@@ -4,5 +4,4 @@ export const container = style({
   display: 'flex',
   flexDirection: 'column',
   gap: 8,
-  alignItems: 'center',
 });

--- a/src/views/ApplyPage/components/CommonSection/index.tsx
+++ b/src/views/ApplyPage/components/CommonSection/index.tsx
@@ -1,6 +1,7 @@
 import Textarea from '@components/Textarea';
 import { sectionContainerVar, sectionTitle } from 'views/ApplyPage/style.css';
 import { Answers } from 'views/ApplyPage/types';
+import { DUMMY_COMMON_QUESTIONS } from 'views/ApplyPage/dummyQuestions';
 
 import FileInput from '../FileInput';
 import Info from '../Info';
@@ -15,24 +16,25 @@ interface CommonSectionProps {
 
 const CommonSection = ({ refCallback, isReview = false }: CommonSectionProps) => {
   const { draftData } = useGetDraft();
-  const { applicant, commonQuestions } = draftData?.data || {};
+  const { applicant, commonQuestions: savedCommonAnswers } = draftData?.data || {};
 
   const { questionsData } = useGetQuestions(applicant);
-  const { commonQuestions: questions } = questionsData?.data || {};
+  const { commonQuestions } = questionsData?.data || {};
+  const commonQuestionGroup = commonQuestions?.questions.length ? commonQuestions : DUMMY_COMMON_QUESTIONS;
 
-  const commonQuestionsById = commonQuestions?.reduce(
+  const commonQuestionsById = savedCommonAnswers?.reduce(
     (acc, draft) => {
       acc ? (acc[draft.id] = draft) : undefined;
       return acc;
     },
     {} as { [key: number]: Answers } | undefined,
   );
-  const hasDescription = questions?.questions.some(({ isDescription }) => isDescription);
+  const hasDescription = commonQuestionGroup?.questions.some(({ isDescription }) => isDescription);
 
   return (
     <section ref={refCallback} id="common" className={sectionContainerVar}>
       <h2 className={sectionTitle}>공통 질문</h2>
-      {questions?.questions.map(
+      {commonQuestionGroup?.questions.map(
         ({ urls, question, id, charLimit, isFile, placeholder, optional, isDescription }, index) => {
           const draftItem = commonQuestionsById?.[id];
           const defaultValue = draftItem ? draftItem.answer.answer : '';
@@ -50,7 +52,7 @@ const CommonSection = ({ refCallback, isReview = false }: CommonSectionProps) =>
                   placeholder={
                     placeholder ||
                     (isFile
-                      ? '링크로 제출할 경우, 이곳에 작성해주세요. (파일로 제출한 경우에는 ‘파일 제출’이라고 기재 후 제출해주세요.)'
+                      ? '링크로 제출할 경우, 이곳에 작성해주세요. (파일로 제출한 경우에는 "파일 제출"이라고 기재 후 제출해주세요.)'
                       : '')
                   }
                   extraInput={

--- a/src/views/ApplyPage/components/DefaultSection/index.tsx
+++ b/src/views/ApplyPage/components/DefaultSection/index.tsx
@@ -208,10 +208,11 @@ const DefaultSection = ({ refCallback, isReview = false }: DefaultSectionProps) 
             maxLength={VALIDATION_CHECK.textInput.maxLength}
             pattern={VALIDATION_CHECK.textInput.pattern}
             errorText={VALIDATION_CHECK.textInput.errorText}
+            style={{ maxWidth: '356px' }}
             disabled={isReview}
           />
         </TextBox>
-        <div style={{ margin: '52px 0 0 22px' }}>
+        <div style={{ margin: '52px 0 0 30px', width: '100%' }}>
           <Radio
             defaultValue={
               leaveAbsence == undefined

--- a/src/views/ApplyPage/components/PartSection/index.tsx
+++ b/src/views/ApplyPage/components/PartSection/index.tsx
@@ -4,6 +4,7 @@ import SelectBox from '@components/Select';
 import Textarea from '@components/Textarea';
 import { sectionContainerVar, sectionTitle } from 'views/ApplyPage/style.css';
 import { Answers } from 'views/ApplyPage/types';
+import { DUMMY_PART_QUESTIONS } from 'views/ApplyPage/dummyQuestions';
 
 import FileInput from '../FileInput';
 import Info from '../Info';
@@ -20,16 +21,17 @@ const PartSection = ({ refCallback, isReview = false }: PartSectionProps) => {
   const { getValues } = useFormContext();
 
   const { draftData } = useGetDraft();
-  const { applicant, partQuestions } = draftData?.data || {};
+  const { applicant, partQuestions: savedPartAnswers } = draftData?.data || {};
   const { part } = applicant || {};
 
   const { questionsData } = useGetQuestions(applicant);
-  const { partQuestions: questions } = questionsData?.data || {};
+  const { partQuestions } = questionsData?.data || {};
+  const partQuestionGroups = partQuestions?.length ? partQuestions : DUMMY_PART_QUESTIONS;
 
-  const partOptions = questions ? questions.map((q) => q.part) : [];
+  const partOptions = partQuestionGroups.map((q) => q.part);
   const selectedPart: string = getValues('part');
-  const filteredQuestions = questions?.find((item) => item.part === selectedPart)?.questions;
-  const partQuestionsById = partQuestions?.reduce(
+  const filteredQuestions = partQuestionGroups.find((item) => item.part === selectedPart)?.questions;
+  const partQuestionsById = savedPartAnswers?.reduce(
     (acc, draft) => {
       acc ? (acc[draft.id] = draft) : undefined;
       return acc;

--- a/src/views/ApplyPage/dummyQuestions.ts
+++ b/src/views/ApplyPage/dummyQuestions.ts
@@ -1,0 +1,70 @@
+import { QuestionResponse } from './types';
+
+const q = (
+  id: number,
+  order: number,
+  question: string,
+  charLimit: number,
+  extra?: Partial<QuestionResponse>,
+): QuestionResponse => ({
+  id,
+  order,
+  question,
+  charLimit,
+  urls: [],
+  ...extra,
+});
+
+export const DUMMY_COMMON_QUESTIONS = {
+  part: 'COMMON',
+  questions: [
+    q(101, 1, 'SOPT에 지원하게 된 동기를 작성해주세요.', 500, { placeholder: '지원 동기를 자유롭게 작성해주세요.' }),
+    q(102, 2, '본인의 강점과 약점을 작성해주세요.', 400),
+    q(103, 3, '팀 프로젝트 경험 중 가장 기억에 남는 것과 본인의 역할을 작성해주세요.', 500),
+  ],
+};
+
+export const DUMMY_PART_QUESTIONS = [
+  {
+    part: '기획',
+    questions: [
+      q(201, 1, '기획자로서 본인이 생각하는 좋은 서비스란 무엇인가요?', 600),
+      q(202, 2, '최근에 인상 깊게 사용한 서비스와 그 이유를 작성해주세요.', 500),
+    ],
+  },
+  {
+    part: '디자인',
+    questions: [
+      q(301, 1, '본인의 디자인 포트폴리오 링크 또는 파일을 제출해주세요.', 300, { isFile: true }),
+      q(302, 2, '디자이너로서 가장 중요하게 생각하는 가치는 무엇인가요?', 500),
+    ],
+  },
+  {
+    part: '웹',
+    questions: [
+      q(401, 1, '본인이 사용해본 프론트엔드 기술 스택과 경험을 작성해주세요.', 500),
+      q(402, 2, '협업 경험에서 어려웠던 점과 해결 방법을 작성해주세요.', 500),
+    ],
+  },
+  {
+    part: '서버',
+    questions: [
+      q(501, 1, '백엔드 개발 경험과 주로 사용하는 기술 스택을 작성해주세요.', 500),
+      q(502, 2, '본인이 설계한 API 또는 데이터베이스 구조를 예시와 함께 설명해주세요.', 600),
+    ],
+  },
+  {
+    part: 'iOS',
+    questions: [
+      q(601, 1, 'iOS 개발 경험과 사용해본 프레임워크를 작성해주세요.', 500),
+      q(602, 2, 'Swift와 Objective-C 중 선호하는 언어와 그 이유를 작성해주세요.', 400),
+    ],
+  },
+  {
+    part: 'Android',
+    questions: [
+      q(701, 1, 'Android 개발 경험과 사용해본 라이브러리를 작성해주세요.', 500),
+      q(702, 2, 'Jetpack Compose 또는 XML 방식 중 선호하는 방식과 그 이유를 작성해주세요.', 400),
+    ],
+  },
+];

--- a/src/views/dialogs/SubmitDialog/index.tsx
+++ b/src/views/dialogs/SubmitDialog/index.tsx
@@ -83,7 +83,7 @@ const SubmitDialog = forwardRef<HTMLDialogElement, SubmitDialogProps>(
             className={`${dataIsPending ? buttonOutside.disabled : buttonOutside.line} ${buttonOutsideVar[deviceType]}`}
             onSubmit={() => setIsChecked(false)}>
             <AmplitudeEventTrack eventName="click-apply-cancel">
-              <button className={buttonInside.line} style={{ color: '#FFFFFF' }} disabled={dataIsPending}>
+              <button className={buttonInside.line} disabled={dataIsPending}>
                 {dataIsPending ? <ButtonLoading width={48} height={18} /> : '검토하기'}
               </button>
             </AmplitudeEventTrack>


### PR DESCRIPTION
## 📋 작업 내용

- [x] 공통/파트별 질문 더미 데이터 추가 (`dummyQuestions.ts`) — API 응답 없을 때 fallback
- [x] Textarea 라벨 너비 고정값(`367px`, `312px`) → `100%` 반응형으로 변경
- [x] Textarea container `alignItems: center` 제거
- [x] DefaultSection 스타일 수정 (nearestStation 입력 maxWidth, Radio margin)
- [x] SubmitDialog 버튼 인라인 컬러(`#FFFFFF`) 제거

## 📌 PR Point

- 질문 API 응답이 비어있을 경우 더미 데이터로 fallback 처리 — dev 배포 환경에서 파트 선택 및 질문 렌더링 확인 가능하도록
- Textarea 라벨 너비가 고정값이라 태블릿/모바일에서 레이아웃이 깨지던 문제 수정
- 더미 데이터는 `dummyQuestions.ts`로 분리해 CommonSection/PartSection에서 공유

---

🤖 made by [claude](https://claude.ai)