### PR TITLE
[Feat] 회원가입 페이지 이메일 인증 플로우 복원

### DIFF
--- a/src/common/components/Input/components/InputTheme/index.tsx
+++ b/src/common/components/Input/components/InputTheme/index.tsx
@@ -1,9 +1,14 @@
-import { useEffect } from 'react';
+import { track } from '@amplitude/analytics-browser';
+import { useCallback, useEffect, useState } from 'react';
 import { useFormContext } from 'react-hook-form';
-import { useLocation } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 
-import { TextBox } from '@components/Input';
+import { InputButton, TextBox, Timer } from '@components/Input';
+import useMutateCheckCode from '@components/Input/hooks/useMutateCheckCode';
+import useMutateCheckUser from '@components/Input/hooks/useMutateCheckUser';
+import useMutateSendCode from '@components/Input/hooks/useMutateSendCode';
 import { VALIDATION_CHECK } from '@constants/validationCheck';
+import useScrollToHash from '@hooks/useScrollToHash';
 import { useDeviceType } from 'contexts/DeviceTypeProvider';
 
 import { successVar } from './style.css';
@@ -24,37 +29,165 @@ export const TextBox이름 = () => {
   );
 };
 
-export const TextBox이메일 = () => {
-  const { watch, trigger } = useFormContext();
-  const { deviceType } = useDeviceType();
+interface TextBox이메일Props {
+  recruitingInfo: { season?: number; group?: string };
+  isVerified: boolean;
+  onChangeVerification: (bool: boolean) => void;
+}
 
-  const email = watch('email');
-  const emailConfirm = watch('emailCheck');
+export const TextBox이메일 = ({
+  recruitingInfo: { season, group },
+  isVerified,
+  onChangeVerification,
+}: TextBox이메일Props) => {
+  const [isActive, setIsActive] = useState(false); // Timer용 state
+
+  const { deviceType } = useDeviceType();
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  const {
+    clearErrors,
+    getValues,
+    setError,
+    setValue,
+    watch,
+    formState: { errors },
+  } = useFormContext();
+  const { email } = getValues(); // TODO: 비밀번호 재설정 활성화 시 name 함께 사용
+
+  const code = watch('code');
+  const watchedEmail = watch('email');
+
+  const inputWidth = deviceType === 'DESK' ? 308 : deviceType === 'TAB' ? 246 : 208;
+
+  useScrollToHash('auto');
+
+  const { sendVerificationCodeMutate, sendVerificationCodeIsPending } = useMutateSendCode({
+    onChangeVerification,
+    onSetTimer: () => setIsActive(true),
+  });
+
+  // TODO: 비밀번호 재설정 활성화 시 checkUserMutate 함께 사용
+  const { checkUserIsPending } = useMutateCheckUser({
+    onSendCode: () => {
+      if (!season || !group) return;
+      sendVerificationCodeMutate({ email, season, group, isSignup: false });
+    },
+  });
+
+  const { checkVerificationCodeMutate, checkVerificationCodeIsPending } = useMutateCheckCode({
+    onSuccess: () => {
+      onChangeVerification(true);
+      setIsActive(false);
+      clearErrors('email');
+    },
+  });
+
+  const handleResetTimer = useCallback(() => {
+    setIsActive(false);
+  }, []);
+
+  const handleSendingEmail = () => {
+    let isDone = true;
+
+    // 이메일 유효성 검사
+    if (!email) {
+      setError('email', { type: 'required', message: '필수 입력 항목이에요.' });
+      isDone = false;
+    }
+
+    // TODO: 비밀번호 재설정 기능 미사용으로 임시 주석 처리 (재개 시 원복)
+    // if (location.pathname === '/password') {
+    //   // 이름 유효성 검사
+    //   if (!name) {
+    //     setError('name', { type: 'required', message: '필수 입력 항목이에요.' });
+    //     isDone = false;
+    //   }
+    //
+    //   // 존재 하는 계정인지 검사
+    //   const nameError = errors.name && errors.name?.message !== VALIDATION_CHECK.name.errorTextNonexistence;
+    //   const emailError = errors.email && errors.email.message !== VALIDATION_CHECK.name.errorTextNonexistence;
+    //
+    //   if (nameError || emailError) isDone = false;
+    //
+    //   // 오류가 없을 때 이메일 확인 요청
+    //   if (!emailError && isDone) {
+    //     track('click-password-email');
+    //     checkUserMutate({ email, name, season, group });
+    //     setValue('code', '');
+    //     clearErrors('email');
+    //   }
+    //   return;
+    // }
+
+    if (location.pathname === '/sign-up' && !errors.email && isDone) {
+      if (!season || !group) return;
+      track('click-signup-email');
+      setValue('code', '');
+      clearErrors('email');
+      sendVerificationCodeMutate({ email, season, group, isSignup: true });
+    }
+  };
+
+  const handleVerificationCodeCheck = () => {
+    checkVerificationCodeMutate({ email, code });
+  };
 
   useEffect(() => {
-    if (emailConfirm != undefined && emailConfirm !== '') trigger('emailCheck');
-  }, [email, emailConfirm, trigger]);
+    onChangeVerification(false);
+    setValue('code', '');
+    setIsActive(false);
+  }, [watchedEmail]);
+
+  useEffect(() => {
+    if (errors.code) navigate('#verification-code');
+  }, [errors.code, navigate]);
 
   return (
     <TextBox label="이메일" name="email" required>
       <InputLine
+        style={{
+          width: inputWidth,
+          paddingRight: isActive ? 50 : 16,
+        }}
         name="email"
         placeholder="이메일을 입력해주세요."
         type="email"
         pattern={VALIDATION_CHECK.email.pattern}
         maxLength={VALIDATION_CHECK.email.maxLength}
-        errorText={VALIDATION_CHECK.email.errorText}
-      />
+        errorText={VALIDATION_CHECK.email.errorText}>
+        <InputButton
+          isLoading={checkUserIsPending || sendVerificationCodeIsPending}
+          text="이메일 인증"
+          onClick={handleSendingEmail}
+          disabled={isActive}
+        />
+        <Timer isActive={isActive} onResetTimer={handleResetTimer} />
+      </InputLine>
       <InputLine
-        name="emailCheck"
-        placeholder="이메일을 다시 입력해주세요."
-        type="email"
-        pattern={VALIDATION_CHECK.email.pattern}
-        maxLength={VALIDATION_CHECK.email.maxLength}
-        errorText={VALIDATION_CHECK.emailConfirm.errorText}
-        validate={VALIDATION_CHECK.emailConfirm.validate(watch, 'email')}
-      />
-      {emailConfirm && email === emailConfirm && <p className={successVar[deviceType]}>이메일이 일치해요.</p>}
+        style={{ width: inputWidth }}
+        id="verification-code"
+        readOnly={!isActive}
+        name="code"
+        placeholder="이메일 인증 번호를 작성해주세요."
+        maxLength={VALIDATION_CHECK.verificationCode.maxLength}>
+        <InputButton
+          disabled={!isActive}
+          isLoading={checkVerificationCodeIsPending}
+          text="확인"
+          onClick={handleVerificationCodeCheck}
+        />
+      </InputLine>
+      {isActive && (
+        <>
+          <p className={successVar[deviceType]}>이메일이 전송되었어요. 약 1분 정도 소요될 수 있어요.</p>
+          <p className={successVar[deviceType]} style={{ marginTop: '-8px' }}>
+            메일이 오지 않는다면 스팸 메일함을 확인해주세요.
+          </p>
+        </>
+      )}
+      {isVerified && <p className={successVar[deviceType]}>인증에 성공했어요.</p>}
     </TextBox>
   );
 };

--- a/src/views/PasswordPage/components/PasswordForm/index.tsx
+++ b/src/views/PasswordPage/components/PasswordForm/index.tsx
@@ -2,7 +2,7 @@ import { lazy } from 'react';
 import { FormProvider, useForm, type FieldValues } from 'react-hook-form';
 
 import Button from '@components/Button';
-import { TextBox비밀번호, TextBox이름, TextBox이메일 } from '@components/Input/components/InputTheme';
+import { TextBox비밀번호, TextBox이름 } from '@components/Input/components/InputTheme';
 import { useRecruitingInfo } from 'contexts/RecruitingInfoProvider';
 import useMutateChangePassword from 'views/PasswordPage/hooks/useMutateChangePassword';
 
@@ -51,7 +51,8 @@ const PasswordForm = () => {
           onSubmit={handleSubmit(handleChangePassword)}
           className={formWrapper}>
           <TextBox이름 />
-          <TextBox이메일 />
+          {/* TODO: 비밀번호 재설정 페이지 활성화 시 TextBox이메일 함께 사용 */}
+          {/* <TextBox이메일 /> */}
           <TextBox비밀번호 />
           <Button
             isLoading={changePasswordIsPending}

--- a/src/views/SignupPage/components/SignupForm/index.tsx
+++ b/src/views/SignupPage/components/SignupForm/index.tsx
@@ -1,4 +1,4 @@
-import { lazy } from 'react';
+import { lazy, useEffect } from 'react';
 import { type FieldValues, FormProvider, useForm } from 'react-hook-form';
 
 import Button from '@components/Button';
@@ -8,6 +8,7 @@ import { InputLine, TextBox } from '@components/Input';
 import { TextBox비밀번호, TextBox이름, TextBox이메일 } from '@components/Input/components/InputTheme';
 import { PRIVACY_POLICY } from '@constants/policy';
 import { VALIDATION_CHECK } from '@constants/validationCheck';
+import useVerificationStatus from '@hooks/useVerificationStatus';
 import { useRecruitingInfo } from 'contexts/RecruitingInfoProvider';
 import useMutateSignUp from 'views/SignupPage/hooks/useMutateSignUp';
 
@@ -24,13 +25,28 @@ const SignupForm = () => {
   } = useRecruitingInfo();
   const { ref: existingApplicantDialogRef, handleShowDialog: handleShowExistingApplicantDialog } = useDialog();
 
+  const { isVerified, handleVerified } = useVerificationStatus();
   const methods = useForm({ mode: 'onBlur' });
-  const { handleSubmit } = methods;
+  const {
+    handleSubmit,
+    setError,
+    setFocus,
+    formState: { errors },
+  } = methods;
   const { signUpMutate, signUpIsPending } = useMutateSignUp({
     onCheckExistence: () => handleShowExistingApplicantDialog(),
   });
 
   const handleSubmitSignUp = ({ email, password, passwordCheck, name, phone }: FieldValues) => {
+    if (!isVerified) {
+      setError('code', {
+        type: 'not-match',
+        message: VALIDATION_CHECK.verificationCode.errorText,
+      });
+
+      return;
+    }
+
     if (!season || !group) {
       return;
     }
@@ -45,6 +61,13 @@ const SignupForm = () => {
       group,
     });
   };
+
+  useEffect(() => {
+    if (errors.email?.message === VALIDATION_CHECK.email.errorTextExistence) {
+      setFocus('email');
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [errors.email?.message, setFocus]);
 
   return (
     <>
@@ -67,7 +90,11 @@ const SignupForm = () => {
               errorText={VALIDATION_CHECK.phoneNumber.errorText}
             />
           </TextBox>
-          <TextBox이메일 />
+          <TextBox이메일
+            recruitingInfo={{ season, group }}
+            isVerified={isVerified}
+            onChangeVerification={handleVerified}
+          />
           <TextBox비밀번호 />
           <div>
             <Checkbox required name="personalInformation">


### PR DESCRIPTION
**Related Issue :** Closes  #596 

---

## 🧑‍🎤 Summary
- TextBox이메일 인증 로직 복원: 이메일 인증코드 발급 → 타이머 → 인증번호 확인 UI/로직을 복구하고, recruitingInfo · isVerified · onChangeVerification props 기반으로 동작하도록 변경
- 회원가입 폼(SignupForm) 인증 연동: useVerificationStatus로 인증 상태 관리
- 이메일 미인증 시 지원서 제출 차단 (인증번호 에러 노출)
- 이미 가입된 이메일일 경우 해당 입력란으로 자동 포커스
- 비밀번호 재설정(PasswordForm): 현재 미사용 기능이라 TextBox이메일(인증 UI)은 주석 처리하고, 재개 시 함께 활성화하도록 TODO 주석 표기


## 🧑‍🎤 Screenshot

<img width="580" height="229" alt="스크린샷 2026-07-28 오후 10 12 23" src="https://github.com/user-attachments/assets/d5c52118-f650-4aa0-81ef-9fe6e9a58c01" />

<img width="611" height="286" alt="스크린샷 2026-07-28 오후 9 52 29" src="https://github.com/user-attachments/assets/59068672-04aa-4e1d-8fe9-5451406b675b" />


<img width="577" height="141" alt="스크린샷 2026-07-28 오후 9 57 59" src="https://github.com/user-attachments/assets/bae981ad-fbd3-41db-8014-75dd5dd1ed4c" />

