### PR TITLE
[Feat] 지원서 페이지 이탈 시 ExitDialog 연결

### DIFF
--- a/src/views/ApplyPage/index.tsx
+++ b/src/views/ApplyPage/index.tsx
@@ -1,7 +1,7 @@
 import { track } from '@amplitude/analytics-browser';
 import { lazy, useCallback, useEffect, useRef, useState } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
-import { useNavigate } from 'react-router-dom';
+import { useBlocker, useNavigate } from 'react-router-dom';
 
 import Button from '@components/Button';
 import Footer from '@components/Layout/components/Footer';
@@ -29,6 +29,7 @@ import BigLoading from 'views/loadings/BigLoding';
 import type { ApplyRequest } from './types';
 
 const DraftDialog = lazy(() => import('views/dialogs').then(({ DraftDialog }) => ({ default: DraftDialog })));
+const ExitDialog = lazy(() => import('views/dialogs').then(({ ExitDialog }) => ({ default: ExitDialog })));
 const PreventApplyDialog = lazy(() =>
   import('views/dialogs').then(({ PreventApplyDialog }) => ({ default: PreventApplyDialog })),
 );
@@ -44,12 +45,21 @@ const ApplyPage = ({ onSetComplete }: ApplyPageProps) => {
 
   // 2. 모달 관련 ref
   const { ref: draftDialogRef, handleShowDialog: handleShowDraftDialog } = useDialog();
+  const { ref: exitDialogRef, handleShowDialog: handleShowExitDialog } = useDialog();
   const { ref: preventApplyDialogRef, handleShowDialog: handleShowPreventApplyDialog } = useDialog();
   const {
     ref: submitDialogRef,
     handleShowDialog: handleShowSubmitDialog,
     handleCloseDialog: handleCloseSubmitDialog,
   } = useDialog();
+
+  const blocker = useBlocker(({ currentLocation, nextLocation }) => currentLocation.pathname !== nextLocation.pathname);
+
+  useEffect(() => {
+    if (blocker.state === 'blocked') {
+      handleShowExitDialog();
+    }
+  }, [blocker.state]);
 
   // 3. category active 상태 관리
   useScrollToHash(); // scrollTo 카테고리
@@ -288,6 +298,11 @@ const ApplyPage = ({ onSetComplete }: ApplyPageProps) => {
   return (
     <>
       <DraftDialog ref={draftDialogRef} />
+      <ExitDialog
+        ref={exitDialogRef}
+        onExit={() => blocker.proceed?.()}
+        onCancel={() => blocker.reset?.()}
+      />
       <PreventApplyDialog ref={preventApplyDialogRef} />
       <SubmitDialog
         userInfo={{

--- a/src/views/dialogs/ExitDialog/index.tsx
+++ b/src/views/dialogs/ExitDialog/index.tsx
@@ -5,20 +5,25 @@ import { useDeviceType } from 'contexts/DeviceTypeProvider';
 
 import { buttonInside, buttonOutside, buttonOutsideVar, buttonWrapperVar, mainTextVar, subTextVar } from '../style.css';
 
-const ExitDialog = forwardRef<HTMLDialogElement>((_, ref) => {
+interface ExitDialogProps {
+  onExit: () => void;
+  onCancel?: () => void;
+}
+
+const ExitDialog = forwardRef<HTMLDialogElement, ExitDialogProps>(({ onExit, onCancel }, ref) => {
   const { deviceType } = useDeviceType();
 
   return (
     <Dialog ref={ref}>
-      <p className={mainTextVar[deviceType]}>이대로 나가시겠어요?</p>
+      <p className={mainTextVar[deviceType]}>페이지에서 나가시겠어요?</p>
       <p className={subTextVar[deviceType]}>저장하지 않은 변경사항은 사라져요.</p>
       <div className={buttonWrapperVar[deviceType]}>
         <form method="dialog" className={`${buttonOutside.line} ${buttonOutsideVar[deviceType]}`}>
-          <button className={buttonInside.line}>돌아가기</button>
+          <button className={buttonInside.line} onClick={onCancel}>돌아가기</button>
         </form>
-        <div className={`${buttonOutside.solid} ${buttonOutsideVar[deviceType]}`}>
-          <button className={buttonInside.solid}>나가기</button>
-        </div>
+        <form method="dialog" className={`${buttonOutside.solid} ${buttonOutsideVar[deviceType]}`}>
+          <button className={buttonInside.solid} onClick={onExit}>나가기</button>
+        </form>
       </div>
     </Dialog>
   );


### PR DESCRIPTION
## 📋 작업 내용

- [x] `ExitDialog`에 `onExit` / `onCancel` props 추가 및 나가기 버튼을 `<form method="dialog">`로 변경
- [x] `ApplyPage`에 `ExitDialog` lazy import 및 렌더링 연결
- [x] `useBlocker`로 React Router 내 페이지 이탈 감지
- [x] 뒤로가기 / 다른 페이지 이동 시 `ExitDialog` 노출, 나가기/돌아가기에 따라 내비게이션 진행 또는 취소

## 📌 PR Point

- 기존 `useBeforeExitPageAlert`는 브라우저 탭 닫기·새로고침만 막았고, React Router 내 이탈(뒤로가기, 링크 이동)은 처리하지 않았음 → `useBlocker`로 분리 처리
- `useBlocker`는 pathname이 바뀌는 이동만 차단하여 해시(#) 이동 등 페이지 내 스크롤 이동에는 다이얼로그가 뜨지 않음
- 기존 ExitDialog의 "나가기" 버튼이 `<div>`로 감싸져 있어 dialog를 닫는 동작이 없었음 → `<form method="dialog">`로 수정
- 나가기: `blocker.proceed()` → 내비게이션 진행 / 돌아가기: `blocker.reset()` → 차단 해제 후 페이지 유지


---

🤖 made by [claude](https://claude.ai)
