### PR TITLE
[Fix] Dialog 브랜딩 컬러 동기화 및 스케줄 라벨 줄바꿈 수정

### DIFF
--- a/src/common/components/Dialog/index.tsx
+++ b/src/common/components/Dialog/index.tsx
@@ -1,7 +1,6 @@
 import { forwardRef, type DialogHTMLAttributes, type ReactNode } from 'react';
 import { createPortal } from 'react-dom';
 import { useDeviceType } from 'contexts/DeviceTypeProvider';
-import { light } from 'styles/theme.css';
 import { containerVar } from './style.css';
 
 interface DialogProps extends DialogHTMLAttributes<HTMLDialogElement> {
@@ -12,11 +11,9 @@ const Dialog = forwardRef<HTMLDialogElement, DialogProps>(({ children, ...dialog
   const { deviceType } = useDeviceType();
 
   return createPortal(
-    <div className={light}>
-      <dialog ref={ref} className={containerVar[deviceType]} {...dialogElementProps}>
-        {children}
-      </dialog>
-    </div>,
+    <dialog ref={ref} className={containerVar[deviceType]} {...dialogElementProps}>
+      {children}
+    </dialog>,
     document.getElementById('modal')!,
   );
 });

--- a/src/styles/BrandingThemeLayout.tsx
+++ b/src/styles/BrandingThemeLayout.tsx
@@ -1,23 +1,46 @@
 import { assignInlineVars } from '@vanilla-extract/dynamic';
-import { type ReactNode } from 'react';
+import { type ReactNode, useLayoutEffect } from 'react';
 
 import { normalizeHexColor, toBlendedHexColor } from '@utils/color';
 import { useTheme } from 'contexts/ThemeProvider';
 import { dark, light, theme } from 'styles/theme.css';
 import useRecruitInfo from 'views/IntroducePage/hooks/useRecruitInfo';
-import type { RecruitInfoResponse } from 'views/IntroducePage/types';
-
-type SoptBrandingColor = RecruitInfoResponse['brandingColor'];
-
-// 지원자용 리크루팅 사이트는 항상 라이트 모드 브랜드 컬러를 사용 (공식 홈페이지 레포는 반대로 dark 고정)
-const BRAND_COLOR_MODE: 'light' | 'dark' = 'light';
 
 const BrandingThemeLayout = ({ children }: { children: ReactNode }) => {
   const { isLight } = useTheme();
   const { data } = useRecruitInfo();
 
-  // SOPT 기수 컬러
-  const brandingColor = data?.brandingColor ? toThemeStyle(data.brandingColor) : undefined;
+  // 지원자용 리크루팅 사이트는 항상 라이트 모드 키컬러를 사용
+  const lightModeKeyColor = data?.brandingColor?.lightModeKeyColor;
+  const brandingColor = lightModeKeyColor ? toThemeStyle(lightModeKeyColor) : undefined;
+
+  // portal이라 브랜딩 CSS 변수만 #modal에 동기화
+  useLayoutEffect(() => {
+    const modalRoot = document.getElementById('modal');
+
+    if (!modalRoot) return;
+    modalRoot.classList.add(light);
+
+    const brandingStyle = lightModeKeyColor ? toThemeStyle(lightModeKeyColor) : undefined;
+
+    if (brandingStyle) {
+      for (const [key, value] of Object.entries(brandingStyle)) {
+        if (value != null) {
+          modalRoot.style.setProperty(key, String(value));
+        }
+      }
+    }
+
+    return () => {
+      modalRoot.classList.remove(light);
+
+      if (brandingStyle) {
+        for (const key of Object.keys(brandingStyle)) {
+          modalRoot.style.removeProperty(key);
+        }
+      }
+    };
+  }, [lightModeKeyColor]);
 
   return (
     <div className={isLight ? light : dark} style={brandingColor}>
@@ -28,12 +51,12 @@ const BrandingThemeLayout = ({ children }: { children: ReactNode }) => {
 
 export default BrandingThemeLayout;
 
-const toThemeStyle = (color: SoptBrandingColor) => {
-  const main = normalizeHexColor(BRAND_COLOR_MODE === 'light' ? color.lightModeKeyColor : color.darkModeKeyColor);
+const toThemeStyle = (keyColor: string) => {
+  const main = normalizeHexColor(keyColor);
 
   return assignInlineVars({
     [theme.color.primary]: main,
-    [theme.color.primaryDark]: toBlendedHexColor(main, 255, 0.2), // 고명도 (hover) = 키컬러 + 흰 20%
-    [theme.color.primaryLight]: toBlendedHexColor(main, 0, 0.1), // 저명도 (active/press) = 키컬러 + 검 10%
+    [theme.color.primaryDark]: toBlendedHexColor(main, 255, 0.2),
+    [theme.color.primaryLight]: toBlendedHexColor(main, 0, 0.1),
   });
 };

--- a/src/views/IntroducePage/components/Schedule/style.css.ts
+++ b/src/views/IntroducePage/components/Schedule/style.css.ts
@@ -71,6 +71,7 @@ export const scheduleGroup = style({
 });
 
 export const oddText = style({
+  whiteSpace: 'nowrap',
   color: colors.gray950,
   ...theme.font.HEADING_4_24_B,
   '@media': {

--- a/src/views/PartDetailPage/components/Schedule/style.css.ts
+++ b/src/views/PartDetailPage/components/Schedule/style.css.ts
@@ -71,6 +71,7 @@ export const scheduleGroup = style({
 });
 
 export const oddText = style({
+  whiteSpace: 'nowrap',
   color: colors.gray950,
   ...theme.font.HEADING_4_24_B,
   '@media': {

--- a/src/views/dialogs/SubmitDialog/style.css.ts
+++ b/src/views/dialogs/SubmitDialog/style.css.ts
@@ -179,17 +179,13 @@ export const checkmark = style({
 
     /* 체크되었을 때 배경색 */
     [`${checkboxWrapper} input:checked ~ &`]: {
-      // border: `1px solid ${colors.gray600}`,
-      // backgroundColor: colors.gray600,
-      border: `1px solid #84E1FA`,
-      backgroundColor: '#84E1FA',
+      border: `1px solid ${theme.color.primary}`,
+      backgroundColor: theme.color.primary,
     },
 
     [`${checkboxWrapper} input:checked:hover ~ &`]: {
-      // border: `1px solid ${colors.gray950}`,
-      // backgroundColor: colors.gray950,
-        border: `1px solid #153858`,
-        backgroundColor: '#153858',
+      border: `1px solid ${theme.color.primaryDark}`,
+      backgroundColor: theme.color.primaryDark,
     },
 
     /* 체크되면 체크마크 보이게 하기 */
@@ -212,8 +208,7 @@ export const checkmark = style({
 
     /* focus-visible 속성 */
     [`${checkboxWrapper} input:focus-visible ~ &`]: {
-      // outline: `2px dotted ${colors.gray600}`,
-      outline: `2px dotted #84E1FA`,
+      outline: `2px dotted ${theme.color.primary}`,
       outlineOffset: 2,
     },
   },


### PR DESCRIPTION
- closed #590

## 🧑‍🎤 Summary

- [x] Dialog portal(`#modal`)에 기수 브랜딩 컬러 CSS 변수를 동기화해 모달에서도 primary 토큰이 적용되도록 수정
- [x] SubmitDialog 체크박스에 하드코딩된 기수 컬러(`#84E1FA` 등)를 `theme.color.primary` / `primaryDark` 변수로 교체
- [x] 소개/파트 상세 스케줄 라벨(`oddText`)에 `whiteSpace: nowrap` 적용해 줄바꿈 방지

## 📌 PR Point

- Dialog는 `#modal`로 portal 되므로 본문 `BrandingThemeLayout`의 CSS 변수를 상속받지 않음 → `#modal`에 `light` 테마 + 브랜딩 변수를 직접 동기화
- 다이얼로그 UI는 light 하드코딩 팔레트 기준이라 `#modal` 테마는 light 고정 (본문 결과 페이지 dark와 별개)
- 키컬러는 `lightModeKeyColor`만 사용 (변경될 수 있지만 우선 통일)


