### PR TITLE
[Hotfix] 개인정보처리방침 노션 링크 추가

### DIFF
--- a/src/common/components/Checkbox/components/Contentbox/index.tsx
+++ b/src/common/components/Checkbox/components/Contentbox/index.tsx
@@ -1,4 +1,6 @@
-import { container } from './style.css';
+import { PRIVACY_POLICY_NOTION_URL } from '@constants/links';
+
+import { container, privacyPolicyLink } from './style.css';
 
 import type { HTMLAttributes } from 'react';
 
@@ -9,6 +11,13 @@ interface ContentboxProps extends HTMLAttributes<HTMLElement> {
 const Contentbox = ({ children, ...contentboxElementProps }: ContentboxProps) => {
   return (
     <article className={container} {...contentboxElementProps}>
+      <a
+        className={privacyPolicyLink}
+        href={PRIVACY_POLICY_NOTION_URL}
+        target="_blank"
+        rel="noreferrer noopener">
+        개인정보처리방침 &gt;
+      </a>
       {children}
     </article>
   );

--- a/src/common/components/Checkbox/components/Contentbox/style.css.ts
+++ b/src/common/components/Checkbox/components/Contentbox/style.css.ts
@@ -15,3 +15,15 @@ export const container = style({
   ...theme.font.BODY_2_16_R,
   letterSpacing: '-0.24px',
 });
+
+export const privacyPolicyLink = style({
+  display: 'block',
+  width: 'fit-content',
+  marginBottom: 8,
+  color: theme.color.baseText,
+  textDecoration: 'underline',
+  textUnderlineOffset: 4,
+  textDecorationThickness: 1,
+  ...theme.font.BODY_2_16_R,
+  letterSpacing: '-0.24px',
+});

--- a/src/common/constants/links.ts
+++ b/src/common/constants/links.ts
@@ -1,1 +1,2 @@
 export const MAKERS_RECRUITMENT_NOTICE_URL = 'https://sopt-makers.notion.site/39-2fb76042aac2800baf8ac068ce9e2b06';
+export const PRIVACY_POLICY_NOTION_URL = 'https://sopt-makers.notion.site/d17c0071ab0e440baadd36c548bc36e4';


### PR DESCRIPTION
## 🧑‍🎤 Summary
개인정보처리방침 노션 링크 추가

## 🧑‍🎤 Screenshot
<img width="602" height="472" alt="image" src="https://github.com/user-attachments/assets/8d355834-9024-41b6-b53b-ea4970e90672" />


