### PR TITLE
[Style] 아이콘 사이즈 수정

### DIFF
--- a/src/views/IntroducePage/components/SoptPart/style.css.ts
+++ b/src/views/IntroducePage/components/SoptPart/style.css.ts
@@ -137,10 +137,6 @@ export const hoverIcon = style({
       width: '24px',
       height: '24px',
     },
-    [breakpoints.desktopLarge]: {
-      width: '380px',
-      height: '284px',
-    },
   },
 });
 


### PR DESCRIPTION
**Related Issue :** Closes  #583 

---

## 🧑‍🎤 Summary
- [x] desktop large 일 때 아이콘 스타일 수정



<img width="368" height="257" alt="스크린샷 2026-05-13 오후 11 03 17" src="https://github.com/user-attachments/assets/e4d6b3b4-9c31-495a-aae8-6e60e77bcc00" />
