### PR TITLE
[Feat] sopt OB 기수 지원 시 이전 활동 기수 여부 dropdown에 '해당사항 없음' 옵션 제거

### DIFF
--- a/src/views/ApplyPage/components/ApplyInfo/index.tsx
+++ b/src/views/ApplyPage/components/ApplyInfo/index.tsx
@@ -13,7 +13,7 @@ import {
   infoItemsVar,
   infoWrapper,
 } from './style.css';
-import { getApplyInfo, OT_DATE_TEXT_MAKERS } from '../../constant';
+import { getApplyInfo, OB_APPLY_NOTICE_CONTENT, OT_DATE_TEXT_MAKERS } from '../../constant';
 import { format } from '@utils/dateFormatter';
 import { MAKERS_RECRUITMENT_NOTICE_URL } from '@constants/links';
 
@@ -27,6 +27,7 @@ const ApplyInfo = memo(({ isReview = false }: { isReview?: boolean }) => {
       interviewEnd,
       finalResultStart,
       otDate,
+      group,
     },
   } = useRecruitingInfo();
 
@@ -41,12 +42,22 @@ const ApplyInfo = memo(({ isReview = false }: { isReview?: boolean }) => {
 
   // makers는 어드민 연동이 안 돼있어 하드코딩
   const otDateText = __IS_MAKERS__ ? OT_DATE_TEXT_MAKERS : otDate ? format(otDate, 'M월 dd일 EEEE') : '';
+  const isOB = !__IS_MAKERS__ && group === 'OB';
   const APPLY_INFO = getApplyInfo(otDateText);
 
   return (
     <section className={infoContainer}>
       {!isReview && (
         <ul className={infoWrapper}>
+          {isOB && (
+            <li key="ob-notice" className={infoItemsVar}>
+              {OB_APPLY_NOTICE_CONTENT.map(({ text, weight }) => (
+                <span key={text} className={weight === 'strong' ? infoItemsBold : ''}>
+                  {text}
+                </span>
+              ))}
+            </li>
+          )}
           <li key="first-info" className={infoItemsVar}>
             지원서 작성 전에{` `}
             <a

--- a/src/views/ApplyPage/components/DefaultSection/index.tsx
+++ b/src/views/ApplyPage/components/DefaultSection/index.tsx
@@ -23,7 +23,7 @@ import {
   profileWrapperVar,
   sectionContainerVar,
 } from './style.css';
-import { getMostRecentSeasonArray } from './utils';
+import { getPastSeasons } from './utils';
 
 interface ProfileImageProps {
   disabled: boolean;
@@ -135,6 +135,7 @@ const DefaultSection = ({ refCallback, isReview = false }: DefaultSectionProps) 
     college,
     email,
     gender,
+    group,
     major,
     mostRecentSeason,
     name,
@@ -144,6 +145,11 @@ const DefaultSection = ({ refCallback, isReview = false }: DefaultSectionProps) 
     univYear,
     leaveAbsence,
   } = applicant || {};
+
+  // OB는 이전 기수(YB) 활동 이력이 반드시 있어야 지원 가능하므로 '해당사항 없음'을 노출하지 않음
+  const shouldShowNoneOption = !__IS_MAKERS__ && group !== 'OB';
+  const pastSeasons = getPastSeasons(season || 0);
+  const mostRecentSeasonOptions = shouldShowNoneOption ? ['해당사항 없음', ...pastSeasons] : pastSeasons;
 
   return (
     <section ref={refCallback} id="default" className={sectionContainerVar}>
@@ -262,7 +268,7 @@ const DefaultSection = ({ refCallback, isReview = false }: DefaultSectionProps) 
         label="이전 기수 활동 여부 (제명 포함)"
         name="mostRecentSeason"
         placeholder="가장 최근에 활동했던 기수를 선택해주세요."
-        options={getMostRecentSeasonArray(season || 0, __IS_MAKERS__ || false)}
+        options={mostRecentSeasonOptions}
         required
         size="lg"
         disabled={isReview}

--- a/src/views/ApplyPage/components/DefaultSection/utils.ts
+++ b/src/views/ApplyPage/components/DefaultSection/utils.ts
@@ -1,9 +1,1 @@
-export const getMostRecentSeasonArray = (season: number, isMakers: boolean) => {
-  const array = Array.from({ length: 10 }, (_, i) => String(season - i - 1));
-
-  if (!isMakers) {
-    array.unshift('해당사항 없음');
-  }
-
-  return array;
-};
+export const getPastSeasons = (season: number) => Array.from({ length: 10 }, (_, i) => String(season - i - 1));

--- a/src/views/ApplyPage/components/DefaultSection/utils.ts
+++ b/src/views/ApplyPage/components/DefaultSection/utils.ts
@@ -1,1 +1,2 @@
-export const getPastSeasons = (season: number) => Array.from({ length: 10 }, (_, i) => String(season - i - 1));
+export const getPastSeasons = (mostRecentSeason: number) =>
+  Array.from({ length: 10 }, (_, i) => String(mostRecentSeason - i - 1));

--- a/src/views/ApplyPage/constant.ts
+++ b/src/views/ApplyPage/constant.ts
@@ -1,19 +1,15 @@
 // makers는 어드민 연동이 안 돼있어 ot 날짜 하드코딩
 export const OT_DATE_TEXT_MAKERS = '8월 22일 토요일';
 
+export const OB_APPLY_NOTICE_CONTENT = [
+  { text: 'SOPT에서 한 번 이상 활동한 경험이 있는 SOPT 회원을 대상으로 한 OB 지원서입니다.', weight: 'normal' },
+  { text: '\nSOPT 활동 경험이 없는 지원자는 YB 모집 기간에 지원해 주시기 바랍니다.', weight: 'strong' },
+];
+
 export const getApplyInfo = (otDateText: string) => ({
   sections: [
     {
       id: 0,
-      content: [
-        {
-          text: '지원서 작성 전에 커리큘럼을 꼭 숙지하고 지원해 주시기 바랍니다.',
-          weight: 'normal',
-        },
-      ],
-    },
-    {
-      id: 1,
       content: [
         {
           text: `${otDateText} OT(오프라인 예정)에 불참 시 지원이 불가하오니 자세히 확인 바랍니다.`,
@@ -22,13 +18,13 @@ export const getApplyInfo = (otDateText: string) => ({
       ],
     },
     {
-      id: 2,
+      id: 1,
       content: [
         { text: '한 번 제출된 지원서는 수정이 불가하니 신중히 작성하신 후 제출 부탁드립니다.', weight: 'normal' },
       ],
     },
     {
-      id: 3,
+      id: 2,
       content: [
         {
           text: '최종 제출하지 않은 임시저장 지원서는 미제출로 간주하오니 반드시 최종 제출하시길 바랍니다.',
@@ -37,7 +33,7 @@ export const getApplyInfo = (otDateText: string) => ({
       ],
     },
     {
-      id: 4,
+      id: 3,
       content: [
         {
           text: `지원 마감 시간이 임박하면 지원자가 몰려 서버가 불안정할 수 있으므로 가급적 여유롭게 제출하는 것을 권장드립니다.`,


### PR DESCRIPTION
**Related Issue :** Closes #603 

---

## 🧑‍🎤 Summary
SOPT OB 기수 지원 시 이전 활동 기수 여부 dropdown에 '해당사항 없음' 옵션 제거

**[추가 설명]**
SOPT OB는 기존에 YB 활동을 최소 1번 이상 했어야 지원이 가능하다는 자격 요건을 가지고 있어요.
하지만 이전까지 자격과 상관없이 OB를 모두 지원 가능하도록 열려있는 상태였어요. 이로 인해 이번 기간에도 그렇고 한번도 활동하지 않은 지원자가 OB지원을 하는 경우가 생겼어요. 

따라서 이를 막기 위해 OB의 경우는 이전 활동 기수 여부 Dropdown에 '해당사항 없음'이라는 옵셥, 즉 탈출구를 없애서 무조건 자격이 되어야만 지원이 가능하도록 수정했어요. 

아직 추가는 안헀지만 이후에 공홈이나 지원서 쪽에 해당 OB 자격 요건에 대해서 상세한 정보를 추가하여 지원자가 헷갈리는 일을 방지하고자 해요.

## 🧑‍🎤 Screenshot
https://github.com/user-attachments/assets/4957b235-9aa5-4f00-841b-99fee233d2bf



## 🧑‍🎤 Comment
기존에 `getMostRecentSeasonArray` 함수의 역할이 최근 기수 정보(season: numer)를 받아 그 기수를 포함하여 최근 기수 일부를 배열로 만들어서 반환하는 역할이었어요.
하지만 내부에는 함수의 이름으로 예측할 수 있는 동작과 다른 메이커스 여부에따른 분기가 있었어요. 또한 이번 PR에서 추가해야하는 동작인 OB 분기처리도 들어가야했어요.

### AS-IS
```ts
export const getMostRecentSeasonArray = (season: number, isMakers: boolean) => {
  const array = Array.from({ length: 10 }, (_, i) => String(season - i - 1));

  // getMostRecentSeasonArray라는 이름으로 예측하기 힘든 동작
  if (!isMakers) {
    array.unshift('해당사항 없음');
  }

  return array;
};
```

이는 함수의 이름으로 예측할 수 있는 동작에서 벗어난 도메인에 종속된 동작이라고 생각했어요.
따라서 makers 여부, YB|OB에 따라 분기하는 로직은 `DefaultSection` 컴포넌트에서 책임을 가지고, 기존 `getMostRecentSeasonArray`함수의 네이밍을 `getPastSeasons`으로 변경하여 이 함수는 오직 최근 기수를 받아 그 기준으로 이전 기수들을 포함한 배열로 반환해주는 순수 함수로 분리 했어요.

### TO-BE
```ts
export const getPastSeasons = (mostRecentSeason: number) =>
  Array.from({ length: 10 }, (_, i) => String(mostRecentSeason - i - 1));
```