### PR TITLE
[Fix] QA 수정 - Windows 아이콘 위치 깨짐, 날짜 포맷, 버튼 텍스트 개선

### DIFF
--- a/src/styles/reset.css.ts
+++ b/src/styles/reset.css.ts
@@ -23,6 +23,11 @@ globalStyle('html', {
   MozTextSizeAdjust: 'none',
   WebkitTextSizeAdjust: 'none',
   textSizeAdjust: 'none',
+  scrollbarWidth: 'none',
+});
+
+globalStyle('html::-webkit-scrollbar', {
+  display: 'none',
 });
 
 globalStyle('body', {

--- a/src/views/ApplyPage/components/FileInput/index.tsx
+++ b/src/views/ApplyPage/components/FileInput/index.tsx
@@ -48,7 +48,7 @@ const FileInput = ({ section, id, isReview, disabled, defaultFile }: FileInputPr
     getValues,
     formState: { errors },
   } = useFormContext();
-  
+
   const fileAnswer = getValues(`${section}${id}`);
   const isFileDeleted = getValues(`file${id}Deleted`);
   const fileValue = getValues(`file${id}`);
@@ -176,13 +176,10 @@ const FileInput = ({ section, id, isReview, disabled, defaultFile }: FileInputPr
       </AmplitudeEventTrack>
       <label
         htmlFor={`file-${id}`}
-        className={`${fileLabelVar[errors[`file${id}`] ? 'error' : fileName === '' ? 'default' : 'selected']} ${fileLabelSizeVar}`}
-      >
+        className={`${fileLabelVar[errors[`file${id}`] ? 'error' : fileName === '' ? 'default' : 'selected']} ${fileLabelSizeVar}`}>
         <div className={textWrapperVar}>
           <span>참고 자료</span>
-          <span className={`${fileNameVar[getFileNameClass()]} ${fileNameSizeVar}`}>
-            {getDisplayText()}
-          </span>
+          <span className={`${fileNameVar[getFileNameClass()]} ${fileNameSizeVar}`}>{getDisplayText()}</span>
         </div>
         <IconPlusButton
           isSelected={fileName !== 'delete-file' && fileValue}

--- a/src/views/ApplyPage/components/FileInput/style.css.ts
+++ b/src/views/ApplyPage/components/FileInput/style.css.ts
@@ -79,7 +79,8 @@ export const fileLabelVar = styleVariants({
 const textWrapper = style({
   display: 'flex',
   alignItems: 'center',
-  width: '100%',
+  flex: 1,
+  minWidth: 0,
 
   color: theme.color.lighterText,
 });
@@ -158,6 +159,7 @@ export const fileIcon = style({
   display: 'flex',
   justifyContent: 'center',
   alignItems: 'center',
+  flexShrink: 0,
   width: '27px',
   height: '27px',
   backgroundColor: theme.color.fileUploadButton,

--- a/src/views/PartDetailPage/components/Schedule/index.tsx
+++ b/src/views/PartDetailPage/components/Schedule/index.tsx
@@ -16,11 +16,12 @@ const Schedule = () => {
 export default Schedule;
 
 const ScheduleBox = () => {
-  const { group, applicationStart, applicationEnd, interviewStart, interviewEnd, finalResultStart } = useRecruitingSchedule();
+  const { group, applicationStart, applicationEnd, interviewStart, interviewEnd, finalResultStart } =
+    useRecruitingSchedule();
 
-  const formattedApplicationStart = applicationStart ? format(applicationStart, 'M월 dd일 aaa hh시') : '';
+  const formattedApplicationStart = applicationStart ? format(applicationStart, 'M월 dd일') : '';
   const formattedApplicationStartHour = applicationStart ? format(applicationStart, 'aaa hh시') : '';
-  const formattedApplicationEnd = applicationEnd ? format(applicationEnd, 'M월 dd일 aaa hh시') : '';
+  const formattedApplicationEnd = applicationEnd ? format(applicationEnd, 'M월 dd일') : '';
   const formattedApplicationEndHour = applicationEnd ? format(applicationEnd, 'aaa hh시') : '';
   const formattedInterviewStart = interviewStart ? format(interviewStart, 'M월 dd일') : '';
   const formattedInterviewEnd = interviewEnd ? format(interviewEnd, 'M월 dd일') : '';

--- a/src/views/SignupPage/components/SignupForm/index.tsx
+++ b/src/views/SignupPage/components/SignupForm/index.tsx
@@ -33,7 +33,7 @@ const SignupForm = () => {
   const handleSubmitSignUp = ({ email, password, passwordCheck, name, phone }: FieldValues) => {
     if (!season || !group) {
       return;
-    };
+    }
 
     signUpMutate({
       email,
@@ -76,7 +76,7 @@ const SignupForm = () => {
             <Contentbox>{PRIVACY_POLICY}</Contentbox>
           </div>
           <Button isLoading={signUpIsPending} type="submit" style={{ marginTop: 30 }} eventName="click-signup-apply">
-            지원서 작성하기
+            가입완료
           </Button>
         </form>
       </FormProvider>


### PR DESCRIPTION
## 📋 작업 내용

- [x] Windows 환경에서 파일 업로드 버튼(IconPlusButton)이 좌측 하단으로 밀리는 레이아웃 버그 수정
- [x] 전역 스크롤바 숨김 처리 (모든 페이지 우측 스크롤바 제거)
- [x] 지원 일정 날짜 포맷 수정 (날짜/시간 분리 포맷 통일)
- [x] 회원가입 버튼 텍스트 수정 ("지원서 작성하기" → "가입완료")

## 📌 PR Point

- **아이콘 위치 버그**: `textWrapper`에 `width: '100%'`를 설정하면, flex 컨테이너(label) 안에서 Mac(WebKit)과 달리 Windows의 Chromium/Edge가 너비를 더 엄격하게 계산해 버튼이 줄 바꿈됩니다. `flex: 1` + `minWidth: 0`으로 변경하고, `fileIcon`에 `flexShrink: 0`을 추가해 버튼이 고정 크기를 유지하도록 수정했습니다.
- **스크롤바 숨김**: `wrapper` div가 아닌 `html` 요소가 실제 스크롤 컨테이너이므로 `reset.css.ts`에 전역으로 `scrollbarWidth: none` 및 `::-webkit-scrollbar` 처리를 추가했습니다.
- **날짜 포맷**: `M월 dd일 aaa hh시` 포맷에서 날짜와 시간을 분리해 기존 `formattedApplicationStartHour` 변수와 포맷을 통일했습니다.
- 리뷰어가 집중해야 할 부분: flex 레이아웃 변경이 다른 뷰포트/브라우저에서 기존 UI에 영향을 주지 않는지 확인

---

🤖 made by [claude](https://claude.ai)
